### PR TITLE
catch error for bad checkpoint files

### DIFF
--- a/src/jaqmc/utils/checkpoint.py
+++ b/src/jaqmc/utils/checkpoint.py
@@ -5,6 +5,7 @@ import logging
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, cast
+from zipfile import BadZipFile
 
 import h5py
 import jax
@@ -131,7 +132,7 @@ class NumPyCheckpointManager:
         for ckpt_path in ckpt_files:
             try:
                 return self.restore_from_file(ckpt_path, fallback)
-            except OSError:
+            except (OSError, EOFError, BadZipFile):
                 logger.warning("Fail to restore checkpoint %s", ckpt_path)
         return 0, fallback
 


### PR DESCRIPTION
Besides `OSError`, NumPy can also raise `EOFError` (when calling `np.load` multiple times on the same file handle, if all data has already been read) and `BadZipFile` error (when the `.npz` file is corrupted). With these two exceptions added, our code is now aligned with https://github.com/google-deepmind/ferminet/blob/6034525ae3319c67a516612fd82ed264d60ce919/ferminet/checkpoint.py#L49-L54

Note that instead of catching all kinds of errors here, we only handle the ones caused by bad checkpoint files so that other unexpected errors can be raised early.