### PR TITLE
fix loss of accuracy in FQH wavefunction

### DIFF
--- a/src/jaqmc/app/hall/wavefunction/mhpo.py
+++ b/src/jaqmc/app/hall/wavefunction/mhpo.py
@@ -17,7 +17,7 @@ from scipy import special as ss
 from jaqmc.app.hall.data import HallData
 from jaqmc.array_types import Params
 from jaqmc.utils.wiring import runtime_dep
-from jaqmc.wavefunction.backbone.psiformer import LayerNormMode, PsiformerBackbone
+from jaqmc.wavefunction.backbone.psiformer import PsiformerBackbone
 from jaqmc.wavefunction.base import ComplexWFOutput, Wavefunction
 from jaqmc.wavefunction.output.orbital import SplitChannelDense
 
@@ -108,9 +108,6 @@ class MHPO(Wavefunction[HallData, ComplexWFOutput]):
             num_layers=self.num_layers,
             num_heads=self.num_heads,
             heads_dim=self.heads_dim,
-            mlp_hidden_dims=(),
-            layer_norm_mode=LayerNormMode.post,
-            input_bias=False,
         )
         self.orbital_layer = MonopoleOrbitals(
             Q=reduced_flux / 2,

--- a/src/jaqmc/app/hall/workflow.py
+++ b/src/jaqmc/app/hall/workflow.py
@@ -66,7 +66,9 @@ class HallTrainWorkflow(VMCWorkflow):
         train.configure_sample_plan(wf.logpsi, {"electrons": sampler})
         train.configure_optimizer(default=KFACOptimizer, f_log_psi=wf.logpsi)
         train.configure_estimators(**estimators)
-        train.configure_loss_grads(LossAndGrad(loss_key=loss_key), f_log_psi=wf.logpsi)
+        train.configure_loss_grads(
+            LossAndGrad(loss_key=loss_key, clip_scale=100), f_log_psi=wf.logpsi
+        )
         self.train_stage = train.build()
 
 


### PR DESCRIPTION
- Use the standard Psiformer backbone
- Set a larger clip range, the same as the original DeepHall code