### PR TITLE
integrate codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+        target: auto
+        threshold: 5%
+    patch:
+      default:
+        target: 60%
+        informational: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,22 @@ jobs:
           enable-cache: true
 
       - name: Run tests
+        if: matrix.tox-env != 'py312-jax0.9.1'
         run: uvx --with tox-uv tox -e ${{ matrix.tox-env }} -- -n 3
+
+      - name: Run tests with coverage
+        if: matrix.tox-env == 'py312-jax0.9.1'
+        run: uvx --with tox-uv tox -e py312-jax0.9.1 -- -n 3 --cov --cov-branch --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
+
+      - name: Upload coverage to Codecov
+        if: matrix.tox-env == 'py312-jax0.9.1'
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: bytedance/jaqmc
+
+      - name: Upload test results to Codecov
+        if: ${{ matrix.tox-env == 'py312-jax0.9.1' && !cancelled() }}
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <p align="center"><img src="docs/_static/jaqmc-light.svg" width="200" height="200"></p>
 <h1 align="center">JaQMC</h1>
 <p align="center">
+  <a href="https://codecov.io/github/bytedance/jaqmc"><img src="https://codecov.io/github/bytedance/jaqmc/graph/badge.svg?token=N9QGZFKI6J"></a>
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.12+-blue.svg"></a>
   <a href="https://bytedance.github.io/jaqmc/"><img src="https://img.shields.io/badge/documentation-teal.svg"></a>


### PR DESCRIPTION
We upload the coverage and test results from the `jax==0.9.1` tests. Codecov will check each PR and comment for coverage changes, but we do not require code coverage to merge PRs.