### PR TITLE
enhance installation instructions and align documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ When contributing new features or bug fixes, please:
 ```bash
 git clone https://github.com/bytedance/jaqmc.git
 cd jaqmc
-uv sync --python 3.12 --extra cuda12   # CPU-only: omit --extra cuda12
+uv sync --frozen --python 3.12 --extra cuda12   # CPU-only: omit --extra cuda12
 source .venv/bin/activate
 uv tool install prek
 prek install
@@ -41,7 +41,7 @@ prek run --all-files             # All hooks at once
 For code style, docstrings, testing conventions, and documentation setup, see the **Contributing** section in the rendered docs (`docs/extending/contributing.md`). To build the docs locally:
 
 ```bash
-uv sync --group docs
+uv sync --frozen --group docs
 sphinx-autobuild docs docs/_build --watch src
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ for you.
 
 ## Installation
 
-Clone the Repository and navigate to the jaqmc directory.
+Before you begin, make sure you have:
+
+- **Python 3.12** or later
+- **Git** (for cloning the repository)
+
+Clone the repository and navigate to the `jaqmc` directory.
 ```bash
 git clone https://github.com/bytedance/jaqmc.git
 cd jaqmc
@@ -44,30 +49,34 @@ cd jaqmc
 
 Install with [uv](https://docs.astral.sh/uv/getting-started/installation/) (recommended):
 ```bash
-uv sync --python 3.12
+uv sync --frozen --python 3.12
 ```
 
-Or with pip (create a venv first):
+This installs the exact dependency versions currently tested by the project from the official PyPI index.
+
+If you prefer `pip`, or if you use a PyPI mirror, create a virtual environment first and install manually:
 
 ```bash
 python -m venv .venv && source .venv/bin/activate
-pip install -e . -r requirements.txt
+pip install -e . -r requirements.txt --extra-index-url https://pypi.org/simple
 ```
+
+The `--extra-index-url https://pypi.org/simple` flag is recommended when you use PyPI mirrors, since some mirrors may not include every required package.
 
 ### GPU Support
 
-For GPU acceleration, choose based on your setup:
+For GPU acceleration, choose the option that matches your setup:
 
 ```bash
-# Option 1: Download CUDA libraries (recommended, no system CUDA needed)
-uv sync --extra cuda12
+# Option 1: Download CUDA libraries (recommended; no system CUDA required)
+uv sync --frozen --python 3.12 --extra cuda12
 # Or with pip:
-pip install -e ".[cuda12]" -r requirements.txt
+pip install -e ".[cuda12]" -r requirements.txt --extra-index-url https://pypi.org/simple
 
-# Option 2: Use local CUDA installation (requires CUDA 12 already installed)
-uv sync --extra cuda12-local
+# Option 2: Use a local CUDA installation (requires CUDA 12 to already be installed)
+uv sync --frozen --python 3.12 --extra cuda12-local
 # Or with pip:
-pip install -e ".[cuda12_local]" -r requirements.txt
+pip install -e ".[cuda12_local]" -r requirements.txt --extra-index-url https://pypi.org/simple
 ```
 
 For troubleshooting GPU setup, see the [JAX installation guide](https://docs.jax.dev/en/latest/installation.html).
@@ -99,7 +108,7 @@ See the [documentation](docs/getting-started/quick-start.md) for detailed guides
 ## Development
 
 ```bash
-uv sync
+uv sync --frozen --python 3.12
 uv tool install prek
 prek install
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 <p align="center">
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.12+-blue.svg"></a>
+  <a href="https://bytedance.github.io/jaqmc/"><img src="https://img.shields.io/badge/documentation-teal.svg"></a>
 </p>
 
 
@@ -96,13 +97,13 @@ jaqmc hydrogen-atom train train.optim.learning_rate.rate=0.01 train.run.iteratio
 jaqmc molecule train system.module=atom system.symbol=Li
 ```
 
-See the [documentation](docs/getting-started/quick-start.md) for detailed guides on installation, molecular simulations, and writing custom workflows.
+See the [documentation](https://bytedance.github.io/jaqmc/getting-started/quick-start.html) for detailed guides on installation, molecular simulations, and writing custom workflows.
 
 ## Where to Go Next
 
-- **Train a real system**: See [Molecules](docs/systems/molecule/index.md), [Solids](docs/systems/solid/index.md), or [Quantum Hall](docs/systems/hall/index.md).
-- **Understand the framework**: Read [Core Concepts](docs/getting-started/concepts.md).
-- **Extend JaQMC**: Start from [Extending JaQMC](docs/extending/index.md).
+- **Train a real system**: See [Molecules](https://bytedance.github.io/jaqmc/systems/molecule/index.html), [Solids](https://bytedance.github.io/jaqmc/systems/solid/index.html), or [Quantum Hall](https://bytedance.github.io/jaqmc/systems/hall/index.html).
+- **Understand the framework**: Read [Core Concepts](https://bytedance.github.io/jaqmc/getting-started/concepts.html).
+- **Extend JaQMC**: Start from [Extending JaQMC](https://bytedance.github.io/jaqmc/extending/index.html).
 - **Contribute code**: See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Development

--- a/docs/extending/contributing.md
+++ b/docs/extending/contributing.md
@@ -6,6 +6,17 @@ This page covers setting up your development environment and the conventions we 
 
 If you plan to contribute code, it's worth setting up a few tools that will catch common issues before they reach code review.
 
+Start by cloning the repository and installing the locked development environment:
+
+```bash
+git clone https://github.com/bytedance/jaqmc.git
+cd jaqmc
+uv sync --frozen --python 3.12 --extra cuda12   # CPU-only: omit --extra cuda12
+source .venv/bin/activate
+```
+
+This installs the exact dependency versions currently tested by the project from the official PyPI index.
+
 ### Pre-commit Hooks
 
 We use [prek](https://github.com/j178/prek) to run Ruff (linting and formatting) and Mypy (type checking) automatically every time you `git commit`. To install the hooks:
@@ -180,7 +191,7 @@ For a minimal workflow smoke test, build a `ConfigManager` with only 2 pretrain/
 To build and preview the docs locally:
 
 ```bash
-uv sync --group docs
+uv sync --frozen --group docs
 sphinx-autobuild docs docs/_build --watch src
 ```
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -12,7 +12,7 @@ Before you begin, make sure you have:
 - **Python 3.12** or later
 - **Git** (for cloning the repository)
 
-### Step 1: Clone the Repository and navigate to the `jaqmc` directory.
+### Step 1: Clone the repository and navigate to the `jaqmc` directory.
 
 ```bash
 git clone https://github.com/bytedance/jaqmc.git
@@ -21,7 +21,7 @@ cd jaqmc
 
 ### Step 2: Install Dependencies
 
-JaQMC recommends [uv](https://docs.astral.sh/uv/getting-started/installation/) for fast, reliable package management. If you don't have `uv` installed yet, follow the link above — it takes about 10 seconds.
+JaQMC recommends [uv](https://docs.astral.sh/uv/getting-started/installation/) for fast, reliable package management. If you do not have `uv` installed yet, follow the link above.
 
 **Using uv (recommended):**
 
@@ -31,21 +31,21 @@ JaQMC recommends [uv](https://docs.astral.sh/uv/getting-started/installation/) f
 :::{tab-item} CPU
 :sync: cpu
 ```bash
-uv sync --python 3.12
+uv sync --frozen --python 3.12
 ```
 :::
 
 :::{tab-item} GPU (Download CUDA)
 :sync: cuda
 ```bash
-uv sync --python 3.12 --extra cuda12
+uv sync --frozen --python 3.12 --extra cuda12
 ```
 :::
 
 :::{tab-item} GPU (Local CUDA)
 :sync: cuda-local
 ```bash
-uv sync --python 3.12 --extra cuda12-local
+uv sync --frozen --python 3.12 --extra cuda12-local
 ```
 :::
 
@@ -53,7 +53,9 @@ uv sync --python 3.12 --extra cuda12-local
 
 **Using pip or conda:**
 
-If you prefer `pip` or `conda`, you'll need to create and activate a virtual environment first.
+These commands install the exact dependency versions currently tested by the project from the official PyPI index.
+
+If you prefer `pip` or `conda`, create and activate an environment first.
 
 ````{dropdown} pip setup
 ```bash
@@ -79,25 +81,27 @@ Then install JaQMC:
 :::{tab-item} CPU
 :sync: cpu
 ```bash
-pip install -e . -r requirements.txt
+pip install -e . -r requirements.txt --extra-index-url https://pypi.org/simple
 ```
 :::
 
 :::{tab-item} GPU (Download CUDA)
 :sync: cuda
 ```bash
-pip install -e ".[cuda12]" -r requirements.txt
+pip install -e ".[cuda12]" -r requirements.txt --extra-index-url https://pypi.org/simple
 ```
 :::
 
 :::{tab-item} GPU (Local CUDA)
 :sync: cuda-local
 ```bash
-pip install -e ".[cuda12_local]" -r requirements.txt
+pip install -e ".[cuda12_local]" -r requirements.txt --extra-index-url https://pypi.org/simple
 ```
 :::
 
 ::::
+
+The `--extra-index-url https://pypi.org/simple` flag is recommended when you use PyPI mirrors, since some mirrors may not include every required package.
 
 For troubleshooting GPU or JAX issues, see the official [JAX installation guide](inv:jax:*:doc#installation).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "click>=8.3.1",
     "flax>=0.10.4",
     # Using folx from GitHub for better shard_map support (see https://github.com/microsoft/folx/pull/36)
-    "folx@git+https://github.com/microsoft/folx@47a0e8d",
+    "folx@git+https://github.com/microsoft/folx@47a0e8d97a311686115aae353a85a45ae6432274",
     "fsspec>=2026.2.0",
     "h5py>=3.15.1",
     "jax>=0.4.36,<=0.9.1",


### PR DESCRIPTION
Link to the online documentation instead of source files in README.

Align the installation and contributor docs with the locked setup we expect users to run, including frozen uv commands and the pip fallback guidance.

Besides, pip can complain about version mismatches for Git dependencies when the revision is abbreviated, so the folx dependency now uses the full commit hash intentionally.