### PR TITLE
add chunked batching for local estimators

### DIFF
--- a/docs/api-reference/estimators.md
+++ b/docs/api-reference/estimators.md
@@ -5,18 +5,21 @@ API reference for built-in estimators. For background, formulas, and configurati
 ## Base classes
 
 ```{eval-rst}
-.. autoclass:: jaqmc.estimator.base.Estimator
-   :members: init, evaluate_local, evaluate_batch, reduce, finalize_stats, finalize_state
+.. autoclass:: jaqmc.estimator.Estimator
+   :members: init, evaluate_batch, reduce, finalize_stats, finalize_state
 
-.. autoclass:: jaqmc.estimator.base.FunctionEstimator
+.. autoclass:: jaqmc.estimator.LocalEstimator
+   :members: evaluate_local, evaluate_batch
+
+.. autoclass:: jaqmc.estimator.FunctionEstimator
    :members:
 
-.. autoclass:: jaqmc.estimator.base.EstimatorPipeline
+.. autoclass:: jaqmc.estimator.EstimatorPipeline
    :members: init, evaluate, finalize_stats, digest
 
-.. autotype:: jaqmc.estimator.base.EstimatorLike
+.. autotype:: jaqmc.estimator.EstimatorLike
 
-.. autotype:: jaqmc.estimator.base.EstimateFn
+.. autotype:: jaqmc.estimator.EstimateFn
 ```
 
 ## Built-in estimators

--- a/docs/api-reference/estimators.md
+++ b/docs/api-reference/estimators.md
@@ -6,10 +6,10 @@ API reference for built-in estimators. For background, formulas, and configurati
 
 ```{eval-rst}
 .. autoclass:: jaqmc.estimator.Estimator
-   :members: init, evaluate_batch, reduce, finalize_stats, finalize_state
+   :members: init, evaluate_batch_walkers, reduce, finalize_stats, finalize_state
 
-.. autoclass:: jaqmc.estimator.LocalEstimator
-   :members: evaluate_local, evaluate_batch
+.. autoclass:: jaqmc.estimator.PerWalkerEstimator
+   :members: evaluate_single_walker, evaluate_batch_walkers
 
 .. autoclass:: jaqmc.estimator.FunctionEstimator
    :members:

--- a/docs/extending/contributing.md
+++ b/docs/extending/contributing.md
@@ -136,32 +136,32 @@ For true multi-process tests (e.g. testing distributed training), see `tests/dis
 
 Estimator tests should cover the following scenarios:
 
-**1. ``evaluate_local`` returns the right keys and shapes:**
+**1. ``evaluate_single_walker`` returns the right keys and shapes:**
 
 ```python
-def test_evaluate_local_shape():
+def test_evaluate_single_walker_shape():
     est = MyEstimator()
     data = ...  # single-walker data
     state = est.init(data, jax.random.PRNGKey(0))
-    stats, state = est.evaluate_local(
+    stats, state = est.evaluate_single_walker(
         None, data, {}, state, jax.random.PRNGKey(1)
     )
     assert "my_key" in stats
     assert stats["my_key"].shape == ()  # scalar per walker
 ```
 
-**2. JIT compatibility** — wrap `evaluate_local` in `jax.jit` and check that it produces finite values. This catches issues with dynamic shapes or Python control flow that JAX cannot trace.
+**2. JIT compatibility** — wrap `evaluate_single_walker` in `jax.jit` and check that it produces finite values. This catches issues with dynamic shapes or Python control flow that JAX cannot trace.
 
-**3. Batched evaluation** — call `evaluate_batch` on a batch of walkers and verify the output has a leading batch dimension:
+**3. Batched evaluation** — call `evaluate_batch_walkers` on a batch of walkers and verify the output has a leading batch dimension:
 
 ```python
-def test_evaluate_batch():
+def test_evaluate_batch_walkers():
     est = MyEstimator()
     state = est.init(single_walker_data, jax.random.PRNGKey(0))
-    local_stats, state = est.evaluate_batch(
+    walker_stats, state = est.evaluate_batch_walkers(
         None, batched_data, {}, state, jax.random.PRNGKey(1)
     )
-    assert local_stats["my_key"].shape == (n_walkers,)
+    assert walker_stats["my_key"].shape == (n_walkers,)
 ```
 
 **4. Physics correctness** — if possible, provide an analytic wavefunction with a known exact value and assert the estimator reproduces it. See `tests/hall_test.py::TestSphericalKinetic` for an example that uses a closed-form Laughlin wavefunction to verify kinetic energy.

--- a/docs/extending/custom-components/estimators.md
+++ b/docs/extending/custom-components/estimators.md
@@ -1,13 +1,24 @@
 # Custom Estimators
 
-Estimators are the most common extension point — every new observable is a new estimator. This page walks through building one, starting from the simplest approach and adding complexity only when needed.
+Estimators compute observables such as energies, densities, losses, and
+diagnostics. Most custom estimators are easiest to write as single-walker
+calculations: you describe what to compute for one sampled configuration, and
+JaQMC maps that calculation over the walker batch.
+
+The sections below build in order: a plain function, then a configurable
+`LocalEstimator`, then runtime dependencies, then the full-batch `Estimator`
+when the whole walker batch is required. After that, a short reference section
+pulls the options together; the last section shows how to register the
+estimator in a real workflow and config.
 
 ## Start with a Function
 
-The simplest estimator is a plain function. Here's one that computes the electronic dipole moment:
+The simplest estimator is a plain function. Here's one that computes the
+electronic dipole moment for one walker:
 
 ```python
-import jax.numpy as jnp
+from jax import numpy as jnp
+
 
 def dipole_moment(params, data, stats, state, rngs):
     del params, stats, rngs
@@ -15,45 +26,60 @@ def dipole_moment(params, data, stats, state, rngs):
     return {"dipole_x": dipole[0], "dipole_y": dipole[1], "dipole_z": dipole[2]}, state
 ```
 
-Pass it directly in your estimators dict — JaQMC wraps it as a {class}`~jaqmc.estimator.base.FunctionEstimator`:
+Pass it directly in your estimators dict:
 
 ```python
 estimators = {"dipole": dipole_moment, ...}
 ```
 
-The function receives a single walker's data (not a batch). The base class
-auto-vmaps it over walkers. If you need the exact `Data` versus `BatchedData`
-convention behind that statement, see <project:../runtime-data-conventions.md>. If
-this is all you need — a fixed computation with no tunable parameters — you're
-done.
+JaQMC wraps the function as a
+{class}`~jaqmc.estimator.base.FunctionEstimator`. The function receives one
+walker's `Data`, not a batch. The wrapper batches it over walkers during
+`evaluate_batch`. If you need the exact `Data` versus `BatchedData` convention,
+see <project:../runtime-data-conventions.md>.
 
-## Making It Configurable
+This form is a good fit for small, fixed observables. If the estimator needs
+user-tunable fields or setup work, use a class instead.
 
-When users should be able to adjust parameters via YAML, wrap the function in a class:
+## Make It Configurable
+
+When users should be able to adjust estimator settings from YAML, use
+{class}`~jaqmc.estimator.base.LocalEstimator`. It is the base class for
+single-walker estimators: you implement `evaluate_local`, and `LocalEstimator`
+provides the batched `evaluate_batch` implementation.
 
 ```python
 from dataclasses import field
 
-from jaqmc.estimator import Estimator
+from jax import numpy as jnp
+
+from jaqmc.estimator import LocalEstimator
 from jaqmc.utils.config import configurable_dataclass
 
+
 @configurable_dataclass
-class DipoleEstimator(Estimator):
+class DipoleEstimator(LocalEstimator):
     """Estimates the electric dipole moment.
 
     Args:
         reference_point: Origin for dipole calculation.
     """
+
     reference_point: list[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
 
     def evaluate_local(self, params, data, prev_local_stats, state, rngs):
         del params, prev_local_stats, rngs
         ref = jnp.array(self.reference_point)
         dipole = -jnp.sum(data.electrons - ref, axis=0)
-        return {"dipole_x": dipole[0], "dipole_y": dipole[1], "dipole_z": dipole[2]}, state
+        return {
+            "dipole_x": dipole[0],
+            "dipole_y": dipole[1],
+            "dipole_z": dipole[2],
+        }, state
 ```
 
-Now `reference_point` is a config field — it appears in `--dry-run` output and users can override it in YAML:
+Now `reference_point` is a config field. It appears in `--dry-run` output and
+users can override it in YAML:
 
 ```yaml
 train:
@@ -62,28 +88,60 @@ train:
       reference_point: [1.0, 0.0, 0.0]
 ```
 
-## Adding Runtime Dependencies
+Because this estimator inherits from `LocalEstimator`, users also get
+`vmap_chunk_size`. The default `null` evaluates the whole walker batch in one
+vmap. On memory-limited runs, users can set an integer to evaluate fewer
+walkers at a time:
 
-The electronic dipole above ignores the nuclear contribution. To include it, the estimator needs the nuclear charges and positions — but these come from the molecule specification, not from YAML. They're set by the workflow at startup.
+```yaml
+train:
+  estimators:
+    expensive_observable:
+      vmap_chunk_size: 128
+```
+
+That knob is specific to the local-vmap path. Estimators that implement their
+own full-batch `evaluate_batch` do not inherit it, because JaQMC cannot know how
+to split their batch logic safely.
+
+## Add Runtime Dependencies
+
+Config fields come from YAML. Runtime dependencies come from the workflow at
+startup: wavefunction evaluate functions, system metadata, spin counts, or
+other live objects that should not be serialized into config.
+
+For example, the electronic dipole above ignores the nuclear contribution. To
+include it, the estimator needs nuclear charges and positions. Mark those fields
+with {func}`~jaqmc.utils.wiring.runtime_dep` so the config system hides them.
 
 :::{note}
-In practice, molecule workflows already include charges and atom positions in the walker data (`data.charges`, `data.atoms`). We use them as runtime deps here to illustrate the pattern — real candidates are things like `f_log_psi` (the wavefunction evaluate function) or `nspins` (the spin configuration), which genuinely live outside the data.
+Molecule workflows usually include charges and atom positions in the walker
+data (`data.charges`, `data.atoms`). This example uses them as runtime
+dependencies to show the pattern. More common runtime dependencies are values
+such as `f_log_psi` or `nspins`.
 :::
 
-Mark them as `runtime_dep()` so they stay invisible to the config system:
-
 ```python
+from dataclasses import field
+from typing import Any
+
+from jax import numpy as jnp
+
+from jaqmc.estimator import LocalEstimator
+from jaqmc.utils.config import configurable_dataclass
 from jaqmc.utils.wiring import runtime_dep
 
+
 @configurable_dataclass
-class DipoleEstimator(Estimator):
-    """Estimates the electric dipole moment (electronic + nuclear).
+class DipoleEstimator(LocalEstimator):
+    """Estimates the electric dipole moment.
 
     Args:
         reference_point: Origin for dipole calculation.
         atom_charges: Nuclear charges Z_I (runtime dep).
         atom_positions: Nuclear positions R_I (runtime dep).
     """
+
     reference_point: list[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
     atom_charges: Any = runtime_dep()
     atom_positions: Any = runtime_dep()
@@ -94,25 +152,31 @@ class DipoleEstimator(Estimator):
         elec = -jnp.sum(data.electrons - ref, axis=0)
         nuc = jnp.sum(self.atom_charges[:, None] * (self.atom_positions - ref), axis=0)
         dipole = elec + nuc
-        return {"dipole_x": dipole[0], "dipole_y": dipole[1], "dipole_z": dipole[2]}, state
+        return {
+            "dipole_x": dipole[0],
+            "dipole_y": dipole[1],
+            "dipole_z": dipole[2],
+        }, state
 ```
 
-Construct it directly — you provide the dependencies yourself:
+Construct it directly when you already have the dependencies:
 
 ```python
 est = DipoleEstimator(atom_charges=system.charges, atom_positions=system.positions)
 ```
 
-Or make it user-configurable via `cfg.get()` and wire the runtime deps separately:
+Or let config create the user-tunable part, then wire runtime dependencies:
 
 ```python
 from jaqmc.utils.wiring import wire
+
 
 est = cfg.get("estimators.dipole", DipoleEstimator())
 wire(est, atom_charges=system.charges, atom_positions=system.positions)
 ```
 
-In YAML, only `reference_point` appears. The runtime deps are invisible:
+Only `reference_point` and inherited `LocalEstimator` config fields appear in
+YAML. Runtime dependencies remain workflow-owned:
 
 ```yaml
 train:
@@ -121,37 +185,125 @@ train:
       reference_point: [1.0, 0.0, 0.0]
 ```
 
-## Choosing Lifecycle Methods
+If a runtime dependency raises an attribute error, check where the estimator is
+wired. Values declared with `runtime_dep()` are intentionally absent from YAML,
+so the workflow needs to provide them with `wire(...)` before the estimator is
+used.
 
-The base class {class}`~jaqmc.estimator.base.Estimator` provides no-op defaults for all methods. Override only what you need:
+## Use Full-Batch Evaluation When Needed
 
-| Override | When |
-|----------|------|
-| `evaluate_local` | You're computing a per-walker observable (most estimators). |
-| `evaluate_batch` | You need the full batch at once — e.g., histogram accumulation, or your logic doesn't decompose per-walker. Overrides the auto-vmap. |
-| `init(self, data, rngs)` | You need to precompute data from runtime deps before the first step — e.g., building index arrays or vmapping a function. Return the initial `state`. |
-| `reduce` | The default mean-with-variance isn't appropriate — e.g., you need median, IQR clipping, or custom aggregation. |
-| `finalize_stats` | The final observable requires nonlinear combinations of step-level averages — e.g., ratios, products, or gradient assembly. |
-| `finalize_state` | You accumulated results in state (e.g., histograms) rather than through per-step statistics. |
+The patterns above hand each call a single walker's `Data`; JaQMC still applies
+those values across the full walker batch. Some observables are more natural
+when the implementation can see the leading batch axis in one go: histograms,
+pair-correlation accumulators, and stateful evaluation summaries are typical
+examples. For those cases, inherit directly from
+{class}`~jaqmc.estimator.base.Estimator` and implement `evaluate_batch`.
 
-For most custom observables, `evaluate_local` alone is sufficient.
+The method receives
+{class}`~jaqmc.data.BatchedData`, so fields listed in
+`batched_data.fields_with_batch` already carry the leading walker axis.
 
-Two things to know about the keys you return from `evaluate_local`:
+```python
+from jax import numpy as jnp
 
-- **Energy prefix**: Keys starting with `energy:` (e.g., `energy:kinetic`, `energy:potential`) are auto-summed by {class}`~jaqmc.estimator.total_energy.TotalEnergy` into `total_energy`, which becomes the VMC optimization target. Use this prefix if your estimator contributes an energy term.
-- **Pipeline order matters**: Estimators run in insertion order, and each receives `prev_local_stats` — the local values from all preceding estimators. If your estimator depends on another's output, place it later in the dict.
+from jaqmc.estimator import Estimator
+from jaqmc.utils.config import configurable_dataclass
+
+
+@configurable_dataclass
+class RadiusHistogram(Estimator):
+    """Accumulates electron-radius counts over evaluation steps.
+
+    Args:
+        bins: Number of histogram bins.
+        max_radius: Upper histogram bound.
+    """
+
+    bins: int = 100
+    max_radius: float = 10.0
+
+    def init(self, data, rngs):
+        del data, rngs
+        return jnp.zeros(self.bins)
+
+    def evaluate_batch(self, params, batched_data, prev_local_stats, state, rngs):
+        del params, prev_local_stats, rngs
+        electrons = batched_data.data.electrons
+        radii = jnp.linalg.norm(electrons, axis=-1).reshape(-1)
+        counts = jnp.histogram(radii, self.bins, (0.0, self.max_radius))[0]
+        return {}, state + counts
+
+    def reduce(self, local_stats):
+        del local_stats
+        return {}
+
+    def finalize_state(self, state, *, n_steps):
+        return {"radius_histogram": state, "radius_histogram:n_steps": n_steps}
+```
+
+This estimator does not expose `vmap_chunk_size`, because it never calls the
+local-vmap implementation. If a full-batch estimator needs a memory-control
+option, make that option describe the estimator's own batching strategy.
+
+## Choose the Right Interface
+
+The examples above are the three main patterns. The tables below are a quick
+way to pick an interface, see which lifecycle hooks you might override, and
+review two naming and ordering rules for the keys you publish and for how
+estimators see each other's outputs.
+
+### Which interface?
+
+The choice comes down to what shape of data the estimator really needs:
+
+| Need | Use | Implement |
+|------|-----|-----------|
+| Fixed single-walker calculation | Plain function | Function body |
+| Configurable single-walker calculation | `LocalEstimator` | `evaluate_local` |
+| Full-batch or state-accumulating calculation | `Estimator` | `evaluate_batch` |
+
+### Lifecycle hooks
+
+After you choose the interface, override only the methods your estimator needs:
+
+| Method | When to override |
+|--------|------------------|
+| `init(self, data, rngs)` | You need derived state before the first step, such as precomputed index arrays. |
+| `evaluate_local` | You inherit from `LocalEstimator` and compute one walker's local values. |
+| `evaluate_batch` | You inherit from `Estimator` and need the whole walker batch at once. |
+| `reduce` | The default mean-with-variance is not appropriate. |
+| `finalize_stats` | Final values require nonlinear combinations of step-level statistics. |
+| `finalize_state` | Final values come from accumulated estimator state. |
+
+For most custom observables, `LocalEstimator.evaluate_local` is the only method
+you need to implement.
+
+### Keys and run order
+
+Two conventions matter for the keys you return and for cross-estimator use:
+
+- **Energy prefix**: Keys starting with `energy:` (for example,
+  `energy:kinetic` or `energy:potential`) are auto-summed by
+  {class}`~jaqmc.estimator.total_energy.TotalEnergy` into `total_energy`,
+  which becomes the VMC optimization target. Use this prefix only for real
+  energy terms; a non-energy key such as `energy:dipole` will change the
+  optimization target.
+- **Pipeline order**: Estimators run in insertion order. Each estimator receives
+  `prev_local_stats`, the local values from preceding estimators. If your
+  estimator depends on another estimator's output, place it later in the
+  estimator dict.
 
 ## End-to-End: Wire Your Estimator into a Real Run
 
-The sections above showed how to define an estimator (function or class) and choose the
-right lifecycle hooks. This section puts those pieces into a complete run path: register
-the estimator in a workflow, enable it in config, run training/evaluation, then verify the
-new stats.
+With the class or function in place and the right interface selected, the
+remaining work is app-specific: register the estimator with the workflow, turn
+it on in YAML, run training or evaluation, and confirm the new statistics in
+the output files.
 
-### 1) Register it in the workflow
+### 1. Register it in the workflow
 
-In your app's workflow module, import your estimator and add it to the estimator collection
-behind an explicit config flag. The concrete code below uses
+In your app's workflow module, import your estimator and add it to the estimator
+collection behind an explicit config flag. The concrete code below uses
 `src/jaqmc/app/molecule/workflow.py` as an example:
 
 ```python
@@ -166,10 +318,12 @@ if cfg.get("estimators.enabled.dipole", False):
     )
 ```
 
-Registering in the shared estimator factory (for molecule, `make_estimators(...)`) makes it
-available to both training and evaluation when both stages use that factory.
+Registering in the shared estimator factory, such as molecule
+`make_estimators(...)`, makes it available to every stage that uses that
+factory. If your estimator does not appear in a run, check this registration
+step first; defining the class only makes it available to import.
 
-### 2) Enable it in YAML
+### 2. Enable it in YAML
 
 In your run config:
 
@@ -181,7 +335,7 @@ estimators:
     reference_point: [0.0, 0.0, 0.0]
 ```
 
-### 3) Run training and evaluation
+### 3. Run training and evaluation
 
 ```bash
 # Train
@@ -193,27 +347,17 @@ jaqmc molecule evaluate --yml water.yml workflow.save_path=./runs/water-dipole-e
   workflow.source_path=./runs/water-dipole run.iterations=200
 ```
 
-### 4) Verify it worked
+### 4. Verify it worked
 
 Quick checks:
 
 1. `train_stats.csv` contains `dipole_x`, `dipole_y`, `dipole_z` columns.
 2. `evaluation_stats.h5` contains the same keys.
-3. `evaluation_digest.npz` typically includes dipole summary values for the same keys.
+3. `evaluation_digest.npz` includes the expected final values when the
+   estimator finalizes stats or state.
 
-If those keys are present and change smoothly over iterations, your estimator is wired and
-running correctly.
-
-### Common Pitfalls in This Flow
-
-- **Forgetting workflow registration**: Defining the estimator class alone does nothing; it
-  must be inserted into `make_estimators(...)`.
-- **Using the `energy:` prefix by accident**: Keys like `energy:dipole` would be folded into
-  `total_energy`. For non-energy observables, use plain keys like `dipole_x`.
-- **Returning batched values from `evaluate_local`**: `evaluate_local` is single-walker.
-  Return per-walker scalars/arrays; batching is handled by the base class.
-- **Runtime dependency not wired**: If you use `runtime_dep()`, ensure the workflow calls
-  `wire(...)` before the estimator is used.
+If those keys are present and change smoothly over iterations, your estimator is
+wired into the run.
 
 ## See Also
 

--- a/docs/extending/custom-components/estimators.md
+++ b/docs/extending/custom-components/estimators.md
@@ -6,7 +6,7 @@ calculations: you describe what to compute for one sampled configuration, and
 JaQMC maps that calculation over the walker batch.
 
 The sections below build in order: a plain function, then a configurable
-`LocalEstimator`, then runtime dependencies, then the full-batch `Estimator`
+`PerWalkerEstimator`, then runtime dependencies, then the full-batch `Estimator`
 when the whole walker batch is required. After that, a short reference section
 pulls the options together; the last section shows how to register the
 estimator in a real workflow and config.
@@ -35,7 +35,7 @@ estimators = {"dipole": dipole_moment, ...}
 JaQMC wraps the function as a
 {class}`~jaqmc.estimator.base.FunctionEstimator`. The function receives one
 walker's `Data`, not a batch. The wrapper batches it over walkers during
-`evaluate_batch`. If you need the exact `Data` versus `BatchedData` convention,
+`evaluate_batch_walkers`. If you need the exact `Data` versus `BatchedData` convention,
 see <project:../runtime-data-conventions.md>.
 
 This form is a good fit for small, fixed observables. If the estimator needs
@@ -44,21 +44,21 @@ user-tunable fields or setup work, use a class instead.
 ## Make It Configurable
 
 When users should be able to adjust estimator settings from YAML, use
-{class}`~jaqmc.estimator.base.LocalEstimator`. It is the base class for
-single-walker estimators: you implement `evaluate_local`, and `LocalEstimator`
-provides the batched `evaluate_batch` implementation.
+{class}`~jaqmc.estimator.base.PerWalkerEstimator`. It is the base class for
+single-walker estimators: you implement `evaluate_single_walker`, and
+`PerWalkerEstimator` provides the batched `evaluate_batch_walkers` implementation.
 
 ```python
 from dataclasses import field
 
 from jax import numpy as jnp
 
-from jaqmc.estimator import LocalEstimator
+from jaqmc.estimator import PerWalkerEstimator
 from jaqmc.utils.config import configurable_dataclass
 
 
 @configurable_dataclass
-class DipoleEstimator(LocalEstimator):
+class DipoleEstimator(PerWalkerEstimator):
     """Estimates the electric dipole moment.
 
     Args:
@@ -67,8 +67,10 @@ class DipoleEstimator(LocalEstimator):
 
     reference_point: list[float] = field(default_factory=lambda: [0.0, 0.0, 0.0])
 
-    def evaluate_local(self, params, data, prev_local_stats, state, rngs):
-        del params, prev_local_stats, rngs
+    def evaluate_single_walker(
+        self, params, data, prev_walker_stats, state, rngs
+    ):
+        del params, prev_walker_stats, rngs
         ref = jnp.array(self.reference_point)
         dipole = -jnp.sum(data.electrons - ref, axis=0)
         return {
@@ -88,7 +90,7 @@ train:
       reference_point: [1.0, 0.0, 0.0]
 ```
 
-Because this estimator inherits from `LocalEstimator`, users also get
+Because this estimator inherits from `PerWalkerEstimator`, users also get
 `vmap_chunk_size`. The default `null` evaluates the whole walker batch in one
 vmap. On memory-limited runs, users can set an integer to evaluate fewer
 walkers at a time:
@@ -101,7 +103,7 @@ train:
 ```
 
 That knob is specific to the local-vmap path. Estimators that implement their
-own full-batch `evaluate_batch` do not inherit it, because JaQMC cannot know how
+own full-batch `evaluate_batch_walkers` do not inherit it, because JaQMC cannot know how
 to split their batch logic safely.
 
 ## Add Runtime Dependencies
@@ -127,13 +129,13 @@ from typing import Any
 
 from jax import numpy as jnp
 
-from jaqmc.estimator import LocalEstimator
+from jaqmc.estimator import PerWalkerEstimator
 from jaqmc.utils.config import configurable_dataclass
 from jaqmc.utils.wiring import runtime_dep
 
 
 @configurable_dataclass
-class DipoleEstimator(LocalEstimator):
+class DipoleEstimator(PerWalkerEstimator):
     """Estimates the electric dipole moment.
 
     Args:
@@ -146,8 +148,10 @@ class DipoleEstimator(LocalEstimator):
     atom_charges: Any = runtime_dep()
     atom_positions: Any = runtime_dep()
 
-    def evaluate_local(self, params, data, prev_local_stats, state, rngs):
-        del params, prev_local_stats, rngs
+    def evaluate_single_walker(
+        self, params, data, prev_walker_stats, state, rngs
+    ):
+        del params, prev_walker_stats, rngs
         ref = jnp.array(self.reference_point)
         elec = -jnp.sum(data.electrons - ref, axis=0)
         nuc = jnp.sum(self.atom_charges[:, None] * (self.atom_positions - ref), axis=0)
@@ -175,7 +179,7 @@ est = cfg.get("estimators.dipole", DipoleEstimator())
 wire(est, atom_charges=system.charges, atom_positions=system.positions)
 ```
 
-Only `reference_point` and inherited `LocalEstimator` config fields appear in
+Only `reference_point` and inherited `PerWalkerEstimator` config fields appear in
 YAML. Runtime dependencies remain workflow-owned:
 
 ```yaml
@@ -197,7 +201,7 @@ those values across the full walker batch. Some observables are more natural
 when the implementation can see the leading batch axis in one go: histograms,
 pair-correlation accumulators, and stateful evaluation summaries are typical
 examples. For those cases, inherit directly from
-{class}`~jaqmc.estimator.base.Estimator` and implement `evaluate_batch`.
+{class}`~jaqmc.estimator.base.Estimator` and implement `evaluate_batch_walkers`.
 
 The method receives
 {class}`~jaqmc.data.BatchedData`, so fields listed in
@@ -226,15 +230,17 @@ class RadiusHistogram(Estimator):
         del data, rngs
         return jnp.zeros(self.bins)
 
-    def evaluate_batch(self, params, batched_data, prev_local_stats, state, rngs):
-        del params, prev_local_stats, rngs
+    def evaluate_batch_walkers(
+        self, params, batched_data, prev_walker_stats, state, rngs
+    ):
+        del params, prev_walker_stats, rngs
         electrons = batched_data.data.electrons
         radii = jnp.linalg.norm(electrons, axis=-1).reshape(-1)
         counts = jnp.histogram(radii, self.bins, (0.0, self.max_radius))[0]
         return {}, state + counts
 
-    def reduce(self, local_stats):
-        del local_stats
+    def reduce(self, walker_stats):
+        del walker_stats
         return {}
 
     def finalize_state(self, state, *, n_steps):
@@ -259,8 +265,8 @@ The choice comes down to what shape of data the estimator really needs:
 | Need | Use | Implement |
 |------|-----|-----------|
 | Fixed single-walker calculation | Plain function | Function body |
-| Configurable single-walker calculation | `LocalEstimator` | `evaluate_local` |
-| Full-batch or state-accumulating calculation | `Estimator` | `evaluate_batch` |
+| Configurable single-walker calculation | `PerWalkerEstimator` | `evaluate_single_walker` |
+| Full-batch or state-accumulating calculation | `Estimator` | `evaluate_batch_walkers` |
 
 ### Lifecycle hooks
 
@@ -269,13 +275,13 @@ After you choose the interface, override only the methods your estimator needs:
 | Method | When to override |
 |--------|------------------|
 | `init(self, data, rngs)` | You need derived state before the first step, such as precomputed index arrays. |
-| `evaluate_local` | You inherit from `LocalEstimator` and compute one walker's local values. |
-| `evaluate_batch` | You inherit from `Estimator` and need the whole walker batch at once. |
+| `evaluate_single_walker` | You inherit from `PerWalkerEstimator` and compute one walker's values. |
+| `evaluate_batch_walkers` | You inherit from `Estimator` and need the whole walker batch at once. |
 | `reduce` | The default mean-with-variance is not appropriate. |
 | `finalize_stats` | Final values require nonlinear combinations of step-level statistics. |
 | `finalize_state` | Final values come from accumulated estimator state. |
 
-For most custom observables, `LocalEstimator.evaluate_local` is the only method
+For most custom observables, `PerWalkerEstimator.evaluate_single_walker` is the only method
 you need to implement.
 
 ### Keys and run order
@@ -289,7 +295,7 @@ Two conventions matter for the keys you return and for cross-estimator use:
   energy terms; a non-energy key such as `energy:dipole` will change the
   optimization target.
 - **Pipeline order**: Estimators run in insertion order. Each estimator receives
-  `prev_local_stats`, the local values from preceding estimators. If your
+  `prev_walker_stats`, the per-walker values from preceding estimators. If your
   estimator depends on another estimator's output, place it later in the
   estimator dict.
 

--- a/docs/extending/custom-components/index.md
+++ b/docs/extending/custom-components/index.md
@@ -16,10 +16,11 @@ A typical component has two kinds of fields:
 The {deco}`~jaqmc.utils.config.configurable_dataclass` decorator prepares a class for the config system. It applies `@dataclass` and sets up serialization so that {meth}`~jaqmc.utils.config.ConfigManager.get`, {meth}`~jaqmc.utils.config.ConfigManager.get_module`, and {meth}`~jaqmc.utils.config.ConfigManager.get_collection` can construct instances from YAML.
 
 ```python
+from jaqmc.estimator import LocalEstimator
 from jaqmc.utils.config import configurable_dataclass
 
 @configurable_dataclass
-class MyEstimator(Estimator):
+class MyEstimator(LocalEstimator):
     cutoff: float = 1e-8  # appears in YAML
 ```
 
@@ -30,10 +31,11 @@ This is equivalent to writing `@dataclass(kw_only=True)` plus the serialization 
 Use `runtime_dep()` to declare a field as a runtime dependency. These fields are hidden from serialization — they won't appear in YAML output or be read from config files.
 
 ```python
+from jaqmc.estimator import LocalEstimator
 from jaqmc.utils.wiring import runtime_dep
 
 @configurable_dataclass
-class MyEstimator(Estimator):
+class MyEstimator(LocalEstimator):
     cutoff: float = 1e-8                              # config field
     f_log_psi: SomeCallable = runtime_dep()            # required
     data_field: str = runtime_dep(default="electrons")  # optional
@@ -77,12 +79,12 @@ est.f_log_psi = wf.evaluate
 Here's {class}`~jaqmc.estimator.kinetic.EuclideanKinetic`, a built-in estimator that uses all three mechanisms:
 
 ```python
-from jaqmc.estimator import Estimator
+from jaqmc.estimator import LocalEstimator
 from jaqmc.utils.config import configurable_dataclass
 from jaqmc.utils.wiring import runtime_dep
 
 @configurable_dataclass
-class EuclideanKinetic(Estimator):
+class EuclideanKinetic(LocalEstimator):
     """Kinetic energy estimator in Euclidean geometry.
 
     Args:
@@ -160,28 +162,28 @@ writers
 :link: estimators
 :link-type: doc
 
-Compute physical observables. Implement `evaluate_local` for single-walker logic; the base class vmaps it over walkers.
+Compute physical observables.
 ::::
 
 ::::{grid-item-card} Optimizers
 :link: optimizers
 :link-type: doc
 
-Transform gradients into parameter updates. Implement the `OptimizerLike` protocol.
+Transform gradients into parameter updates.
 ::::
 
 ::::{grid-item-card} Samplers
 :link: samplers
 :link-type: doc
 
-Propose and accept/reject electron moves. Implement the `SamplerLike` protocol.
+Propose and accept/reject electron moves.
 ::::
 
 ::::{grid-item-card} Writers
 :link: writers
 :link-type: doc
 
-Record per-step statistics. Subclass `Writer` and implement `write` and `open`.
+Record per-step statistics.
 ::::
 
 :::::

--- a/docs/extending/custom-components/index.md
+++ b/docs/extending/custom-components/index.md
@@ -16,11 +16,11 @@ A typical component has two kinds of fields:
 The {deco}`~jaqmc.utils.config.configurable_dataclass` decorator prepares a class for the config system. It applies `@dataclass` and sets up serialization so that {meth}`~jaqmc.utils.config.ConfigManager.get`, {meth}`~jaqmc.utils.config.ConfigManager.get_module`, and {meth}`~jaqmc.utils.config.ConfigManager.get_collection` can construct instances from YAML.
 
 ```python
-from jaqmc.estimator import LocalEstimator
+from jaqmc.estimator import PerWalkerEstimator
 from jaqmc.utils.config import configurable_dataclass
 
 @configurable_dataclass
-class MyEstimator(LocalEstimator):
+class MyEstimator(PerWalkerEstimator):
     cutoff: float = 1e-8  # appears in YAML
 ```
 
@@ -31,11 +31,11 @@ This is equivalent to writing `@dataclass(kw_only=True)` plus the serialization 
 Use `runtime_dep()` to declare a field as a runtime dependency. These fields are hidden from serialization — they won't appear in YAML output or be read from config files.
 
 ```python
-from jaqmc.estimator import LocalEstimator
+from jaqmc.estimator import PerWalkerEstimator
 from jaqmc.utils.wiring import runtime_dep
 
 @configurable_dataclass
-class MyEstimator(LocalEstimator):
+class MyEstimator(PerWalkerEstimator):
     cutoff: float = 1e-8                              # config field
     f_log_psi: SomeCallable = runtime_dep()            # required
     data_field: str = runtime_dep(default="electrons")  # optional
@@ -79,12 +79,12 @@ est.f_log_psi = wf.evaluate
 Here's {class}`~jaqmc.estimator.kinetic.EuclideanKinetic`, a built-in estimator that uses all three mechanisms:
 
 ```python
-from jaqmc.estimator import LocalEstimator
+from jaqmc.estimator import PerWalkerEstimator
 from jaqmc.utils.config import configurable_dataclass
 from jaqmc.utils.wiring import runtime_dep
 
 @configurable_dataclass
-class EuclideanKinetic(LocalEstimator):
+class EuclideanKinetic(PerWalkerEstimator):
     """Kinetic energy estimator in Euclidean geometry.
 
     Args:
@@ -96,7 +96,9 @@ class EuclideanKinetic(LocalEstimator):
     f_log_psi: WavefunctionEvaluate = runtime_dep()   # required runtime dep
     data_field: str = runtime_dep(default="electrons")  # optional runtime dep
 
-    def evaluate_local(self, params, data, prev_local_stats, state, rngs):
+    def evaluate_single_walker(
+        self, params, data, prev_walker_stats, state, rngs
+    ):
         # Uses self.f_log_psi to compute the Laplacian of log|psi|
         ...
         return {"energy:kinetic": kinetic_energy}, state

--- a/docs/extending/jax-for-jaqmc.md
+++ b/docs/extending/jax-for-jaqmc.md
@@ -16,10 +16,10 @@ from typing import Any
 
 from jaqmc.app.molecule.data import MoleculeData
 from jaqmc.array_types import Params, PRNGKey
-from jaqmc.estimator import Estimator
+from jaqmc.estimator import LocalEstimator
 
 
-class PotentialEnergy(Estimator):
+class PotentialEnergy(LocalEstimator):
     def evaluate_local(
         self,
         params: Params,
@@ -35,9 +35,9 @@ class PotentialEnergy(Estimator):
 
 What this example shows:
 
-- You write logic for **one walker** in `evaluate_local`.
-- JaQMC's base `Estimator` class batches that logic with `jax.vmap` in `evaluate_batch`.
-- Workflow stages may compile the batched computation with `jax.jit`.
+- You write logic for **one walker** in {meth}`~jaqmc.estimator.LocalEstimator.evaluate_local`.
+- JaQMC's {class}`~jaqmc.estimator.LocalEstimator` class batches that logic with {func}`jax.vmap` in {meth}`~jaqmc.estimator.LocalEstimator.evaluate_batch`.
+- Workflow stages may compile the batched computation with {func}`jax.jit`.
 
 Keep this "single walker -> `vmap` -> `jit`" model in mind while reading the rest of the page.
 
@@ -45,8 +45,8 @@ Keep this "single walker -> `vmap` -> `jit`" model in mind while reading the res
 
 Before you start extending JaQMC, make sure you are comfortable with:
 
-- `jax.numpy` (imported as `jnp` throughout JaQMC), so you are comfortable writing array-based code
-- `jax.jit`, `jax.vmap`, and `jax.grad`, because JaQMC relies heavily on compilation, batching, and automatic differentiation
+- {mod}`jax.numpy` (imported as `jnp` throughout JaQMC), so you are comfortable writing array-based code
+- {func}`jax.jit`, {func}`jax.vmap`, and {func}`jax.grad`, because JaQMC relies heavily on compilation, batching, and automatic differentiation
 - pytrees and PRNG keys, because JaQMC passes structured state and randomness through many interfaces
 - the basic Flax [`Module`](inv:flax:py:class#flax.linen.Module) / `init` / `apply` model, because JaQMC wavefunctions are Flax modules
 
@@ -71,7 +71,7 @@ A **walker** is one sampled electron configuration. The most important JaQMC-spe
 That pattern explains several design choices you will see in the docs:
 
 - A wavefunction `__call__` usually receives one JaQMC [Data](#api-wavefunctions-data) object, not a batch.
-- Estimators often implement `evaluate_local` for one walker, while the base class handles batching.
+- Estimators often inherit from {class}`~jaqmc.estimator.LocalEstimator` and implement {meth}`~jaqmc.estimator.LocalEstimator.evaluate_local` for one walker, while `LocalEstimator` handles batching.
 - Runtime state and parameters must be JAX-friendly pytrees so they can pass through transforms cleanly.
 
 If that pattern feels strange at first, focus on understanding `vmap` before worrying about more advanced JAX topics.

--- a/docs/extending/jax-for-jaqmc.md
+++ b/docs/extending/jax-for-jaqmc.md
@@ -16,27 +16,27 @@ from typing import Any
 
 from jaqmc.app.molecule.data import MoleculeData
 from jaqmc.array_types import Params, PRNGKey
-from jaqmc.estimator import LocalEstimator
+from jaqmc.estimator import PerWalkerEstimator
 
 
-class PotentialEnergy(LocalEstimator):
-    def evaluate_local(
+class PotentialEnergy(PerWalkerEstimator):
+    def evaluate_single_walker(
         self,
         params: Params,
         data: MoleculeData,
-        prev_local_stats: Mapping[str, Any],
+        prev_walker_stats: Mapping[str, Any],
         state: object,
         rngs: PRNGKey,
     ) -> tuple[dict[str, jnp.ndarray], object]:
-        del params, prev_local_stats, rngs
+        del params, prev_walker_stats, rngs
         r = jnp.linalg.norm(data["electrons"][0] - data["atoms"][0])
         return {"energy:potential": -1.0 / r}, state
 ```
 
 What this example shows:
 
-- You write logic for **one walker** in {meth}`~jaqmc.estimator.LocalEstimator.evaluate_local`.
-- JaQMC's {class}`~jaqmc.estimator.LocalEstimator` class batches that logic with {func}`jax.vmap` in {meth}`~jaqmc.estimator.LocalEstimator.evaluate_batch`.
+- You write logic for **one walker** in {meth}`~jaqmc.estimator.PerWalkerEstimator.evaluate_single_walker`.
+- JaQMC's {class}`~jaqmc.estimator.PerWalkerEstimator` class batches that logic with {func}`jax.vmap` in {meth}`~jaqmc.estimator.PerWalkerEstimator.evaluate_batch_walkers`.
 - Workflow stages may compile the batched computation with {func}`jax.jit`.
 
 Keep this "single walker -> `vmap` -> `jit`" model in mind while reading the rest of the page.
@@ -71,7 +71,7 @@ A **walker** is one sampled electron configuration. The most important JaQMC-spe
 That pattern explains several design choices you will see in the docs:
 
 - A wavefunction `__call__` usually receives one JaQMC [Data](#api-wavefunctions-data) object, not a batch.
-- Estimators often inherit from {class}`~jaqmc.estimator.LocalEstimator` and implement {meth}`~jaqmc.estimator.LocalEstimator.evaluate_local` for one walker, while `LocalEstimator` handles batching.
+- Estimators often inherit from {class}`~jaqmc.estimator.PerWalkerEstimator` and implement {meth}`~jaqmc.estimator.PerWalkerEstimator.evaluate_single_walker` for one walker, while `PerWalkerEstimator` handles batching.
 - Runtime state and parameters must be JAX-friendly pytrees so they can pass through transforms cleanly.
 
 If that pattern feels strange at first, focus on understanding `vmap` before worrying about more advanced JAX topics.

--- a/docs/extending/runtime-data-conventions.md
+++ b/docs/extending/runtime-data-conventions.md
@@ -34,7 +34,7 @@ For a beginner, the simplest way to think about it is: "`Data` holds the arrays
 my components read while the run is executing."
 
 Most high-level extension hooks use `Data` in its single-walker form. A
-wavefunction or `evaluate_local` implementation usually receives one walker's
+wavefunction or `evaluate_single_walker` implementation usually receives one walker's
 values in that object.
 
 It is not limited to electron coordinates. Built-in apps already use

--- a/docs/extending/writing-workflows.md
+++ b/docs/extending/writing-workflows.md
@@ -58,7 +58,7 @@ The simplest estimator is a plain function with signature `(params, data, stats,
 :pyobject: potential_energy
 ```
 
-The signature ``(params, data, stats, state, rngs)`` is the standard estimator interface. ``stats`` (called ``prev_local_stats`` in the {class}`~jaqmc.estimator.base.Estimator` class interface) contains values from other estimators in the current step (for derived quantities like total energy), and ``state`` carries mutable state across iterations. Simple estimators like this one can ignore most parameters — ``del`` marks them as intentionally unused.
+The signature ``(params, data, stats, state, rngs)`` is the standard estimator interface. ``stats`` (called ``prev_walker_stats`` in the {class}`~jaqmc.estimator.base.Estimator` class interface) contains values from other estimators in the current step (for derived quantities like total energy), and ``state`` carries mutable state across iterations. Simple estimators like this one can ignore most parameters — ``del`` marks them as intentionally unused.
 
 The ``energy:`` prefix is a naming convention: any estimator that returns a key starting with ``energy:`` contributes to the total energy, which becomes the VMC optimization target. A {class}`~jaqmc.estimator.total_energy.TotalEnergy` estimator auto-sums all ``energy:``-prefixed keys into a ``total_energy`` value — you'll use it in Step 5.
 

--- a/docs/guide/analyzing-wavefunctions.md
+++ b/docs/guide/analyzing-wavefunctions.md
@@ -179,7 +179,7 @@ print(f"  electron position: {single_data.electrons}")
 
 ## 4. Computing Physical Observables
 
-JaQMC provides built-in estimators for computing physical observables. Each estimator implements `evaluate_local` for a single walker, and `evaluate_batch` automatically vmaps it over the batch of walkers.
+JaQMC provides built-in estimators for computing physical observables. Each estimator implements `evaluate_single_walker` for a single walker, and `evaluate_batch_walkers` automatically vmaps it over the batch of walkers.
 
 We'll use the built-in {class}`~jaqmc.estimator.kinetic.EuclideanKinetic` estimator and the `potential_energy` function. {class}`~jaqmc.estimator.base.EstimatorPipeline` accepts both {class}`~jaqmc.estimator.base.Estimator` subclass instances and plain functions with the estimator signature:
 
@@ -197,7 +197,7 @@ estimator_state = pipeline.init(batched_data, jax.random.PRNGKey(0))
 
 ### Using `shard_map` for device-parallel evaluation
 
-Internally, `evaluate_batch` uses `jax.vmap` to map `evaluate_local` over all walkers. However, the restored checkpoint data carries [named sharding](inv:jax:*:doc#notebooks/shard_map) metadata (e.g. `qmc_batch_axis`) from training, while freshly created arrays like random keys do not. Mixing these inside a single `vmap` triggers a JAX error about inconsistent axis specs.
+Internally, `evaluate_batch_walkers` uses `jax.vmap` to map `evaluate_single_walker` over all walkers. However, the restored checkpoint data carries [named sharding](inv:jax:*:doc#notebooks/shard_map) metadata (e.g. `qmc_batch_axis`) from training, while freshly created arrays like random keys do not. Mixing these inside a single `vmap` triggers a JAX error about inconsistent axis specs.
 
 The solution is the same one the training loop uses: wrap the call in `jit_sharded`, which combines `jax.jit` with [`shard_map`](inv:jax:*:doc#notebooks/shard_map). Inside a `shard_map`, each device only sees its own **local shard** — plain arrays with no global sharding metadata — so the `vmap` inside `evaluate_batch` works without conflict.
 
@@ -259,7 +259,7 @@ print(f"  Potential var: {final_stats['energy:potential_var']:.6f}")
 
 The local energy $E_L(r) = H\psi(r)/\psi(r)$ should be constant everywhere for an exact eigenstate. Plotting it against electron-nucleus distance reveals how well the wavefunction performs at different regions.
 
-We use the same `jit_sharded` pattern to vmap `evaluate_local` over walkers:
+We use the same `jit_sharded` pattern to vmap `evaluate_single_walker` over walkers:
 
 ```{code-cell} ipython3
 ---
@@ -268,7 +268,9 @@ slideshow:
   slide_type: ''
 ---
 def compute_local_energy(params, data):
-    kinetic_stats, _ = kinetic_est.evaluate_local(params, data, {}, None, jax.random.PRNGKey(0))
+    kinetic_stats, _ = kinetic_est.evaluate_single_walker(
+        params, data, {}, None, jax.random.PRNGKey(0)
+    )
     potential_stats, _ = potential_energy(params, data, {}, None, jax.random.PRNGKey(0))
     return kinetic_stats["energy:kinetic"] + potential_stats["energy:potential"]
 

--- a/docs/guide/running-workflows.md
+++ b/docs/guide/running-workflows.md
@@ -64,6 +64,25 @@ For most production runs, the highest-value decisions are how long to train, whe
 keep pretraining, and whether you need a different optimizer or wavefunction. Everything
 else is usually a second-order adjustment.
 
+#### Fit larger runs in memory
+
+If a run does not fit in device memory, first decide whether you can change the walker
+count. Lowering `workflow.batch_size` reduces memory, but it also increases variance and
+can hurt optimization quality. To keep the same number of walkers, set `vmap_chunk_size`
+on a local estimator so the work is evaluated in smaller pieces. That trades speed for
+lower peak memory.
+
+The tightest part of the model varies by system, but the kinetic energy estimator is
+often the right place to start:
+
+```bash
+jaqmc <app> train ... \
+  estimators.energy.kinetic.vmap_chunk_size=128
+```
+
+Use the largest chunk size that still fits. Smaller chunks cut peak memory further, but
+they add overhead.
+
 (recipe-resume-evaluate)=
 ### Resume, branch, or evaluate
 

--- a/docs/guide/writers.md
+++ b/docs/guide/writers.md
@@ -37,7 +37,7 @@ To add another console field, use the statistic key that the estimator writes, n
 train.writers.console.fields="pmove:.2f,energy=total_energy:.6f,A=observable_a:.6f"
 ```
 
-For most estimators, the key is the output key in the estimator code. If a custom estimator returns `{"observable_a": value}` from `evaluate_local` and uses the default reducer, the scalar mean is written as `observable_a` and the variance is written as `observable_a_var`.
+For most estimators, the key is the output key in the estimator code. If a custom estimator returns `{"observable_a": value}` from `evaluate_single_walker` and uses the default reducer, the scalar mean is written as `observable_a` and the variance is written as `observable_a_var`.
 
 If you're unsure which key to use, inspect an existing run's output files. The CSV header lists scalar keys that can be printed in the console:
 

--- a/src/jaqmc/app/hall/estimator/one_rdm.py
+++ b/src/jaqmc/app/hall/estimator/one_rdm.py
@@ -30,7 +30,7 @@ from scipy import special as ss
 
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import Data
-from jaqmc.estimator.base import Estimator, mean_reduce
+from jaqmc.estimator.base import LocalEstimator, mean_reduce
 from jaqmc.utils.config import configurable_dataclass
 from jaqmc.utils.wiring import runtime_dep
 from jaqmc.wavefunction.base import NumericWavefunctionEvaluate
@@ -92,7 +92,7 @@ def _uniform_sample_sphere(key: PRNGKey) -> jnp.ndarray:
 
 
 @configurable_dataclass
-class OneRDM(Estimator):
+class OneRDM(LocalEstimator):
     r"""One-body reduced density matrix on the Haldane sphere.
 
     Computes the 1-RDM in the monopole harmonic basis

--- a/src/jaqmc/app/hall/estimator/one_rdm.py
+++ b/src/jaqmc/app/hall/estimator/one_rdm.py
@@ -30,7 +30,7 @@ from scipy import special as ss
 
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import Data
-from jaqmc.estimator.base import LocalEstimator, mean_reduce
+from jaqmc.estimator.base import PerWalkerEstimator, mean_reduce
 from jaqmc.utils.config import configurable_dataclass
 from jaqmc.utils.wiring import runtime_dep
 from jaqmc.wavefunction.base import NumericWavefunctionEvaluate
@@ -92,7 +92,7 @@ def _uniform_sample_sphere(key: PRNGKey) -> jnp.ndarray:
 
 
 @configurable_dataclass
-class OneRDM(LocalEstimator):
+class OneRDM(PerWalkerEstimator):
     r"""One-body reduced density matrix on the Haldane sphere.
 
     Computes the 1-RDM in the monopole harmonic basis
@@ -123,15 +123,15 @@ class OneRDM(LocalEstimator):
         assert len(self._orbitals) == norbs
         return None
 
-    def evaluate_local(
+    def evaluate_single_walker(
         self,
         params: Params,
         data: Data,
-        prev_local_stats: Mapping[str, Any],
+        prev_walker_stats: Mapping[str, Any],
         state: Any,
         rngs: PRNGKey,
     ) -> tuple[dict[str, Any], Any]:
-        del prev_local_stats
+        del prev_walker_stats
         electrons = data[self.data_field]
         nelec = electrons.shape[0]
 
@@ -169,7 +169,7 @@ class OneRDM(LocalEstimator):
 
         return {"one_rdm": one_rdm}, state
 
-    def reduce(self, local_stats: Mapping[str, Any]) -> dict[str, Any]:
+    def reduce(self, walker_stats: Mapping[str, Any]) -> dict[str, Any]:
         """Mean over walkers without variance (complex matrix).
 
         Uses the default ``mean_reduce`` but skips variance since the
@@ -179,7 +179,7 @@ class OneRDM(LocalEstimator):
         Returns:
             Step-level mean of the 1-RDM across walkers.
         """
-        return mean_reduce(local_stats, include_variance=False)
+        return mean_reduce(walker_stats, include_variance=False)
 
     def finalize_stats(
         self, batched_stats: Mapping[str, Any], state: Any

--- a/src/jaqmc/app/hall/estimator/pair_correlation.py
+++ b/src/jaqmc/app/hall/estimator/pair_correlation.py
@@ -40,15 +40,15 @@ class PairCorrelation(Estimator):
     def init(self, data: Data, rngs: PRNGKey) -> jnp.ndarray:
         return jnp.zeros(self.bins)
 
-    def evaluate_batch(
+    def evaluate_batch_walkers(
         self,
         params: Any,
         batched_data: BatchedData,
-        prev_local_stats: Mapping[str, Any],
+        prev_walker_stats: Mapping[str, Any],
         state: jnp.ndarray,
         rngs: PRNGKey,
     ) -> tuple[dict[str, Any], jnp.ndarray]:
-        del params, prev_local_stats, rngs
+        del params, prev_walker_stats, rngs
         electrons = batched_data.data.electrons
         batch_size, nelec, _ = electrons.shape
         theta, phi = electrons[..., 0], electrons[..., 1]
@@ -72,7 +72,8 @@ class PairCorrelation(Estimator):
         # to a density.  Division by number of evaluation steps is NOT included.
         return {}, state + to_add * 4 * self.bins / batch_size / nelec**2 / jnp.pi
 
-    def reduce(self, local_stats: Mapping[str, Any]) -> dict[str, Any]:
+    def reduce(self, walker_stats: Mapping[str, Any]) -> dict[str, Any]:
+        del walker_stats
         return {}
 
     def finalize_stats(

--- a/src/jaqmc/app/hall/estimator/penalized_loss.py
+++ b/src/jaqmc/app/hall/estimator/penalized_loss.py
@@ -13,12 +13,12 @@ from typing import Any
 
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import Data
-from jaqmc.estimator.base import Estimator
+from jaqmc.estimator.base import LocalEstimator
 from jaqmc.utils.config import configurable_dataclass
 
 
 @configurable_dataclass
-class PenalizedLoss(Estimator):
+class PenalizedLoss(LocalEstimator):
     """Adds angular momentum penalties to total energy for state selection.
 
     Reads ``total_energy``, ``angular_momentum_z``,

--- a/src/jaqmc/app/hall/estimator/penalized_loss.py
+++ b/src/jaqmc/app/hall/estimator/penalized_loss.py
@@ -13,17 +13,17 @@ from typing import Any
 
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import Data
-from jaqmc.estimator.base import LocalEstimator
+from jaqmc.estimator.base import PerWalkerEstimator
 from jaqmc.utils.config import configurable_dataclass
 
 
 @configurable_dataclass
-class PenalizedLoss(LocalEstimator):
+class PenalizedLoss(PerWalkerEstimator):
     """Adds angular momentum penalties to total energy for state selection.
 
     Reads ``total_energy``, ``angular_momentum_z``,
     ``angular_momentum_z_square``, and ``angular_momentum_square`` from
-    ``prev_local_stats`` and outputs a ``penalized_loss`` key.
+    ``prev_walker_stats`` and outputs a ``penalized_loss`` key.
 
     Args:
         lz_center: Target :math:`L_z` value.
@@ -35,28 +35,28 @@ class PenalizedLoss(LocalEstimator):
     lz_penalty: float = 0.0
     l2_penalty: float = 0.0
 
-    def evaluate_local(
+    def evaluate_single_walker(
         self,
         params: Params,
         data: Data,
-        prev_local_stats: Mapping[str, Any],
+        prev_walker_stats: Mapping[str, Any],
         state: None,
         rngs: PRNGKey,
     ) -> tuple[dict[str, Any], None]:
         del params, data, rngs
 
-        loss = prev_local_stats["total_energy"]
+        loss = prev_walker_stats["total_energy"]
 
         if self.lz_penalty:
-            lz = prev_local_stats["angular_momentum_z"]
-            lz_sq = prev_local_stats["angular_momentum_z_square"]
+            lz = prev_walker_stats["angular_momentum_z"]
+            lz_sq = prev_walker_stats["angular_momentum_z_square"]
             # (Lz - lz_center)^2 = Lz^2 - 2*lz_center*Lz + lz_center^2
             loss = loss + self.lz_penalty * (
                 lz_sq - 2 * self.lz_center * lz + self.lz_center**2
             )
 
         if self.l2_penalty:
-            l2 = prev_local_stats["angular_momentum_square"]
+            l2 = prev_walker_stats["angular_momentum_square"]
             loss = loss + self.l2_penalty * l2
 
         return {"penalized_loss": loss}, state

--- a/src/jaqmc/app/hall/hamiltonian.py
+++ b/src/jaqmc/app/hall/hamiltonian.py
@@ -12,12 +12,12 @@ from jax.numpy import cos, sin
 from jaqmc.app.hall.config import InteractionType
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import Data
-from jaqmc.estimator.base import Estimator
+from jaqmc.estimator.base import LocalEstimator
 from jaqmc.utils.config import configurable_dataclass
 
 
 @configurable_dataclass
-class SpherePotential(Estimator):
+class SpherePotential(LocalEstimator):
     r"""Potential energy on the Haldane sphere.
 
     Converts spherical coordinates to Cartesian, computes pairwise

--- a/src/jaqmc/app/hall/hamiltonian.py
+++ b/src/jaqmc/app/hall/hamiltonian.py
@@ -12,12 +12,12 @@ from jax.numpy import cos, sin
 from jaqmc.app.hall.config import InteractionType
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import Data
-from jaqmc.estimator.base import LocalEstimator
+from jaqmc.estimator.base import PerWalkerEstimator
 from jaqmc.utils.config import configurable_dataclass
 
 
 @configurable_dataclass
-class SpherePotential(LocalEstimator):
+class SpherePotential(PerWalkerEstimator):
     r"""Potential energy on the Haldane sphere.
 
     Converts spherical coordinates to Cartesian, computes pairwise
@@ -35,15 +35,15 @@ class SpherePotential(LocalEstimator):
     radius: float = 1.0
     interaction_strength: float = 1.0
 
-    def evaluate_local(
+    def evaluate_single_walker(
         self,
         params: Params,
         data: Data,
-        prev_local_stats: Mapping[str, Any],
+        prev_walker_stats: Mapping[str, Any],
         state: None,
         rngs: PRNGKey,
     ) -> tuple[dict[str, Any], None]:
-        del params, prev_local_stats, rngs
+        del params, prev_walker_stats, rngs
         electrons = data["electrons"]
         theta, phi = electrons[..., 0], electrons[..., 1]
 

--- a/src/jaqmc/app/molecule/hamiltonian.py
+++ b/src/jaqmc/app/molecule/hamiltonian.py
@@ -6,8 +6,8 @@ from jax import numpy as jnp
 from jaqmc.geometry import obc
 
 
-def potential_energy(params, data, prev_local_stats, state, rngs):
-    del params, rngs, prev_local_stats
+def potential_energy(params, data, prev_walker_stats, state, rngs):
+    del params, rngs, prev_walker_stats
     nelec = data.electrons.shape[0]
     natom = data.atoms.shape[0]
     r_ae = obc.pair_displacements_between(data.electrons, data.atoms)[1]

--- a/src/jaqmc/app/solid/hamiltonian.py
+++ b/src/jaqmc/app/solid/hamiltonian.py
@@ -7,7 +7,7 @@ from typing import Any
 from jax import numpy as jnp
 
 from jaqmc.array_types import Params, PRNGKey
-from jaqmc.estimator import Estimator
+from jaqmc.estimator import LocalEstimator
 from jaqmc.estimator.ewald import EwaldSum
 from jaqmc.utils.config import configurable_dataclass
 from jaqmc.utils.wiring import runtime_dep
@@ -16,7 +16,7 @@ from .data import SolidData
 
 
 @configurable_dataclass
-class PotentialEnergy(Estimator):
+class PotentialEnergy(LocalEstimator):
     """Potential energy estimator for solid systems using Ewald summation.
 
     Args:
@@ -29,7 +29,7 @@ class PotentialEnergy(Estimator):
         self.ewald = EwaldSum(self.supercell_lattice)
         return None
 
-    def evaluate(
+    def evaluate_local(
         self,
         params: Params,
         data: SolidData,

--- a/src/jaqmc/app/solid/hamiltonian.py
+++ b/src/jaqmc/app/solid/hamiltonian.py
@@ -7,7 +7,7 @@ from typing import Any
 from jax import numpy as jnp
 
 from jaqmc.array_types import Params, PRNGKey
-from jaqmc.estimator import LocalEstimator
+from jaqmc.estimator import PerWalkerEstimator
 from jaqmc.estimator.ewald import EwaldSum
 from jaqmc.utils.config import configurable_dataclass
 from jaqmc.utils.wiring import runtime_dep
@@ -16,7 +16,7 @@ from .data import SolidData
 
 
 @configurable_dataclass
-class PotentialEnergy(LocalEstimator):
+class PotentialEnergy(PerWalkerEstimator):
     """Potential energy estimator for solid systems using Ewald summation.
 
     Args:
@@ -29,15 +29,15 @@ class PotentialEnergy(LocalEstimator):
         self.ewald = EwaldSum(self.supercell_lattice)
         return None
 
-    def evaluate_local(
+    def evaluate_single_walker(
         self,
         params: Params,
         data: SolidData,
-        prev_local_stats: Mapping[str, Any],
+        prev_walker_stats: Mapping[str, Any],
         state: None,
         rngs: PRNGKey,
     ) -> tuple[dict[str, Any], None]:
-        del params, rngs, prev_local_stats
+        del params, rngs, prev_walker_stats
 
         electrons = data.electrons.reshape(-1, 3)
         atoms = data.atoms.reshape(-1, 3)

--- a/src/jaqmc/estimator/__init__.py
+++ b/src/jaqmc/estimator/__init__.py
@@ -7,6 +7,7 @@ from .base import (
     EstimatorLike,
     EstimatorPipeline,
     FunctionEstimator,
+    LocalEstimator,
 )
 
 __all__ = [
@@ -15,4 +16,5 @@ __all__ = [
     "EstimatorLike",
     "EstimatorPipeline",
     "FunctionEstimator",
+    "LocalEstimator",
 ]

--- a/src/jaqmc/estimator/__init__.py
+++ b/src/jaqmc/estimator/__init__.py
@@ -7,7 +7,7 @@ from .base import (
     EstimatorLike,
     EstimatorPipeline,
     FunctionEstimator,
-    LocalEstimator,
+    PerWalkerEstimator,
 )
 
 __all__ = [
@@ -16,5 +16,5 @@ __all__ = [
     "EstimatorLike",
     "EstimatorPipeline",
     "FunctionEstimator",
-    "LocalEstimator",
+    "PerWalkerEstimator",
 ]

--- a/src/jaqmc/estimator/base.py
+++ b/src/jaqmc/estimator/base.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025-2026 Bytedance Ltd. and/or its affiliates
 # SPDX-License-Identifier: Apache-2.0
 
+from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
 from typing import Any
 
@@ -53,7 +54,7 @@ def mean_reduce(
 
 
 @configurable_dataclass
-class Estimator[DataT: Data]:
+class Estimator[DataT: Data](ABC):
     """Base estimator with default no-op implementations.
 
     An estimator computes an observable quantity through a lifecycle
@@ -85,7 +86,11 @@ class Estimator[DataT: Data]:
        statistics.  Called only during evaluation digest, never inside
        JIT.
 
-    Subclass and override only the methods you need.
+    Subclass and override only the methods you need. Most estimators should
+    inherit from :class:`LocalEstimator`, which batches single-walker
+    ``evaluate_local`` implementations automatically. Inherit directly from
+    this class when the estimator owns full-batch logic through
+    ``evaluate_batch``.
 
     Runtime dependencies should be declared as
     :func:`~jaqmc.utils.wiring.runtime_dep` fields.
@@ -106,8 +111,6 @@ class Estimator[DataT: Data]:
         DataT: Concrete one-walker ``Data`` subtype consumed by this estimator.
     """
 
-    chunk_size: int | None = None
-
     def init(self, data: DataT, rngs: PRNGKey) -> Any:
         """Initialize estimator state from an example data point.
 
@@ -119,33 +122,7 @@ class Estimator[DataT: Data]:
         """
         return None
 
-    def evaluate_local(
-        self,
-        params: Params,
-        data: DataT,
-        prev_local_stats: Mapping[str, Any],
-        state: Any,
-        rngs: PRNGKey,
-    ) -> tuple[dict[str, Any], Any]:
-        """Compute local values for a single walker.
-
-        This is the main method to override.  The default
-        ``evaluate_batch`` vmaps this over the walker dimension.
-
-        Args:
-            params: Wavefunction parameters.
-            data: Data for a single walker.
-            prev_local_stats: Local values produced by earlier
-                estimators in the pipeline (single-walker).
-            state: Estimator state from ``init`` or previous step.
-            rngs: Random state.
-
-        Returns:
-            A tuple ``(local_stats, state)`` where ``local_stats``
-            maps string keys to per-walker scalar or array values.
-        """
-        return {}, state
-
+    @abstractmethod
     def evaluate_batch(
         self,
         params: Params,
@@ -156,9 +133,10 @@ class Estimator[DataT: Data]:
     ) -> tuple[dict[str, Any], Any]:
         """Compute local values over a batch of walkers.
 
-        By default, vmaps ``evaluate_local`` over the walker dimension.
-        Override directly for estimators that don't need per-walker
-        vmapping (e.g. histogram aggregation, stats-only estimators).
+        The base implementation is a no-op. Override this directly for
+        estimators that own full-batch logic (e.g. histogram aggregation,
+        stats-only estimators). Inherit from :class:`LocalEstimator` for the
+        common pattern where ``evaluate_local`` is vmapped over walkers.
 
         Args:
             params: Wavefunction parameters.
@@ -172,12 +150,6 @@ class Estimator[DataT: Data]:
             A tuple ``(local_stats, state)`` where ``local_stats``
             values have a leading walker dimension.
         """
-        rngs = jax.random.split(rngs, batched_data.batch_size)
-        return chunked_vmap(
-            self.evaluate_local,
-            in_axes=(None, batched_data.vmap_axis, 0, None, 0),
-            chunk_size=self.chunk_size,
-        )(params, batched_data.data, prev_local_stats, state, rngs)
 
     def reduce(self, local_stats: Mapping[str, Any]) -> dict[str, Any]:
         """Aggregate per-walker local values into per-step statistics.
@@ -238,7 +210,67 @@ class Estimator[DataT: Data]:
         return {}
 
 
-class FunctionEstimator(Estimator):
+@configurable_dataclass
+class LocalEstimator[DataT: Data](Estimator[DataT], ABC):
+    """Estimator whose single-walker ``evaluate_local`` is batched by vmap.
+
+    Args:
+        vmap_chunk_size: Number of walkers to evaluate per vmap chunk. Set to
+            ``None`` to evaluate the full batch at once.
+    """
+
+    vmap_chunk_size: int | None = None
+
+    @abstractmethod
+    def evaluate_local(
+        self,
+        params: Params,
+        data: DataT,
+        prev_local_stats: Mapping[str, Any],
+        state: Any,
+        rngs: PRNGKey,
+    ) -> tuple[dict[str, Any], Any]:
+        """Compute local values for a single walker.
+
+        This is the main method to override when inheriting from
+        :class:`LocalEstimator`, which vmaps it over the walker dimension.
+
+        Args:
+            params: Wavefunction parameters.
+            data: Data for a single walker.
+            prev_local_stats: Local values produced by earlier
+                estimators in the pipeline (single-walker).
+            state: Estimator state from ``init`` or previous step.
+            rngs: Random state.
+
+        Returns:
+            A tuple ``(local_stats, state)`` where ``local_stats``
+            maps string keys to per-walker scalar or array values.
+        """
+
+    def evaluate_batch(
+        self,
+        params: Params,
+        batched_data: BatchedData[DataT],
+        prev_local_stats: Mapping[str, Any],
+        state: Any,
+        rngs: PRNGKey,
+    ) -> tuple[dict[str, Any], Any]:
+        """Vmap ``evaluate_local`` over the walker dimension.
+
+        Returns:
+            A tuple ``(local_stats, state)`` where ``local_stats`` values have
+            a leading walker dimension.
+        """
+        rngs = jax.random.split(rngs, batched_data.batch_size)
+        return chunked_vmap(
+            self.evaluate_local,
+            in_axes=(None, batched_data.vmap_axis, 0, None, 0),
+            chunk_size=self.vmap_chunk_size,
+        )(params, batched_data.data, prev_local_stats, state, rngs)
+
+
+class FunctionEstimator(LocalEstimator):
     """Wraps a plain function as an :class:`Estimator`.
 
     The function is called as ``evaluate_local``; ``init``, ``reduce``,

--- a/src/jaqmc/estimator/base.py
+++ b/src/jaqmc/estimator/base.py
@@ -10,6 +10,7 @@ from jax import numpy as jnp
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import BatchedData, Data
 from jaqmc.utils import parallel_jax
+from jaqmc.utils.chunked_vmap import chunked_vmap
 from jaqmc.utils.config import configurable_dataclass
 
 type EstimateFn = Callable[
@@ -105,6 +106,8 @@ class Estimator[DataT: Data]:
         DataT: Concrete one-walker ``Data`` subtype consumed by this estimator.
     """
 
+    chunk_size: int | None = None
+
     def init(self, data: DataT, rngs: PRNGKey) -> Any:
         """Initialize estimator state from an example data point.
 
@@ -170,9 +173,10 @@ class Estimator[DataT: Data]:
             values have a leading walker dimension.
         """
         rngs = jax.random.split(rngs, batched_data.batch_size)
-        return jax.vmap(
+        return chunked_vmap(
             self.evaluate_local,
             in_axes=(None, batched_data.vmap_axis, 0, None, 0),
+            chunk_size=self.chunk_size,
         )(params, batched_data.data, prev_local_stats, state, rngs)
 
     def reduce(self, local_stats: Mapping[str, Any]) -> dict[str, Any]:

--- a/src/jaqmc/estimator/base.py
+++ b/src/jaqmc/estimator/base.py
@@ -18,35 +18,35 @@ type EstimateFn = Callable[
     [Params, Data, Mapping[str, Any], Any, PRNGKey],
     tuple[dict[str, Any], Any],
 ]
-"""Signature for a plain function usable as an estimator's ``evaluate_local``."""
+"""Signature for a plain function usable as ``evaluate_single_walker``."""
 
 type EstimatorLike = Estimator | EstimateFn
 """Anything accepted where an :class:`Estimator` is expected."""
 
 
 def mean_reduce(
-    local_stats: Mapping[str, Any], include_variance: bool = True
+    walker_stats: Mapping[str, Any], include_variance: bool = True
 ) -> dict[str, Any]:
-    """Reduce per-walker local values to step-level mean (and variance).
+    """Reduce per-walker values to step-level mean (and variance).
 
     Computes the mean over walkers and across devices.  When
     ``include_variance`` is True, appends ``{key}_var`` entries with
     the corresponding variance.
 
     Args:
-        local_stats: Per-walker values (leading walker dimension).
+        walker_stats: Per-walker values (leading walker dimension).
         include_variance: Whether to include ``_var`` keys.
 
     Returns:
         Step-level statistics (walker dimension consumed).
     """
     stats = parallel_jax.pmean(
-        jax.tree.map(lambda x: jnp.nanmean(x, axis=0), local_stats)
+        jax.tree.map(lambda x: jnp.nanmean(x, axis=0), walker_stats)
     )
     if include_variance:
         var_stats = jax.tree.map(
             lambda x, mean_x: parallel_jax.pmean(jnp.nanmean(x**2, axis=0)) - mean_x**2,
-            local_stats,
+            walker_stats,
             stats,
         )
         stats.update({f"{k}_var": v for k, v in var_stats.items()})
@@ -62,11 +62,11 @@ class Estimator[DataT: Data](ABC):
 
     **Stats path** (per-step statistics → final values):
 
-    1. **evaluate** (``evaluate_local`` / ``evaluate_batch``) — compute
-       per-walker local values.  For example, a kinetic energy estimator
+    1. **evaluate** (``evaluate_single_walker`` / ``evaluate_batch_walkers``)
+       — compute per-walker values. For example, a kinetic energy estimator
        returns one energy scalar per walker.
 
-    2. **reduce** — aggregate local values across walkers into per-step
+    2. **reduce** — aggregate per-walker values across walkers into per-step
        statistics.  The default computes mean and variance over walkers
        (via ``mean_reduce``).  The output is what gets written to disk
        at each step.
@@ -87,10 +87,10 @@ class Estimator[DataT: Data](ABC):
        JIT.
 
     Subclass and override only the methods you need. Most estimators should
-    inherit from :class:`LocalEstimator`, which batches single-walker
-    ``evaluate_local`` implementations automatically. Inherit directly from
+    inherit from :class:`PerWalkerEstimator`, which batches single-walker
+    ``evaluate_single_walker`` implementations automatically. Inherit directly from
     this class when the estimator owns full-batch logic through
-    ``evaluate_batch``.
+    ``evaluate_batch_walkers``.
 
     Runtime dependencies should be declared as
     :func:`~jaqmc.utils.wiring.runtime_dep` fields.
@@ -114,60 +114,60 @@ class Estimator[DataT: Data](ABC):
     def init(self, data: DataT, rngs: PRNGKey) -> Any:
         """Initialize estimator state from an example data point.
 
-        Called once before the first ``evaluate`` call.
+        Called once before the first ``evaluate_batch_walkers`` call.
 
         Returns:
-            State to thread through evaluate calls, or ``None``
+            State to thread through evaluation calls, or ``None``
             if no state is needed.
         """
         return None
 
     @abstractmethod
-    def evaluate_batch(
+    def evaluate_batch_walkers(
         self,
         params: Params,
         batched_data: BatchedData[DataT],
-        prev_local_stats: Mapping[str, Any],
+        prev_walker_stats: Mapping[str, Any],
         state: Any,
         rngs: PRNGKey,
     ) -> tuple[dict[str, Any], Any]:
-        """Compute local values over a batch of walkers.
+        """Compute per-walker values over a batch of walkers.
 
         The base implementation is a no-op. Override this directly for
         estimators that own full-batch logic (e.g. histogram aggregation,
-        stats-only estimators). Inherit from :class:`LocalEstimator` for the
-        common pattern where ``evaluate_local`` is vmapped over walkers.
+        stats-only estimators). Inherit from :class:`PerWalkerEstimator` for the
+        common pattern where ``evaluate_single_walker`` is vmapped over walkers.
 
         Args:
             params: Wavefunction parameters.
             batched_data: Batched sampled data.
-            prev_local_stats: Local values produced by earlier
+            prev_walker_stats: Per-walker values produced by earlier
                 estimators in the pipeline (with walker dimension).
             state: Estimator state.
             rngs: Random state.
 
         Returns:
-            A tuple ``(local_stats, state)`` where ``local_stats``
+            A tuple ``(walker_stats, state)`` where ``walker_stats``
             values have a leading walker dimension.
         """
 
-    def reduce(self, local_stats: Mapping[str, Any]) -> dict[str, Any]:
-        """Aggregate per-walker local values into per-step statistics.
+    def reduce(self, walker_stats: Mapping[str, Any]) -> dict[str, Any]:
+        """Aggregate per-walker values into per-step statistics.
 
-        Called once per step after ``evaluate_batch``.  The output is
+        Called once per step after ``evaluate_batch_walkers``. The output is
         what gets recorded by writers at each step.
 
         The default computes the mean (and variance) over walkers via
         ``mean_reduce``.
 
         Args:
-            local_stats: This estimator's output from
-                ``evaluate_batch`` (values have a walker dimension).
+            walker_stats: This estimator's output from
+                ``evaluate_batch_walkers`` (values have a walker dimension).
 
         Returns:
             Step-level statistics (walker dimension consumed).
         """
-        return mean_reduce(local_stats)
+        return mean_reduce(walker_stats)
 
     def finalize_stats(
         self, batched_stats: Mapping[str, Any], state: Any
@@ -211,8 +211,8 @@ class Estimator[DataT: Data](ABC):
 
 
 @configurable_dataclass
-class LocalEstimator[DataT: Data](Estimator[DataT], ABC):
-    """Estimator whose single-walker ``evaluate_local`` is batched by vmap.
+class PerWalkerEstimator[DataT: Data](Estimator[DataT], ABC):
+    """Estimator whose ``evaluate_single_walker`` is batched over walkers by vmap.
 
     Args:
         vmap_chunk_size: Number of walkers to evaluate per vmap chunk. Set to
@@ -222,73 +222,73 @@ class LocalEstimator[DataT: Data](Estimator[DataT], ABC):
     vmap_chunk_size: int | None = None
 
     @abstractmethod
-    def evaluate_local(
+    def evaluate_single_walker(
         self,
         params: Params,
         data: DataT,
-        prev_local_stats: Mapping[str, Any],
+        prev_walker_stats: Mapping[str, Any],
         state: Any,
         rngs: PRNGKey,
     ) -> tuple[dict[str, Any], Any]:
-        """Compute local values for a single walker.
+        """Compute per-walker values for a single walker.
 
         This is the main method to override when inheriting from
-        :class:`LocalEstimator`, which vmaps it over the walker dimension.
+        :class:`PerWalkerEstimator`, which vmaps it over the walker dimension.
 
         Args:
             params: Wavefunction parameters.
             data: Data for a single walker.
-            prev_local_stats: Local values produced by earlier
+            prev_walker_stats: Per-walker values produced by earlier
                 estimators in the pipeline (single-walker).
             state: Estimator state from ``init`` or previous step.
             rngs: Random state.
 
         Returns:
-            A tuple ``(local_stats, state)`` where ``local_stats``
+            A tuple ``(walker_stats, state)`` where ``walker_stats``
             maps string keys to per-walker scalar or array values.
         """
 
-    def evaluate_batch(
+    def evaluate_batch_walkers(
         self,
         params: Params,
         batched_data: BatchedData[DataT],
-        prev_local_stats: Mapping[str, Any],
+        prev_walker_stats: Mapping[str, Any],
         state: Any,
         rngs: PRNGKey,
     ) -> tuple[dict[str, Any], Any]:
-        """Vmap ``evaluate_local`` over the walker dimension.
+        """Vmap ``evaluate_single_walker`` over the walker dimension.
 
         Returns:
-            A tuple ``(local_stats, state)`` where ``local_stats`` values have
+            A tuple ``(walker_stats, state)`` where ``walker_stats`` values have
             a leading walker dimension.
         """
         rngs = jax.random.split(rngs, batched_data.batch_size)
         return chunked_vmap(
-            self.evaluate_local,
+            self.evaluate_single_walker,
             in_axes=(None, batched_data.vmap_axis, 0, None, 0),
             chunk_size=self.vmap_chunk_size,
-        )(params, batched_data.data, prev_local_stats, state, rngs)
+        )(params, batched_data.data, prev_walker_stats, state, rngs)
 
 
-class FunctionEstimator(LocalEstimator):
+class FunctionEstimator(PerWalkerEstimator):
     """Wraps a plain function as an :class:`Estimator`.
 
-    The function is called as ``evaluate_local``; ``init``, ``reduce``,
+    The function is called as ``evaluate_single_walker``; ``init``, ``reduce``,
     ``finalize_stats``, and ``finalize_state`` use the base-class defaults.
     """
 
     def __init__(self, fn: EstimateFn) -> None:
         self._fn = fn
 
-    def evaluate_local(self, params, data, prev_local_stats, state, rngs):
-        return self._fn(params, data, prev_local_stats, state, rngs)
+    def evaluate_single_walker(self, params, data, prev_walker_stats, state, rngs):
+        return self._fn(params, data, prev_walker_stats, state, rngs)
 
 
 class EstimatorPipeline:
     """Chains named estimators into an evaluate → reduce → finalize pipeline.
 
     Each estimator runs in insertion order. Later estimators can read
-    earlier estimators' local values via ``prev_local_stats``.
+    earlier estimators' per-walker values via ``prev_walker_stats``.
     Key ownership is tracked so that :meth:`finalize_stats` dispatches each
     subset of statistics to the correct estimator.
 
@@ -335,7 +335,7 @@ class EstimatorPipeline:
         state: dict[str, Any],
         rngs: PRNGKey,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
-        """Compute averaged local values of the observables.
+        """Compute averaged per-walker values of the observables.
 
         Args:
             params: Wavefunction parameters.
@@ -347,14 +347,14 @@ class EstimatorPipeline:
             A tuple ``(step_stats, state)``, where ``step_stats`` is a flat
             dictionary merging each estimator's :meth:`~Estimator.reduce` output.
         """
-        local_stats: dict[str, Any] = {}
+        walker_stats: dict[str, Any] = {}
         step_stats: dict[str, Any] = {}
         for name, estimator in self.estimators.items():
             rngs, sub_rngs = jax.random.split(rngs)
-            stats_parts, state[name] = estimator.evaluate_batch(
-                params, batched_data, local_stats, state[name], sub_rngs
+            stats_parts, state[name] = estimator.evaluate_batch_walkers(
+                params, batched_data, walker_stats, state[name], sub_rngs
             )
-            local_stats.update(stats_parts)
+            walker_stats.update(stats_parts)
             reduced = estimator.reduce(stats_parts)
             self._reduce_keys[name] = frozenset(reduced.keys())
             step_stats.update(reduced)

--- a/src/jaqmc/estimator/ecp/estimator.py
+++ b/src/jaqmc/estimator/ecp/estimator.py
@@ -19,7 +19,7 @@ from jax import numpy as jnp
 
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import Data
-from jaqmc.estimator.base import Estimator
+from jaqmc.estimator.base import LocalEstimator
 from jaqmc.geometry.pbc import build_distance_fn
 from jaqmc.utils.config import configurable_dataclass
 from jaqmc.utils.wiring import runtime_dep
@@ -30,7 +30,7 @@ from .quadrature import get_quadrature
 
 
 @configurable_dataclass
-class ECPEnergy(Estimator):
+class ECPEnergy(LocalEstimator):
     r"""ECP energy estimator.
 
     Computes both local and nonlocal effective core potential contributions.

--- a/src/jaqmc/estimator/ecp/estimator.py
+++ b/src/jaqmc/estimator/ecp/estimator.py
@@ -19,7 +19,7 @@ from jax import numpy as jnp
 
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import Data
-from jaqmc.estimator.base import LocalEstimator
+from jaqmc.estimator.base import PerWalkerEstimator
 from jaqmc.geometry.pbc import build_distance_fn
 from jaqmc.utils.config import configurable_dataclass
 from jaqmc.utils.wiring import runtime_dep
@@ -30,7 +30,7 @@ from .quadrature import get_quadrature
 
 
 @configurable_dataclass
-class ECPEnergy(LocalEstimator):
+class ECPEnergy(PerWalkerEstimator):
     r"""ECP energy estimator.
 
     Computes both local and nonlocal effective core potential contributions.
@@ -113,15 +113,15 @@ class ECPEnergy(LocalEstimator):
         )
         return None
 
-    def evaluate_local(
+    def evaluate_single_walker(
         self,
         params: Params,
         data: Data,
-        prev_local_stats: Mapping[str, Any],
+        prev_walker_stats: Mapping[str, Any],
         state: None,
         rngs: PRNGKey,
     ) -> tuple[dict[str, Any], None]:
-        del prev_local_stats
+        del prev_walker_stats
 
         electrons = data[self.electrons_field]
         atoms = data[self.atoms_field]
@@ -241,7 +241,7 @@ class ECPRadial:
         #
         # PySCF uses l=-1 for the local channel and l=0,1,2,... for
         # semi-local channels.  We map l → channel_idx = l + 1 so that
-        # channel 0 is always the local potential (used by evaluate_local
+        # channel 0 is always the local potential (used by evaluate_single_walker
         # as `radial_values[..., 0]`) and channels 1+ are nonlocal.
         for i, atom_idx in enumerate(ecp_atom_indices):
             sym = atom_symbols[atom_idx]

--- a/src/jaqmc/estimator/histogram.py
+++ b/src/jaqmc/estimator/histogram.py
@@ -87,15 +87,15 @@ class HistogramEstimator(Estimator):
             "compensation": jnp.zeros((n, *shape)),
         }
 
-    def evaluate_batch(
+    def evaluate_batch_walkers(
         self,
         params: Params,
         batched_data: BatchedData,
-        prev_local_stats: Mapping[str, Any],
+        prev_walker_stats: Mapping[str, Any],
         state: dict[str, jnp.ndarray],
         rngs: PRNGKey,
     ) -> tuple[dict[str, Any], dict[str, jnp.ndarray]]:
-        del params, prev_local_stats, rngs
+        del params, prev_walker_stats, rngs
         bins, ranges = self._histogram_spec()
         values = self.extract(batched_data.data)
         ndim = len(ranges)
@@ -108,7 +108,8 @@ class HistogramEstimator(Estimator):
         new_comp = (new_sum - state["histogram"]) - adjusted
         return {}, {"histogram": new_sum, "compensation": new_comp}
 
-    def reduce(self, local_stats: Mapping[str, Any]) -> dict[str, Any]:
+    def reduce(self, walker_stats: Mapping[str, Any]) -> dict[str, Any]:
+        del walker_stats
         return {}
 
     def finalize_stats(

--- a/src/jaqmc/estimator/kinetic/euclidean.py
+++ b/src/jaqmc/estimator/kinetic/euclidean.py
@@ -11,7 +11,7 @@ from jax import numpy as jnp
 
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import Data
-from jaqmc.estimator.base import Estimator
+from jaqmc.estimator.base import LocalEstimator
 from jaqmc.utils import parallel_jax
 from jaqmc.utils.config import configurable_dataclass
 from jaqmc.utils.func_transform import (
@@ -26,7 +26,7 @@ from ._common import LaplacianMode, _apply_kinetic_formula, _flatten_positions
 
 
 @configurable_dataclass
-class EuclideanKinetic(Estimator):
+class EuclideanKinetic(LocalEstimator):
     """Kinetic energy estimator in Euclidean geometry.
 
     The most computationally expensive default energy component. The

--- a/src/jaqmc/estimator/kinetic/euclidean.py
+++ b/src/jaqmc/estimator/kinetic/euclidean.py
@@ -11,7 +11,7 @@ from jax import numpy as jnp
 
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import Data
-from jaqmc.estimator.base import LocalEstimator
+from jaqmc.estimator.base import PerWalkerEstimator
 from jaqmc.utils import parallel_jax
 from jaqmc.utils.config import configurable_dataclass
 from jaqmc.utils.func_transform import (
@@ -26,7 +26,7 @@ from ._common import LaplacianMode, _apply_kinetic_formula, _flatten_positions
 
 
 @configurable_dataclass
-class EuclideanKinetic(LocalEstimator):
+class EuclideanKinetic(PerWalkerEstimator):
     """Kinetic energy estimator in Euclidean geometry.
 
     The most computationally expensive default energy component. The
@@ -68,15 +68,15 @@ class EuclideanKinetic(LocalEstimator):
                 "Sparsity threshold is only supported in forward_laplacian mode."
             )
 
-    def evaluate_local(
+    def evaluate_single_walker(
         self,
         params: Params,
         data: Data,
-        prev_local_stats: Mapping[str, Any],
+        prev_walker_stats: Mapping[str, Any],
         state: None,
         rngs: PRNGKey,
     ) -> tuple[dict[str, Any], None]:
-        del prev_local_stats, rngs
+        del prev_walker_stats, rngs
         if self.mode == LaplacianMode.forward_laplacian:
             return self._evaluate_forward_laplacian(params, data, state)
         return self._evaluate_standard(params, data, state)

--- a/src/jaqmc/estimator/kinetic/spherical.py
+++ b/src/jaqmc/estimator/kinetic/spherical.py
@@ -18,7 +18,7 @@ from jax.numpy import cos, sin, tan
 
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import Data
-from jaqmc.estimator.base import Estimator
+from jaqmc.estimator.base import LocalEstimator
 from jaqmc.utils.config import configurable_dataclass
 from jaqmc.utils.func_transform import with_imag, with_real
 from jaqmc.utils.wiring import runtime_dep
@@ -109,7 +109,7 @@ def _angular_momentum_square(f, Q: float):
 
 
 @configurable_dataclass
-class SphericalKinetic(Estimator):
+class SphericalKinetic(LocalEstimator):
     r"""Kinetic energy on a sphere with magnetic monopole.
 
     Uses the Hessian-based calculation following the formulas in

--- a/src/jaqmc/estimator/kinetic/spherical.py
+++ b/src/jaqmc/estimator/kinetic/spherical.py
@@ -18,7 +18,7 @@ from jax.numpy import cos, sin, tan
 
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import Data
-from jaqmc.estimator.base import LocalEstimator
+from jaqmc.estimator.base import PerWalkerEstimator
 from jaqmc.utils.config import configurable_dataclass
 from jaqmc.utils.func_transform import with_imag, with_real
 from jaqmc.utils.wiring import runtime_dep
@@ -109,7 +109,7 @@ def _angular_momentum_square(f, Q: float):
 
 
 @configurable_dataclass
-class SphericalKinetic(LocalEstimator):
+class SphericalKinetic(PerWalkerEstimator):
     r"""Kinetic energy on a sphere with magnetic monopole.
 
     Uses the Hessian-based calculation following the formulas in
@@ -142,15 +142,15 @@ class SphericalKinetic(LocalEstimator):
     f_log_psi: NumericWavefunctionEvaluate = runtime_dep()
     data_field: str = runtime_dep(default="electrons")
 
-    def evaluate_local(
+    def evaluate_single_walker(
         self,
         params: Params,
         data: Data,
-        prev_local_stats: Mapping[str, Any],
+        prev_walker_stats: Mapping[str, Any],
         state: None,
         rngs: PRNGKey,
     ) -> tuple[dict[str, Any], None]:
-        del prev_local_stats, rngs
+        del prev_walker_stats, rngs
         if self.mode == LaplacianMode.forward_laplacian:
             return self._evaluate_forward_laplacian(params, data, state)
         return self._evaluate_hessian(params, data, state)

--- a/src/jaqmc/estimator/loss_grad.py
+++ b/src/jaqmc/estimator/loss_grad.py
@@ -11,7 +11,7 @@ from jax import numpy as jnp
 
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import Data
-from jaqmc.estimator.base import Estimator, mean_reduce
+from jaqmc.estimator.base import LocalEstimator, mean_reduce
 from jaqmc.utils import parallel_jax
 from jaqmc.utils.array import match_first_axis_of
 from jaqmc.utils.clip import iqr_clip
@@ -22,7 +22,7 @@ from jaqmc.wavefunction.base import NumericWavefunctionEvaluate
 
 
 @configurable_dataclass
-class LossAndGrad(Estimator):
+class LossAndGrad(LocalEstimator):
     r"""Estimator that computes the VMC loss and parameter gradients.
 
     The gradient of the variational energy with respect to wavefunction

--- a/src/jaqmc/estimator/loss_grad.py
+++ b/src/jaqmc/estimator/loss_grad.py
@@ -11,7 +11,7 @@ from jax import numpy as jnp
 
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import Data
-from jaqmc.estimator.base import LocalEstimator, mean_reduce
+from jaqmc.estimator.base import PerWalkerEstimator, mean_reduce
 from jaqmc.utils import parallel_jax
 from jaqmc.utils.array import match_first_axis_of
 from jaqmc.utils.clip import iqr_clip
@@ -22,7 +22,7 @@ from jaqmc.wavefunction.base import NumericWavefunctionEvaluate
 
 
 @configurable_dataclass
-class LossAndGrad(LocalEstimator):
+class LossAndGrad(PerWalkerEstimator):
     r"""Estimator that computes the VMC loss and parameter gradients.
 
     The gradient of the variational energy with respect to wavefunction
@@ -39,7 +39,7 @@ class LossAndGrad(LocalEstimator):
     The computation proceeds in three stages across the estimator
     lifecycle:
 
-    1. ``evaluate_local`` — evaluates :math:`\log\psi` and its
+    1. ``evaluate_single_walker`` — evaluates :math:`\log\psi` and its
        parameter gradient for each walker, and reads the loss value.
     2. ``reduce`` — applies IQR clipping to the local energies for
        outlier robustness, then forms the per-walker product
@@ -48,7 +48,7 @@ class LossAndGrad(LocalEstimator):
        to assemble the final gradient.
 
     Args:
-        loss_key: Key in prev_local_stats to use as the loss.
+        loss_key: Key in prev_walker_stats to use as the loss.
         clip_scale: Multiplier on the interquartile range (IQR) that sets
             the clipping window for local energies. A walker whose energy
             falls outside :math:`[Q_1 - s \cdot \text{IQR},\;
@@ -64,11 +64,11 @@ class LossAndGrad(LocalEstimator):
     clip_scale: float = 5.0
     f_log_psi: NumericWavefunctionEvaluate = runtime_dep()
 
-    def evaluate_local(
+    def evaluate_single_walker(
         self,
         params: Params,
         data: Data,
-        prev_local_stats: Mapping[str, Any],
+        prev_walker_stats: Mapping[str, Any],
         state: None,
         rngs: PRNGKey,
     ) -> tuple[dict[str, Any], None]:
@@ -78,30 +78,30 @@ class LossAndGrad(LocalEstimator):
         # Without this, JAX assumes grads share params' non-varying sharding,
         # which confuses the compiler (known bug in JAX 0.8.1).
         primals, grads = value_and_grad_f(parallel_jax.pvary(params), data)
-        if not jnp.isscalar(prev_local_stats[self.loss_key]):
+        if not jnp.isscalar(prev_walker_stats[self.loss_key]):
             raise ValueError(
                 "Expected scalar loss value (i.e. ndim=0), got shape "
-                f"{prev_local_stats[self.loss_key].shape}."
+                f"{prev_walker_stats[self.loss_key].shape}."
             )
         # We copy over loss stats because we need to do customized reduce
         return {
             "logpsi": primals,
             "grad_logpsi": grads,
-            "loss": prev_local_stats[self.loss_key],
+            "loss": prev_walker_stats[self.loss_key],
         }, state
 
-    def reduce(self, local_stats: Mapping[str, Any]) -> dict[str, Any]:
-        clipped_loss = iqr_clip(local_stats["loss"], scale=self.clip_scale)
+    def reduce(self, walker_stats: Mapping[str, Any]) -> dict[str, Any]:
+        clipped_loss = iqr_clip(walker_stats["loss"], scale=self.clip_scale)
         grad_logpsi_and_loss = jax.tree.map(
             lambda x: jnp.real(jnp.conj(x) * match_first_axis_of(clipped_loss, x)),
-            local_stats["grad_logpsi"],
+            walker_stats["grad_logpsi"],
         )
         return mean_reduce(
             {
                 "grad_logpsi_and_loss": grad_logpsi_and_loss,
-                "loss": local_stats["loss"],
+                "loss": walker_stats["loss"],
                 "clipped_loss": clipped_loss,
-                "grad_logpsi": local_stats["grad_logpsi"],
+                "grad_logpsi": walker_stats["grad_logpsi"],
             }
         )
 

--- a/src/jaqmc/estimator/spin.py
+++ b/src/jaqmc/estimator/spin.py
@@ -18,13 +18,13 @@ from jax import numpy as jnp
 
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import Data
-from jaqmc.estimator.base import Estimator
+from jaqmc.estimator.base import LocalEstimator
 from jaqmc.utils.config import configurable_dataclass
 from jaqmc.utils.wiring import runtime_dep
 
 
 @configurable_dataclass
-class SpinSquared(Estimator):
+class SpinSquared(LocalEstimator):
     r"""Estimator for the total spin operator :math:`S^2`.
 
     Computes the local value of :math:`S^2` for a single walker using

--- a/src/jaqmc/estimator/spin.py
+++ b/src/jaqmc/estimator/spin.py
@@ -18,13 +18,13 @@ from jax import numpy as jnp
 
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import Data
-from jaqmc.estimator.base import LocalEstimator
+from jaqmc.estimator.base import PerWalkerEstimator
 from jaqmc.utils.config import configurable_dataclass
 from jaqmc.utils.wiring import runtime_dep
 
 
 @configurable_dataclass
-class SpinSquared(LocalEstimator):
+class SpinSquared(PerWalkerEstimator):
     r"""Estimator for the total spin operator :math:`S^2`.
 
     Computes the local value of :math:`S^2` for a single walker using
@@ -69,15 +69,15 @@ class SpinSquared(LocalEstimator):
         self._vmapped_phase_logpsi = jax.vmap(self.phase_logpsi, in_axes=(None, 0))
         return None
 
-    def evaluate_local(
+    def evaluate_single_walker(
         self,
         params: Params,
         data: Data,
-        prev_local_stats: Mapping[str, Any],
+        prev_walker_stats: Mapping[str, Any],
         state: None,
         rngs: PRNGKey,
     ) -> tuple[dict[str, Any], None]:
-        del prev_local_stats, rngs
+        del prev_walker_stats, rngs
         s2 = self._sz * (self._sz + 1) + self._sum_wf_ratios(params, data)
         return {"spin:s2": s2}, state
 

--- a/src/jaqmc/estimator/total_energy.py
+++ b/src/jaqmc/estimator/total_energy.py
@@ -8,12 +8,12 @@ from jax import numpy as jnp
 
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import Data
-from jaqmc.estimator.base import Estimator, mean_reduce
+from jaqmc.estimator.base import LocalEstimator, mean_reduce
 from jaqmc.utils.config import configurable_dataclass
 
 
 @configurable_dataclass
-class TotalEnergy(Estimator):
+class TotalEnergy(LocalEstimator):
     """Estimator that computes total energy from component energies.
 
     Energy components use the ``energy:`` prefix convention (e.g.

--- a/src/jaqmc/estimator/total_energy.py
+++ b/src/jaqmc/estimator/total_energy.py
@@ -8,12 +8,12 @@ from jax import numpy as jnp
 
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import Data
-from jaqmc.estimator.base import LocalEstimator, mean_reduce
+from jaqmc.estimator.base import PerWalkerEstimator, mean_reduce
 from jaqmc.utils.config import configurable_dataclass
 
 
 @configurable_dataclass
-class TotalEnergy(LocalEstimator):
+class TotalEnergy(PerWalkerEstimator):
     """Estimator that computes total energy from component energies.
 
     Energy components use the ``energy:`` prefix convention (e.g.
@@ -27,17 +27,17 @@ class TotalEnergy(LocalEstimator):
     Args:
         output_name: Name of the output total energy field.
         components: Stat keys to sum. When None (default), auto-derives
-            from ``prev_local_stats`` keys starting with ``energy:``.
+            from ``prev_walker_stats`` keys starting with ``energy:``.
     """
 
     output_name: str = "total_energy"
     components: list[str] | None = None
 
-    def evaluate_local(
+    def evaluate_single_walker(
         self,
         params: Params,
         data: Data,
-        prev_local_stats: Mapping[str, Any],
+        prev_walker_stats: Mapping[str, Any],
         state: None,
         rngs: PRNGKey,
     ) -> tuple[dict[str, Any], None]:
@@ -45,26 +45,26 @@ class TotalEnergy(LocalEstimator):
         keys = (
             self.components
             if self.components is not None
-            else [k for k in prev_local_stats if k.startswith("energy:")]
+            else [k for k in prev_walker_stats if k.startswith("energy:")]
         )
         total = 0
         for name in keys:
-            if not jnp.isscalar(energy_part := prev_local_stats[name]):
+            if not jnp.isscalar(energy_part := prev_walker_stats[name]):
                 raise ValueError(
                     f"Expected {name} to be a scalar, but got shape "
                     f"{energy_part.shape}. If you're using a custom kinetic "
-                    "energy estimator, make sure evaluate_local returns a "
+                    "energy estimator, make sure evaluate_single_walker returns a "
                     "scalar per walker."
                 )
             total += energy_part
         return {self.output_name: total}, state
 
-    def reduce(self, local_stats: Mapping[str, Any]) -> dict[str, Any]:
+    def reduce(self, walker_stats: Mapping[str, Any]) -> dict[str, Any]:
         key = self.output_name
-        energy = local_stats[key]
+        energy = walker_stats[key]
         if jnp.iscomplexobj(energy):
             return {
-                **mean_reduce(local_stats, include_variance=False),
+                **mean_reduce(walker_stats, include_variance=False),
                 **mean_reduce({f"{key}_real": energy.real}),
             }
-        return mean_reduce(local_stats)
+        return mean_reduce(walker_stats)

--- a/src/jaqmc/optimizer/sr/jasr.py
+++ b/src/jaqmc/optimizer/sr/jasr.py
@@ -16,6 +16,8 @@ from jax import scipy as jsp
 from jax.flatten_util import ravel_pytree
 from optax import tree_utils as otu
 
+from jaqmc.utils.chunked_vmap import chunked_vmap
+
 try:
     from jax import enable_x64 as _enable_x64
 except ImportError:
@@ -1043,24 +1045,6 @@ class PAxis:
             return 1
 
 
-def chunked_vmap(
-    fun,
-    in_axes: int | Sequence[Any] = 0,
-    out_axes: Any = 0,
-    chunk_size: int | None = None,
-):
-    """Chunked vmap implemented via ``lax.scan``.
-
-    Returns:
-        A wrapped function with the same signature as ``fun``.
-    """
-
-    def wrapped(*args):
-        return _chunked_vmap_wrapped(fun, in_axes, out_axes, chunk_size, *args)
-
-    return wrapped
-
-
 def tree_broadcast(prefix_tree, full_tree, **kw):
     # use jax.tree.broadcast if available
     if hasattr(jax.tree, "broadcast"):
@@ -1070,89 +1054,6 @@ def tree_broadcast(prefix_tree, full_tree, **kw):
         return jax.tree.map(lambda _: prefix_tree, full_tree)
     # otherwise, return prefix_tree as is
     return prefix_tree
-
-
-def _none_is_leaf(x):
-    return x is None
-
-
-def _mapped_axis_sizes(args, full_in_axes):
-    return jax.tree.leaves(
-        jax.tree.map(
-            lambda x, ax: x.shape[ax] if ax is not None else None,
-            args,
-            full_in_axes,
-            is_leaf=_none_is_leaf,
-        )
-    )
-
-
-def _validate_batch_sizes(axes_sizes):
-    if not axes_sizes:
-        raise ValueError("chunked_vmap requires at least one mapped axis")
-    total_size = axes_sizes[0]
-    for size in axes_sizes[1:]:
-        if size != total_size:
-            raise ValueError("Inconsistent batch sizes")
-    return total_size
-
-
-def _take_chunk_from_args(args, full_in_axes, start, size):
-    return jax.tree.map(
-        lambda x, ax: (
-            lax.dynamic_slice_in_dim(x, start, size, ax) if ax is not None else x
-        ),
-        args,
-        full_in_axes,
-        is_leaf=_none_is_leaf,
-    )
-
-
-def _reorg_chunked_output(scan, rem, ax, *, num_chunks, chunk_size):
-    if ax is None:
-        return scan[0]
-    scan = scan.reshape(num_chunks * chunk_size, *scan.shape[2:])
-    full = jnp.concatenate([scan, rem], axis=0)
-    return jnp.moveaxis(full, 0, ax)
-
-
-def _chunked_vmap_wrapped(fun, in_axes, out_axes, chunk_size, *args):
-    full_in_axes = tree_broadcast(in_axes, args, is_leaf=_none_is_leaf)
-    zero_out_axes = jax.tree.map(lambda _: 0, out_axes)
-    vmapped_f = jax.vmap(fun, in_axes=full_in_axes, out_axes=zero_out_axes)
-
-    axes_sizes = _mapped_axis_sizes(args, full_in_axes)
-    total_size = _validate_batch_sizes(axes_sizes)
-    if chunk_size is None or chunk_size >= total_size:
-        return jax.vmap(fun, in_axes=in_axes, out_axes=out_axes)(*args)
-
-    num_chunks = total_size // chunk_size
-    remainder = total_size % chunk_size
-
-    def scan_body(_, chunk_idx):
-        start = chunk_idx * chunk_size
-        chunk_args = _take_chunk_from_args(args, full_in_axes, start, chunk_size)
-        return None, vmapped_f(*chunk_args)
-
-    _, scan_ys = lax.scan(scan_body, None, jnp.arange(num_chunks))
-
-    start = num_chunks * chunk_size
-    rem_args = _take_chunk_from_args(args, full_in_axes, start, remainder)
-    rem_ys = vmapped_f(*rem_args)
-    full_out_axes = tree_broadcast(out_axes, rem_ys, is_leaf=_none_is_leaf)
-    return jax.tree.map(
-        lambda scan, rem, ax: _reorg_chunked_output(
-            scan,
-            rem,
-            ax,
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-        ),
-        scan_ys,
-        rem_ys,
-        full_out_axes,
-        is_leaf=_none_is_leaf,
-    )
 
 
 def take_single_sample(data, in_axes, index: int = 0):

--- a/src/jaqmc/utils/atomic/pretrain.py
+++ b/src/jaqmc/utils/atomic/pretrain.py
@@ -107,11 +107,11 @@ def make_pretrain_loss(
     def evaluate(
         params: Params,
         data: Data,
-        prev_local_stats: Mapping[str, Any],
+        prev_walker_stats: Mapping[str, Any],
         state: None,
         rngs: PRNGKey,
     ) -> tuple[dict[str, Any], None]:
-        del prev_local_stats, rngs
+        del prev_walker_stats, rngs
         # By default the sharding of grads will follow params in JAX. However, grads is
         # varying but params is not varying, and this can confuse the JAX compiler.
         # This can cause bug in JAX 0.8.1. To fix this, simply add pvary to params.

--- a/src/jaqmc/utils/chunked_vmap.py
+++ b/src/jaqmc/utils/chunked_vmap.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2025-2026 Bytedance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+from jax import lax
+from jax import numpy as jnp
+
+from jaqmc.array_types import PyTree
+
+
+def chunked_vmap(
+    fun, in_axes: PyTree = 0, out_axes: PyTree = 0, chunk_size: int | None = None
+):
+    """Return a ``vmap`` wrapper that evaluates mapped inputs in chunks.
+
+    The wrapped function is intended to match ``jax.vmap`` for the supported
+    ``in_axes``/``out_axes`` signatures while reducing peak memory use. When
+    ``chunk_size`` is ``None`` or at least the mapped batch size, this delegates
+    directly to ``jax.vmap``.
+
+    Args:
+        fun: Function to vectorize.
+        in_axes: Axis specification for mapped inputs, following ``jax.vmap``.
+            This may be a prefix tree; the implementation broadcasts it to
+            every input leaf before slicing chunk inputs. On older JAX without
+            ``jax.tree.broadcast``, nested prefix axes must already match the
+            full input tree.
+        out_axes: Axis specification for mapped outputs, following ``jax.vmap``.
+            Chunk outputs are collected by ``lax.scan`` and then restored to
+            this layout. Literal ``None`` output leaves are preserved.
+        chunk_size: Positive number of mapped inputs to evaluate per chunk. If
+            ``None``, or at least the mapped batch size, evaluation delegates
+            to plain ``jax.vmap``.
+
+    Returns:
+        A wrapped function with the same signature as ``fun``. When called, the
+        wrapper requires at least one mapped input leaf and all mapped input
+        leaves must share one batch size.
+    """
+
+    def wrapped(*args):
+        return _chunked_vmap_wrapped(fun, in_axes, out_axes, chunk_size, *args)
+
+    return wrapped
+
+
+def _chunked_vmap_wrapped(fun, in_axes, out_axes, chunk_size, *args):
+    """Evaluate ``fun`` with chunked ``vmap`` semantics.
+
+    This function expands prefix ``in_axes`` before slicing inputs, evaluates
+    full chunks through ``lax.scan``, evaluates one remainder chunk, and then
+    restores each output leaf to the user-requested ``out_axes`` layout.
+
+    Returns:
+        The output pytree produced by ``fun`` with the same mapped-axis layout
+        as ``jax.vmap(fun, in_axes=in_axes, out_axes=out_axes)(*args)``.
+    """
+    # Slicing needs a concrete axis spec for every input leaf. Public vmap
+    # accepts prefix trees, so expand that prefix form before chunking.
+    full_in_axes = _tree_broadcast(in_axes, args, is_leaf=_none_is_leaf)
+    # Mapped output leaves are produced on axis 0 inside each chunk. Leaves
+    # with out_axes=None stay unmapped, as in plain jax.vmap.
+    chunk_out_axes = jax.tree.map(lambda _: 0, out_axes)
+    vmapped_chunk = jax.vmap(fun, in_axes=full_in_axes, out_axes=chunk_out_axes)
+
+    mapped_axis_sizes = _mapped_axis_sizes(args, full_in_axes)
+    batch_size = _validate_batch_sizes(mapped_axis_sizes)
+    if chunk_size is None or chunk_size >= batch_size:
+        return jax.vmap(fun, in_axes=in_axes, out_axes=out_axes)(*args)
+
+    num_chunks = batch_size // chunk_size
+    remainder_size = batch_size % chunk_size
+
+    def scan_body(_, chunk_idx):
+        start = chunk_idx * chunk_size
+        chunk_args = _take_chunk_from_args(args, full_in_axes, start, chunk_size)
+        return None, vmapped_chunk(*chunk_args)
+
+    _, chunk_outputs = lax.scan(scan_body, None, jnp.arange(num_chunks))
+
+    # Always run the remainder path, even when remainder_size is 0. That keeps
+    # the reconstruction logic uniform and gives the output tree used to
+    # broadcast out_axes below.
+    remainder_start = num_chunks * chunk_size
+    remainder_args = _take_chunk_from_args(
+        args, full_in_axes, remainder_start, remainder_size
+    )
+    remainder_outputs = vmapped_chunk(*remainder_args)
+    full_out_axes = _tree_broadcast(out_axes, remainder_outputs, is_leaf=_none_is_leaf)
+    return jax.tree.map(
+        lambda chunked_output, remainder_output, out_axis: _restore_vmap_output_leaf(
+            chunked_output,
+            remainder_output,
+            out_axis,
+            num_chunks=num_chunks,
+            chunk_size=chunk_size,
+        ),
+        chunk_outputs,
+        remainder_outputs,
+        full_out_axes,
+        is_leaf=_none_is_leaf,
+    )
+
+
+def _none_is_leaf(x):
+    """Treat literal ``None`` as a pytree leaf.
+
+    This lets axis broadcasting and output reconstruction preserve ``None`` as
+    data instead of treating it as an empty pytree.
+
+    Returns:
+        ``True`` when ``x`` is ``None``.
+    """
+    return x is None
+
+
+def _mapped_axis_sizes(args, full_in_axes):
+    """Return the batch size of each mapped input leaf.
+
+    Unmapped leaves produce ``None`` before the final flattening step. Since
+    JAX treats ``None`` as an empty pytree by default, those placeholders drop
+    out of the returned list, leaving only mapped input sizes.
+
+    Returns:
+        A list containing one batch size for each mapped input leaf.
+    """
+    # Unmapped leaves produce None here. The final jax.tree.leaves call uses
+    # JAX's default pytree treatment, where None has no leaves, so only mapped
+    # input sizes remain for validation.
+    return jax.tree.leaves(
+        jax.tree.map(
+            lambda x, ax: x.shape[ax] if ax is not None else None,
+            args,
+            full_in_axes,
+            is_leaf=_none_is_leaf,
+        )
+    )
+
+
+def _validate_batch_sizes(axes_sizes):
+    """Validate that all mapped input leaves share one batch size.
+
+    Returns:
+        The common mapped batch size.
+
+    Raises:
+        ValueError: If no input leaf is mapped or mapped leaf sizes disagree.
+    """
+    if not axes_sizes:
+        raise ValueError("chunked_vmap requires at least one mapped axis")
+    total_size = axes_sizes[0]
+    for size in axes_sizes[1:]:
+        if size != total_size:
+            raise ValueError("Inconsistent batch sizes")
+    return total_size
+
+
+def _take_chunk_from_args(args, full_in_axes, start, size):
+    """Slice mapped input leaves to one chunk.
+
+    Leaves whose axis spec is ``None`` are not mapped and are passed through
+    unchanged to every chunk.
+
+    Returns:
+        A pytree matching ``args`` where mapped leaves contain the requested
+        chunk and unmapped leaves are unchanged.
+    """
+    return jax.tree.map(
+        lambda x, ax: (
+            lax.dynamic_slice_in_dim(x, start, size, ax) if ax is not None else x
+        ),
+        args,
+        full_in_axes,
+        is_leaf=_none_is_leaf,
+    )
+
+
+def _restore_vmap_output_leaf(
+    chunked_output, remainder_output, out_axis, *, num_chunks, chunk_size
+):
+    """Restore one output leaf to the layout requested by ``out_axes``.
+
+    Full chunk outputs arrive from ``lax.scan`` with shape
+    ``[num_chunks, chunk_size, ...]`` for mapped leaves. This helper flattens
+    those scan/chunk axes, appends the remainder output, and moves the mapped
+    axis to ``out_axis``.
+
+    Returns:
+        One reconstructed output leaf.
+    """
+    # A literal None output leaf is data, not a chunked array. Plain jax.vmap
+    # preserves it, so the chunked path must preserve it too.
+    if chunked_output is None:
+        return None
+    if out_axis is None:
+        # For out_axes=None, vmapped_chunk returns an unmapped value for each
+        # full chunk, and lax.scan stacks those values over chunks. All chunks
+        # represent the same unmapped output, so return the first one just as
+        # plain jax.vmap would return a single value.
+        return chunked_output[0]
+
+    # lax.scan stacks chunk results as [num_chunks, chunk_size, ...]. Plain vmap
+    # has one mapped axis, so flatten the first two axes before applying out_axis.
+    chunked_output = chunked_output.reshape(
+        num_chunks * chunk_size, *chunked_output.shape[2:]
+    )
+    full_output = jnp.concatenate([chunked_output, remainder_output], axis=0)
+    return jnp.moveaxis(full_output, 0, out_axis)
+
+
+def _tree_broadcast(prefix_tree, full_tree, **kw):
+    """Broadcast an axes prefix tree to match a full pytree.
+
+    Modern JAX provides ``jax.tree.broadcast`` for the prefix-tree semantics
+    accepted by ``jax.vmap``. The fallback only handles scalar integer axes and
+    top-level ``None``; nested prefix trees must already match ``full_tree`` on
+    older JAX versions.
+
+    Returns:
+        ``prefix_tree`` expanded to the structure of ``full_tree`` when
+        broadcasting is available or supported by the fallback.
+    """
+    # Modern JAX supports the same prefix-tree broadcasting needed by vmap.
+    if hasattr(jax.tree, "broadcast"):
+        return jax.tree.broadcast(prefix_tree, full_tree, **kw)
+    # Older JAX fallback
+    from jax._src.tree_util import broadcast_prefix
+
+    leaves = broadcast_prefix(prefix_tree, full_tree, **kw)
+    return jax.tree.structure(full_tree).unflatten(leaves)

--- a/src/jaqmc/utils/chunked_vmap.py
+++ b/src/jaqmc/utils/chunked_vmap.py
@@ -21,13 +21,10 @@ def chunked_vmap(
     Args:
         fun: Function to vectorize.
         in_axes: Axis specification for mapped inputs, following ``jax.vmap``.
-            This may be a prefix tree; the implementation broadcasts it to
-            every input leaf before slicing chunk inputs. On older JAX without
-            ``jax.tree.broadcast``, nested prefix axes must already match the
-            full input tree.
+            This may be a prefix tree.
         out_axes: Axis specification for mapped outputs, following ``jax.vmap``.
             Chunk outputs are collected by ``lax.scan`` and then restored to
-            this layout. Literal ``None`` output leaves are preserved.
+            this layout. Literal ``None`` output leaves are preserved as is.
         chunk_size: Positive number of mapped inputs to evaluate per chunk. If
             ``None``, or at least the mapped batch size, evaluation delegates
             to plain ``jax.vmap``.
@@ -115,18 +112,21 @@ def _none_is_leaf(x):
 
 
 def _mapped_axis_sizes(args, full_in_axes):
-    """Return the batch size of each mapped input leaf.
+    """Return only mapped-axis batch sizes from ``args``.
 
-    Unmapped leaves produce ``None`` before the final flattening step. Since
-    JAX treats ``None`` as an empty pytree by default, those placeholders drop
-    out of the returned list, leaving only mapped input sizes.
+    For each input leaf, this computes ``x.shape[ax]`` when ``ax`` is mapped
+    and uses ``None`` when ``ax`` is ``None`` (unmapped). The final
+    ``jax.tree.leaves`` call drops those ``None`` placeholders by default, so
+    the returned list contains sizes for mapped leaves only.
+
+    Example:
+        Axis sizes ``[8, None, 4]`` become ``[8, 4]``.
 
     Returns:
-        A list containing one batch size for each mapped input leaf.
+        A list of mapped-axis batch sizes, one entry per mapped input leaf.
     """
-    # Unmapped leaves produce None here. The final jax.tree.leaves call uses
-    # JAX's default pytree treatment, where None has no leaves, so only mapped
-    # input sizes remain for validation.
+    # Build per-leaf mapped sizes, using None as a placeholder for unmapped
+    # leaves. jax.tree.leaves then drops None entries by default.
     return jax.tree.leaves(
         jax.tree.map(
             lambda x, ax: x.shape[ax] if ax is not None else None,

--- a/tests/app/hall/hall_test.py
+++ b/tests/app/hall/hall_test.py
@@ -43,7 +43,7 @@ def _make_lll(nelec: int, Q: int):
 
 
 def _eval_single(estimator, data):
-    return estimator.evaluate_local(None, data, {}, None, None)[0]
+    return estimator.evaluate_single_walker(None, data, {}, None, None)[0]
 
 
 class TestHallData:
@@ -166,18 +166,18 @@ class TestSpherePotential:
         )
         electrons = jnp.array([[0.0, 0.0], [jnp.pi, 0.0]])
         data = HallData(electrons=electrons)
-        stats, _ = estimator.evaluate_local(None, data, {}, None, None)
+        stats, _ = estimator.evaluate_single_walker(None, data, {}, None, None)
         assert jnp.allclose(stats["energy:potential"], 0.5, atol=1e-5)
 
 
 class TestPenalizedLoss:
-    """PenalizedLoss: pure arithmetic on prev_local_stats."""
+    """PenalizedLoss: pure arithmetic on prev_walker_stats."""
 
     def test_no_penalty(self):
         """With zero penalties, loss == total_energy."""
         est = PenalizedLoss(lz_penalty=0.0, l2_penalty=0.0)
         stats = {"total_energy": 5.0}
-        out, _ = est.evaluate_local(None, None, stats, None, None)
+        out, _ = est.evaluate_single_walker(None, None, stats, None, None)
         np.testing.assert_allclose(out["penalized_loss"], 5.0)
 
     def test_lz_penalty_only(self):
@@ -189,7 +189,7 @@ class TestPenalizedLoss:
             "angular_momentum_z_square": 9.0,
         }
         # penalty = 2.0 * (9 - 2*1*3 + 1^2) = 2.0 * 4 = 8
-        out, _ = est.evaluate_local(None, None, stats, None, None)
+        out, _ = est.evaluate_single_walker(None, None, stats, None, None)
         np.testing.assert_allclose(out["penalized_loss"], 18.0)
 
     def test_both_penalties(self):
@@ -201,7 +201,7 @@ class TestPenalizedLoss:
             "angular_momentum_z_square": 4.0,
             "angular_momentum_square": 6.0,
         }
-        out, _ = est.evaluate_local(None, None, stats, None, None)
+        out, _ = est.evaluate_single_walker(None, None, stats, None, None)
         # energy(1) + lz_penalty(4) + l2_penalty(3) = 8
         np.testing.assert_allclose(out["penalized_loss"], 8.0)
 

--- a/tests/app/hall/one_rdm_test.py
+++ b/tests/app/hall/one_rdm_test.py
@@ -71,9 +71,9 @@ class TestMonopoleHarmonics:
         assert jnp.allclose(Y_000(coords), expected, atol=1e-6)
 
 
-class TestOneRDMEvaluateLocal:
+class TestOneRDMEvaluateSingleWalker:
     def test_output_shape(self):
-        """evaluate_local should return a complex (norbs, norbs) matrix."""
+        """evaluate_single_walker should return a complex (norbs, norbs) matrix."""
         flux = 2
         nelec = 3
         log_psi = _make_lll(nelec, Q=flux / 2)
@@ -82,14 +82,16 @@ class TestOneRDMEvaluateLocal:
         data = HallData(electrons=_sample(jax.random.PRNGKey(0), 1, nelec)[0])
         estimator.init(data, jax.random.PRNGKey(1))
 
-        stats, _ = estimator.evaluate_local(None, data, {}, None, jax.random.PRNGKey(2))
+        stats, _ = estimator.evaluate_single_walker(
+            None, data, {}, None, jax.random.PRNGKey(2)
+        )
         assert "one_rdm" in stats
         norbs = flux + 1
         assert stats["one_rdm"].shape == (norbs, norbs)
         assert jnp.iscomplexobj(stats["one_rdm"])
 
     def test_jit_compatible(self):
-        """evaluate_local should work under jax.jit."""
+        """evaluate_single_walker should work under jax.jit."""
         flux = 2
         nelec = 3
         log_psi = _make_lll(nelec, Q=flux / 2)
@@ -98,7 +100,9 @@ class TestOneRDMEvaluateLocal:
         data = HallData(electrons=_sample(jax.random.PRNGKey(0), 1, nelec)[0])
         estimator.init(data, jax.random.PRNGKey(1))
 
-        jitted = jax.jit(lambda d, k: estimator.evaluate_local(None, d, {}, None, k))
+        jitted = jax.jit(
+            lambda d, k: estimator.evaluate_single_walker(None, d, {}, None, k)
+        )
         stats, _ = jitted(data, jax.random.PRNGKey(2))
         assert stats["one_rdm"].shape == (flux + 1, flux + 1)
 
@@ -137,14 +141,14 @@ class TestOneRDMSmoke:
             key, sample_key, eval_key = jax.random.split(key, 3)
             electrons = _sample(sample_key, n_walkers, nelec)
             eval_keys = jax.random.split(eval_key, n_walkers)
-            local_stats, _ = jax.vmap(
-                lambda elec, k: estimator.evaluate_local(
+            walker_stats, _ = jax.vmap(
+                lambda elec, k: estimator.evaluate_single_walker(
                     None, HallData(electrons=elec), {}, None, k
                 ),
                 in_axes=(0, 0),
             )(electrons, eval_keys)
             # Compute mean manually (reduce needs shard_map context for pmean)
-            step_stats = jax.tree.map(lambda x: jnp.nanmean(x, axis=0), local_stats)
+            step_stats = jax.tree.map(lambda x: jnp.nanmean(x, axis=0), walker_stats)
             all_step_stats.append(step_stats)
 
         batched_stats = jax.tree.map(lambda *xs: jnp.stack(xs), *all_step_stats)
@@ -164,8 +168,8 @@ class TestOneRDMSmoke:
 
 
 class TestOneRDMPipeline:
-    def test_evaluate_batch_and_finalize_stats(self):
-        """OneRDM integrates with evaluate_batch and finalize_stats lifecycle."""
+    def test_evaluate_batch_walkers_and_finalize_stats(self):
+        """OneRDM integrates with the batched evaluator and finalize_stats."""
         flux = 2
         nelec = 3
         n_walkers = 8
@@ -181,16 +185,16 @@ class TestOneRDMPipeline:
 
         state = estimator.init(batched_data.unbatched_example(), jax.random.PRNGKey(1))
 
-        # evaluate_batch vmaps evaluate_local over walkers
-        local_stats, state = estimator.evaluate_batch(
+        # evaluate_batch_walkers vmaps evaluate_single_walker over walkers
+        walker_stats, state = estimator.evaluate_batch_walkers(
             None, batched_data, {}, state, jax.random.PRNGKey(2)
         )
 
         norbs = flux + 1
-        assert local_stats["one_rdm"].shape == (n_walkers, norbs, norbs)
+        assert walker_stats["one_rdm"].shape == (n_walkers, norbs, norbs)
 
         # Manual reduce (skip pmean which needs shard_map context)
-        step_stats = jax.tree.map(lambda x: jnp.nanmean(x, axis=0), local_stats)
+        step_stats = jax.tree.map(lambda x: jnp.nanmean(x, axis=0), walker_stats)
         assert step_stats["one_rdm"].shape == (norbs, norbs)
 
         # Finalize with batch dim of 1

--- a/tests/estimator/density_test.py
+++ b/tests/estimator/density_test.py
@@ -81,7 +81,7 @@ class TestKahanSummation:
         }
 
         for _ in range(100):
-            _, state = est.evaluate_batch(None, batched, {}, state, KEY)
+            _, state = est.evaluate_batch_walkers(None, batched, {}, state, KEY)
 
         expected = float(2**24) + 100
         np.testing.assert_allclose(float(state["histogram"][0, 0]), expected, rtol=1e-6)
@@ -115,7 +115,7 @@ class TestSphericalDensity:
         batched = _make_batched(electrons)
         data = _TestData(electrons=jnp.zeros((1, 2)))
         state = est.init(data, KEY)
-        _, state = est.evaluate_batch(None, batched, {}, state, KEY)
+        _, state = est.evaluate_batch_walkers(None, batched, {}, state, KEY)
         hist = state["histogram"][0]  # single-device histogram
         _assert_bin(hist, 0, 1.0)
         _assert_bin(hist, 2, 1.0)
@@ -128,7 +128,7 @@ class TestSphericalDensity:
         batched = _make_batched(electrons)
         data = _TestData(electrons=jnp.zeros((1, 2)))
         state = est.init(data, KEY)
-        _, state = est.evaluate_batch(None, batched, {}, state, KEY)
+        _, state = est.evaluate_batch_walkers(None, batched, {}, state, KEY)
         _assert_bin(state["histogram"][0], (0, 1), 1.0)
 
     def test_multi_step_accumulation(self):
@@ -139,7 +139,7 @@ class TestSphericalDensity:
         data = _TestData(electrons=jnp.zeros((1, 2)))
         state = est.init(data, KEY)
         for _ in range(3):
-            _, state = est.evaluate_batch(None, batched, {}, state, KEY)
+            _, state = est.evaluate_batch_walkers(None, batched, {}, state, KEY)
         _assert_bin(state["histogram"][0], 0, 3.0)
 
     def test_reduce_returns_empty(self):
@@ -170,7 +170,7 @@ class TestCartesianDensity:
         batched = _make_batched(electrons)
         data = _TestData(electrons=jnp.zeros((1, 3)))
         state = est.init(data, KEY)
-        _, state = est.evaluate_batch(None, batched, {}, state, KEY)
+        _, state = est.evaluate_batch_walkers(None, batched, {}, state, KEY)
         _assert_bin(state["histogram"][0], 5, 1.0)
 
     def test_direction_normalization(self):
@@ -184,7 +184,7 @@ class TestCartesianDensity:
         batched = _make_batched(electrons)
         data = _TestData(electrons=jnp.zeros((1, 3)))
         state = est.init(data, KEY)
-        _, state = est.evaluate_batch(None, batched, {}, state, KEY)
+        _, state = est.evaluate_batch_walkers(None, batched, {}, state, KEY)
         _assert_bin(state["histogram"][0], 5, 1.0)
 
     def test_oblique_direction(self):
@@ -198,7 +198,7 @@ class TestCartesianDensity:
         batched = _make_batched(electrons)
         data = _TestData(electrons=jnp.zeros((1, 3)))
         state = est.init(data, KEY)
-        _, state = est.evaluate_batch(None, batched, {}, state, KEY)
+        _, state = est.evaluate_batch_walkers(None, batched, {}, state, KEY)
         _assert_bin(state["histogram"][0], 8, 1.0)
 
     def test_2d_histogram(self):
@@ -213,7 +213,7 @@ class TestCartesianDensity:
         batched = _make_batched(electrons)
         data = _TestData(electrons=jnp.zeros((1, 3)))
         state = est.init(data, KEY)
-        _, state = est.evaluate_batch(None, batched, {}, state, KEY)
+        _, state = est.evaluate_batch_walkers(None, batched, {}, state, KEY)
         n = jax.device_count()
         assert state["histogram"].shape == (n, 4, 4)
         _assert_bin(state["histogram"][0], (1, 2), 1.0)
@@ -231,7 +231,7 @@ class TestCartesianDensity:
         batched = _make_batched(electrons)
         data = _TestData(electrons=jnp.zeros((1, 3)))
         state = est.init(data, KEY)
-        _, state = est.evaluate_batch(None, batched, {}, state, KEY)
+        _, state = est.evaluate_batch_walkers(None, batched, {}, state, KEY)
         # Only x and z remain -> 2D histogram
         n = jax.device_count()
         assert state["histogram"].shape == (n, 4, 4)
@@ -250,7 +250,7 @@ class TestCartesianDensity:
         batched = _make_batched(electrons)
         data = _TestData(electrons=jnp.zeros((1, 3)))
         state = est.init(data, KEY)
-        _, state = est.evaluate_batch(None, batched, {}, state, KEY)
+        _, state = est.evaluate_batch_walkers(None, batched, {}, state, KEY)
         n = jax.device_count()
         assert state["histogram"].shape == (n, 10)
         _assert_bin(state["histogram"][0], 5, 1.0)
@@ -274,7 +274,7 @@ class TestFractionalDensity:
         batched = _make_batched(electrons)
         data = _TestData(electrons=jnp.zeros((1, 3)))
         state = est.init(data, KEY)
-        _, state = est.evaluate_batch(None, batched, {}, state, KEY)
+        _, state = est.evaluate_batch_walkers(None, batched, {}, state, KEY)
         _assert_bin(state["histogram"][0], 5, 1.0)
 
     def test_non_orthogonal_cell(self):
@@ -296,7 +296,7 @@ class TestFractionalDensity:
         batched = _make_batched(electrons)
         data = _TestData(electrons=jnp.zeros((1, 3)))
         state = est.init(data, KEY)
-        _, state = est.evaluate_batch(None, batched, {}, state, KEY)
+        _, state = est.evaluate_batch_walkers(None, batched, {}, state, KEY)
         _assert_bin(state["histogram"][0], 5, 1.0)
 
     def test_wrapping(self):
@@ -311,7 +311,7 @@ class TestFractionalDensity:
         batched = _make_batched(electrons)
         data = _TestData(electrons=jnp.zeros((1, 3)))
         state = est.init(data, KEY)
-        _, state = est.evaluate_batch(None, batched, {}, state, KEY)
+        _, state = est.evaluate_batch_walkers(None, batched, {}, state, KEY)
         _assert_bin(state["histogram"][0], 5, 1.0)
 
     def test_2d_axes(self):
@@ -329,7 +329,7 @@ class TestFractionalDensity:
         batched = _make_batched(electrons)
         data = _TestData(electrons=jnp.zeros((1, 3)))
         state = est.init(data, KEY)
-        _, state = est.evaluate_batch(None, batched, {}, state, KEY)
+        _, state = est.evaluate_batch_walkers(None, batched, {}, state, KEY)
         n = jax.device_count()
         assert state["histogram"].shape == (n, 5, 5)
         _assert_bin(state["histogram"][0], (1, 3), 1.0)
@@ -349,7 +349,7 @@ class TestFractionalDensity:
         batched = _make_batched(electrons)
         data = _TestData(electrons=jnp.zeros((1, 3)))
         state = est.init(data, KEY)
-        _, state = est.evaluate_batch(None, batched, {}, state, KEY)
+        _, state = est.evaluate_batch_walkers(None, batched, {}, state, KEY)
         n = jax.device_count()
         assert state["histogram"].shape == (n, 10)
         _assert_bin(state["histogram"][0], 5, 1.0)

--- a/tests/estimator/estimator_test.py
+++ b/tests/estimator/estimator_test.py
@@ -8,7 +8,13 @@ import numpy as np
 import pytest
 from jax import numpy as jnp
 
-from jaqmc.estimator import Estimator, EstimatorPipeline, FunctionEstimator
+from jaqmc.data import BatchedData, Data
+from jaqmc.estimator import (
+    Estimator,
+    EstimatorPipeline,
+    FunctionEstimator,
+    LocalEstimator,
+)
 
 
 def _dummy_evaluate(params, data, stats, state, rngs):
@@ -33,11 +39,48 @@ class _BatchEstimator(Estimator):
         return {k: v * 2 for k, v in mean_stats.items()}
 
 
+class _ToyData(Data):
+    x: jnp.ndarray
+    scale: jnp.ndarray
+
+
+class _LocalValueEstimator(LocalEstimator):
+    def evaluate_local(self, params, data, prev_local_stats, state, rngs):
+        del params, rngs
+        return {"value": data.x * data.scale + prev_local_stats["bias"]}, state
+
+
 def test_function_estimator_delegates_to_fn():
     est = FunctionEstimator(_dummy_evaluate)
     result, state = est.evaluate_local(None, None, {}, "s", None)
     assert result == {"value": 1.0}
     assert state == "s"
+
+
+def test_local_estimator_chunks_default_vmap():
+    batched_data = BatchedData(
+        _ToyData(x=jnp.arange(7.0), scale=jnp.array(2.0)),
+        fields_with_batch=["x"],
+    )
+    prev_local_stats = {"bias": jnp.arange(7.0) * 10}
+
+    full_est = _LocalValueEstimator()
+    chunked_est = _LocalValueEstimator(vmap_chunk_size=3)
+
+    full, _ = full_est.evaluate_batch(
+        None, batched_data, prev_local_stats, None, jax.random.PRNGKey(0)
+    )
+    chunked, _ = chunked_est.evaluate_batch(
+        None, batched_data, prev_local_stats, None, jax.random.PRNGKey(0)
+    )
+
+    np.testing.assert_allclose(chunked["value"], full["value"])
+
+
+def test_chunk_knob_only_lives_on_local_estimators():
+    assert "vmap_chunk_size" not in Estimator.__dataclass_fields__
+    assert "vmap_chunk_size" not in _BatchEstimator.__dataclass_fields__
+    assert "vmap_chunk_size" in LocalEstimator.__dataclass_fields__
 
 
 def _make_pipeline_and_state():

--- a/tests/estimator/estimator_test.py
+++ b/tests/estimator/estimator_test.py
@@ -13,7 +13,7 @@ from jaqmc.estimator import (
     Estimator,
     EstimatorPipeline,
     FunctionEstimator,
-    LocalEstimator,
+    PerWalkerEstimator,
 )
 
 
@@ -22,17 +22,20 @@ def _dummy_evaluate(params, data, stats, state, rngs):
 
 
 class _BatchEstimator(Estimator):
-    """Estimator that overrides evaluate_batch to skip vmap."""
+    """Estimator that overrides evaluate_batch_walkers to skip vmap."""
 
     def __init__(self, key: str, value: float):
         self._key = key
         self._value = value
 
-    def evaluate_batch(self, params, batched_data, prev_local_stats, state, rngs):
+    def evaluate_batch_walkers(
+        self, params, batched_data, prev_walker_stats, state, rngs
+    ):
+        del batched_data, prev_walker_stats
         return {self._key: jnp.array(self._value)}, state
 
-    def reduce(self, local_stats):
-        return local_stats
+    def reduce(self, walker_stats):
+        return walker_stats
 
     def finalize_stats(self, batch_stats, state):
         mean_stats = jax.tree.map(lambda x: jnp.nanmean(x, axis=0), batch_stats)
@@ -44,15 +47,15 @@ class _ToyData(Data):
     scale: jnp.ndarray
 
 
-class _LocalValueEstimator(LocalEstimator):
-    def evaluate_local(self, params, data, prev_local_stats, state, rngs):
+class _LocalValueEstimator(PerWalkerEstimator):
+    def evaluate_single_walker(self, params, data, prev_walker_stats, state, rngs):
         del params, rngs
-        return {"value": data.x * data.scale + prev_local_stats["bias"]}, state
+        return {"value": data.x * data.scale + prev_walker_stats["bias"]}, state
 
 
 def test_function_estimator_delegates_to_fn():
     est = FunctionEstimator(_dummy_evaluate)
-    result, state = est.evaluate_local(None, None, {}, "s", None)
+    result, state = est.evaluate_single_walker(None, None, {}, "s", None)
     assert result == {"value": 1.0}
     assert state == "s"
 
@@ -62,16 +65,16 @@ def test_local_estimator_chunks_default_vmap():
         _ToyData(x=jnp.arange(7.0), scale=jnp.array(2.0)),
         fields_with_batch=["x"],
     )
-    prev_local_stats = {"bias": jnp.arange(7.0) * 10}
+    prev_walker_stats = {"bias": jnp.arange(7.0) * 10}
 
     full_est = _LocalValueEstimator()
     chunked_est = _LocalValueEstimator(vmap_chunk_size=3)
 
-    full, _ = full_est.evaluate_batch(
-        None, batched_data, prev_local_stats, None, jax.random.PRNGKey(0)
+    full, _ = full_est.evaluate_batch_walkers(
+        None, batched_data, prev_walker_stats, None, jax.random.PRNGKey(0)
     )
-    chunked, _ = chunked_est.evaluate_batch(
-        None, batched_data, prev_local_stats, None, jax.random.PRNGKey(0)
+    chunked, _ = chunked_est.evaluate_batch_walkers(
+        None, batched_data, prev_walker_stats, None, jax.random.PRNGKey(0)
     )
 
     np.testing.assert_allclose(chunked["value"], full["value"])
@@ -80,7 +83,7 @@ def test_local_estimator_chunks_default_vmap():
 def test_chunk_knob_only_lives_on_local_estimators():
     assert "vmap_chunk_size" not in Estimator.__dataclass_fields__
     assert "vmap_chunk_size" not in _BatchEstimator.__dataclass_fields__
-    assert "vmap_chunk_size" in LocalEstimator.__dataclass_fields__
+    assert "vmap_chunk_size" in PerWalkerEstimator.__dataclass_fields__
 
 
 def _make_pipeline_and_state():

--- a/tests/estimator/kinetic_forward_laplacian_test.py
+++ b/tests/estimator/kinetic_forward_laplacian_test.py
@@ -56,8 +56,10 @@ def test_forward_laplacian_vs_scan_equivalence(n_particles, n_dims, coeff):
         mode=LaplacianMode.forward_laplacian, f_log_psi=log_psi, data_field="positions"
     )
 
-    stats_scan, _ = estimator_scan.evaluate_local(params, data, {}, None, key)
-    stats_fwd_lap, _ = estimator_fwd_lap.evaluate_local(params, data, {}, None, key)
+    stats_scan, _ = estimator_scan.evaluate_single_walker(params, data, {}, None, key)
+    stats_fwd_lap, _ = estimator_fwd_lap.evaluate_single_walker(
+        params, data, {}, None, key
+    )
 
     ke_scan = float(stats_scan["energy:kinetic"])
     ke_fwd_lap = float(stats_fwd_lap["energy:kinetic"])
@@ -95,8 +97,10 @@ def test_forward_laplacian_kinetic_with_complex_wavefunction():
         mode=LaplacianMode.scan, f_log_psi=log_psi_complex, data_field="positions"
     )
 
-    stats_fwd_lap, _ = estimator_fwd_lap.evaluate_local(params, data, {}, None, key)
-    stats_scan, _ = estimator_scan.evaluate_local(params, data, {}, None, key)
+    stats_fwd_lap, _ = estimator_fwd_lap.evaluate_single_walker(
+        params, data, {}, None, key
+    )
+    stats_scan, _ = estimator_scan.evaluate_single_walker(params, data, {}, None, key)
 
     # Kinetic energy can be complex for complex wavefunctions
     ke_fwd_lap = stats_fwd_lap["energy:kinetic"]
@@ -140,8 +144,10 @@ def test_forward_laplacian_kinetic_edge_cases():
 
     # Test zero positions
     data = SimpleData(positions=jnp.zeros((3, 3)))
-    stats_fwd_lap, _ = estimator_fwd_lap.evaluate_local(params, data, {}, None, key)
-    stats_scan, _ = estimator_scan.evaluate_local(params, data, {}, None, key)
+    stats_fwd_lap, _ = estimator_fwd_lap.evaluate_single_walker(
+        params, data, {}, None, key
+    )
+    stats_scan, _ = estimator_scan.evaluate_single_walker(params, data, {}, None, key)
 
     ke_fwd_lap = float(stats_fwd_lap["energy:kinetic"])
     ke_scan = float(stats_scan["energy:kinetic"])
@@ -156,8 +162,10 @@ def test_forward_laplacian_kinetic_edge_cases():
 
     # Test very small positions
     data = SimpleData(positions=jnp.ones((3, 3)) * 1e-10)
-    stats_fwd_lap, _ = estimator_fwd_lap.evaluate_local(params, data, {}, None, key)
-    stats_scan, _ = estimator_scan.evaluate_local(params, data, {}, None, key)
+    stats_fwd_lap, _ = estimator_fwd_lap.evaluate_single_walker(
+        params, data, {}, None, key
+    )
+    stats_scan, _ = estimator_scan.evaluate_single_walker(params, data, {}, None, key)
 
     ke_fwd_lap = float(stats_fwd_lap["energy:kinetic"])
     ke_scan = float(stats_scan["energy:kinetic"])
@@ -174,8 +182,10 @@ def test_forward_laplacian_kinetic_edge_cases():
 
     # Test single particle, single dimension
     data = SimpleData(positions=jnp.array([[0.5]]))
-    stats_fwd_lap, _ = estimator_fwd_lap.evaluate_local(params, data, {}, None, key)
-    stats_scan, _ = estimator_scan.evaluate_local(params, data, {}, None, key)
+    stats_fwd_lap, _ = estimator_fwd_lap.evaluate_single_walker(
+        params, data, {}, None, key
+    )
+    stats_scan, _ = estimator_scan.evaluate_single_walker(params, data, {}, None, key)
 
     ke_fwd_lap = float(stats_fwd_lap["energy:kinetic"])
     ke_scan = float(stats_scan["energy:kinetic"])

--- a/tests/estimator/spin_test.py
+++ b/tests/estimator/spin_test.py
@@ -78,8 +78,8 @@ def _expected_s2_constant_wf(n_up, n_down):
 def test_s2_constant_wavefunction(n_up, n_down):
     """S^2 with constant wavefunction matches analytical formula."""
     est, data, key = _make_spin_estimator(n_up, n_down)
-    stats, _ = est.evaluate_local(
-        params={}, data=data, prev_local_stats={}, state=None, rngs=key
+    stats, _ = est.evaluate_single_walker(
+        params={}, data=data, prev_walker_stats={}, state=None, rngs=key
     )
     expected = _expected_s2_constant_wf(n_up, n_down)
     np.testing.assert_allclose(float(stats["spin:s2"]), expected, atol=1e-5)
@@ -99,8 +99,8 @@ def test_s2_fully_polarized():
     data = _ElectronData(electrons=jnp.ones((n_up, 3)))
     key = jax.random.key(0)
     est.init(data, key)
-    stats, _ = est.evaluate_local(
-        params={}, data=data, prev_local_stats={}, state=None, rngs=key
+    stats, _ = est.evaluate_single_walker(
+        params={}, data=data, prev_walker_stats={}, state=None, rngs=key
     )
     expected = 1.5 * 2.5  # S_z=3/2, S^2=S_z(S_z+1)
     np.testing.assert_allclose(float(stats["spin:s2"]), expected, atol=1e-5)
@@ -113,8 +113,8 @@ def test_s2_singlet_identical_orbitals():
     S^2 = 0*(0+1) + 1 - 1*1 = 0 (singlet).
     """
     est, data, key = _make_spin_estimator(1, 1)
-    stats, _ = est.evaluate_local(
-        params={}, data=data, prev_local_stats={}, state=None, rngs=key
+    stats, _ = est.evaluate_single_walker(
+        params={}, data=data, prev_walker_stats={}, state=None, rngs=key
     )
     np.testing.assert_allclose(float(stats["spin:s2"]), 0.0, atol=1e-5)
 

--- a/tests/optimizer/jasr_test.py
+++ b/tests/optimizer/jasr_test.py
@@ -17,7 +17,6 @@ from jaqmc.optimizer.sr.jasr import (
     active_leaf_indices,
     calc_gram_matrix,
     calc_gram_matrix_chunked,
-    chunked_vmap,
     estimate_required_damping,
     get_preset_params,
     get_structural_active_mask,
@@ -78,32 +77,6 @@ def _structural_mask_and_idx(log_psi_fn, params, samples, score_in_axes=0):
     mask = get_structural_active_mask(log_psi_fn, params, sample)
     idx = active_leaf_indices(params, mask)
     return mask, idx
-
-
-def test_chunked_vmap():
-    def f(inputs):
-        return {
-            "a": (inputs["x"][0] + 1, inputs["x"][1] - 1),
-            "b": jnp.sum(inputs["z"]),
-            "c": inputs["x"][0] ** 2 + inputs["y"],
-        }
-
-    inputs = {
-        "x": (jnp.arange(21), jnp.arange(21)),
-        "y": jnp.ones((3, 21)),
-        "z": jnp.arange(5),
-    }
-    in_axes = ({"x": 0, "y": 1, "z": None},)
-    out_axes = {"a": 0, "b": None, "c": 1}
-    if not hasattr(jax.tree, "broadcast"):
-        # no broadcast available, need to fully specify in_axes and out_axes
-        in_axes[0]["x"] = (0, 0)
-        out_axes["a"] = (0, 0)
-
-    y_ref = jax.vmap(f, in_axes=in_axes, out_axes=out_axes)(inputs)
-    y = chunked_vmap(f, in_axes=in_axes, out_axes=out_axes, chunk_size=6)(inputs)
-
-    chex.assert_trees_all_close(y, y_ref)
 
 
 @pytest.mark.parametrize("complex", [False, True])

--- a/tests/utils/atomic/pretrain_test.py
+++ b/tests/utils/atomic/pretrain_test.py
@@ -83,7 +83,9 @@ class TestPretrainOrbitalShape:
             orbitals_fn=wf.orbitals, scf=scf, nspins=nspins, full_det=wf.full_det
         )
         loss_estimator.init(data, TEST_KEY)
-        stats, _ = loss_estimator.evaluate_local(params, data, {}, None, TEST_KEY)
+        stats, _ = loss_estimator.evaluate_single_walker(
+            params, data, {}, None, TEST_KEY
+        )
 
         assert jnp.isfinite(stats["loss"])
         assert stats["loss"] > 0, "Random params should not match SCF orbitals exactly"

--- a/tests/utils/chunked_vmap_test.py
+++ b/tests/utils/chunked_vmap_test.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2025-2026 Bytedance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+import chex
+import jax
+from jax import numpy as jnp
+
+from jaqmc.utils.chunked_vmap import chunked_vmap
+
+
+def test_chunked_vmap_matches_vmap_for_nested_axes():
+    def f(inputs):
+        return {
+            "a": (inputs["x"][0] + 1, inputs["x"][1] - 1),
+            "b": jnp.sum(inputs["z"]),
+            "c": inputs["x"][0] ** 2 + inputs["y"],
+        }
+
+    inputs = {
+        "x": (jnp.arange(21), jnp.arange(21)),
+        "y": jnp.ones((3, 21)),
+        "z": jnp.arange(5),
+    }
+    in_axes = ({"x": 0, "y": 1, "z": None},)
+    out_axes = {"a": 0, "b": None, "c": 1}
+    if not hasattr(jax.tree, "broadcast"):
+        # no broadcast available, need to fully specify in_axes and out_axes
+        in_axes[0]["x"] = (0, 0)
+        out_axes["a"] = (0, 0)
+
+    y_ref = jax.vmap(f, in_axes=in_axes, out_axes=out_axes)(inputs)
+    y = chunked_vmap(f, in_axes=in_axes, out_axes=out_axes, chunk_size=6)(inputs)
+
+    chex.assert_trees_all_close(y, y_ref)
+
+
+def test_chunked_vmap_handles_exact_chunk_partition():
+    def f(x):
+        return {"leading": x + 1, "nonleading": jnp.stack([x, x**2])}
+
+    x = jnp.arange(21)
+    out_axes = {"leading": 0, "nonleading": 1}
+
+    y_ref = jax.vmap(f, out_axes=out_axes)(x)
+    y = chunked_vmap(f, out_axes=out_axes, chunk_size=7)(x)
+
+    chex.assert_trees_all_close(y, y_ref)
+
+
+def test_chunked_vmap_preserves_none_output_leaf():
+    def evaluate_local(params, data, prev_local_stats, state, rng):
+        del params, prev_local_stats, rng
+        return {"energy:kinetic": data * 2}, state
+
+    params = {"w": jnp.array([1.0])}
+    data = jnp.arange(10.0)
+    prev_local_stats = {}
+    state = None
+    rngs = jax.random.split(jax.random.PRNGKey(0), 10)
+    in_axes = (None, 0, 0, None, 0)
+
+    y_ref = jax.vmap(evaluate_local, in_axes=in_axes)(
+        params, data, prev_local_stats, state, rngs
+    )
+    y = chunked_vmap(evaluate_local, in_axes=in_axes, chunk_size=4)(
+        params, data, prev_local_stats, state, rngs
+    )
+
+    chex.assert_trees_all_close(y, y_ref)

--- a/tests/utils/chunked_vmap_test.py
+++ b/tests/utils/chunked_vmap_test.py
@@ -48,22 +48,22 @@ def test_chunked_vmap_handles_exact_chunk_partition():
 
 
 def test_chunked_vmap_preserves_none_output_leaf():
-    def evaluate_local(params, data, prev_local_stats, state, rng):
-        del params, prev_local_stats, rng
+    def evaluate_single_walker(params, data, prev_walker_stats, state, rng):
+        del params, prev_walker_stats, rng
         return {"energy:kinetic": data * 2}, state
 
     params = {"w": jnp.array([1.0])}
     data = jnp.arange(10.0)
-    prev_local_stats = {}
+    prev_walker_stats = {}
     state = None
     rngs = jax.random.split(jax.random.PRNGKey(0), 10)
     in_axes = (None, 0, 0, None, 0)
 
-    y_ref = jax.vmap(evaluate_local, in_axes=in_axes)(
-        params, data, prev_local_stats, state, rngs
+    y_ref = jax.vmap(evaluate_single_walker, in_axes=in_axes)(
+        params, data, prev_walker_stats, state, rngs
     )
-    y = chunked_vmap(evaluate_local, in_axes=in_axes, chunk_size=4)(
-        params, data, prev_local_stats, state, rngs
+    y = chunked_vmap(evaluate_single_walker, in_axes=in_axes, chunk_size=4)(
+        params, data, prev_walker_stats, state, rngs
     )
 
     chex.assert_trees_all_close(y, y_ref)


### PR DESCRIPTION
Here we add configurable chunked batching for estimators that batch over a single-walker evaluation hook, and rename the estimator API so that it matches that contract more clearly.

The existing chunked `vmap` helper is moved from JaSR into `jaqmc.utils.chunked_vmap`, and JaSR now reuses the shared helper. Estimator batching also uses this helper through the new `PerWalkerEstimator` base class.

As part of this, the estimator naming is updated to make the walker-wise path explicit:

- `LocalEstimator` is renamed to `PerWalkerEstimator`.
- `evaluate_local` is renamed to `evaluate_single_walker`.
- `evaluate_batch` is renamed to `evaluate_batch_walkers`.
- `local_stats` / `prev_local_stats` are renamed to `walker_stats` / `prev_walker_stats`.

The estimator API is now split as follows:

- `Estimator` is for general estimators that implement full-batch `evaluate_batch_walkers` logic.
- `PerWalkerEstimator` is for estimators that implement single-walker `evaluate_single_walker`; JaQMC batches it with `vmap`.
- The `vmap_chunk_size` configuration option only lives on `PerWalkerEstimator`.

This keeps full-batch estimators, such as histogram-style estimators, from exposing a misleading chunk-size option while still giving memory-heavy per-walker estimators a way to trade speed for lower peak memory.