### PR TITLE
host documentations on Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,9 @@
 # Required
 version: 2
 
+formats:
+  - pdf
+
 # Set the OS, Python version, and other tools you might need
 build:
   os: ubuntu-26.04

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,26 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version, and other tools you might need
+build:
+  os: ubuntu-26.04
+  tools:
+    python: "3.13"
+  apt_packages:
+    - graphviz
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally, but recommended,
+# declare the Python requirements required to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+   install:
+   - method: uv
+     command: sync
+     groups: [docs]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.12+-blue.svg"></a>
-  <a href="https://bytedance.github.io/jaqmc/"><img src="https://img.shields.io/badge/documentation-teal.svg"></a>
+  <a href="https://jaqmc.readthedocs.io/latest/"><img src="https://img.shields.io/badge/documentation-teal.svg"></a>
 </p>
 
 
@@ -97,13 +97,13 @@ jaqmc hydrogen-atom train train.optim.learning_rate.rate=0.01 train.run.iteratio
 jaqmc molecule train system.module=atom system.symbol=Li
 ```
 
-See the [documentation](https://bytedance.github.io/jaqmc/getting-started/quick-start.html) for detailed guides on installation, molecular simulations, and writing custom workflows.
+See the [documentation](https://jaqmc.readthedocs.io/latest/getting-started/quick-start.html) for detailed guides on installation, molecular simulations, and writing custom workflows.
 
 ## Where to Go Next
 
-- **Train a real system**: See [Molecules](https://bytedance.github.io/jaqmc/systems/molecule/index.html), [Solids](https://bytedance.github.io/jaqmc/systems/solid/index.html), or [Quantum Hall](https://bytedance.github.io/jaqmc/systems/hall/index.html).
-- **Understand the framework**: Read [Core Concepts](https://bytedance.github.io/jaqmc/getting-started/concepts.html).
-- **Extend JaQMC**: Start from [Extending JaQMC](https://bytedance.github.io/jaqmc/extending/index.html).
+- **Train a real system**: See [Molecules](https://jaqmc.readthedocs.io/latest/systems/molecule/index.html), [Solids](https://jaqmc.readthedocs.io/latest/systems/solid/index.html), or [Quantum Hall](https://jaqmc.readthedocs.io/latest/systems/hall/index.html).
+- **Understand the framework**: Read [Core Concepts](https://jaqmc.readthedocs.io/latest/getting-started/concepts.html).
+- **Extend JaQMC**: Start from [Extending JaQMC](https://jaqmc.readthedocs.io/latest/extending/index.html).
 - **Contribute code**: See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Development
@@ -142,4 +142,4 @@ If you use JaQMC in your research, please cite the following paper, which introd
 }
 ```
 
-See [Citing JaQMC](https://bytedance.github.io/jaqmc/citing.html) for additional citations for specific techniques.
+See [Citing JaQMC](https://jaqmc.readthedocs.io/latest/citing.html) for additional citations for specific techniques.

--- a/docs/_static/readthedocs.js
+++ b/docs/_static/readthedocs.js
@@ -1,0 +1,25 @@
+function triggerRtdSearch() {
+  const event = new CustomEvent("readthedocs-search-show");
+  document.dispatchEvent(event);
+}
+
+document.addEventListener("DOMContentLoaded", function (event) {
+  document.querySelectorAll(".search-button__button").forEach((element) => {
+    element.onclick = triggerRtdSearch;
+  });
+  document.addEventListener("keydown", (e) => {
+    const useCommandKey =
+      navigator.platform.indexOf("Mac") === 0 ||
+      navigator.platform === "iPhone";
+    const metaKeyUsed = useCommandKey
+      ? e.metaKey && !e.ctrlKey
+      : !e.metaKey && e.ctrlKey;
+    if (metaKeyUsed && e.key === "k" && !e.shiftKey && !e.altKey) {
+      const searchDialog = document.getElementById("pst-search-dialog");
+      if (document.contains(searchDialog)) {
+        searchDialog.close();
+      }
+      triggerRtdSearch();
+    }
+  });
+});

--- a/docs/_static/rtd-search-theme.css
+++ b/docs/_static/rtd-search-theme.css
@@ -1,0 +1,43 @@
+readthedocs-search {
+  --readthedocs-search-backdrop-color: color-mix(
+    in srgb,
+    var(--pst-color-black) 35%,
+    transparent
+  );
+  --readthedocs-search-color: var(--pst-color-text-base);
+  --readthedocs-search-link-color: var(--pst-color-link);
+
+  --readthedocs-search-content-background-color: var(--pst-color-background);
+  --readthedocs-search-content-border-color: var(--pst-color-border);
+  --readthedocs-search-filters-border-color: var(--pst-color-border);
+  --readthedocs-search-footer-background-color: var(--pst-color-surface);
+  --readthedocs-search-footer-color: var(--pst-color-text-base);
+  --readthedocs-search-footer-code-background-color: var(
+    --pst-color-on-background
+  );
+  --readthedocs-search-footer-code-border-color: var(--pst-color-border);
+  --readthedocs-search-input-background-color: var(--pst-color-surface);
+
+  --readthedocs-search-result-highlight-color: var(
+    --readthedocs-search-result-section-highlight-color,
+    var(--pst-color-primary)
+  );
+  --readthedocs-search-result-background-color: transparent;
+  --readthedocs-search-result-color: var(
+    --readthedocs-search-result-section-color,
+    var(--pst-color-text-muted)
+  );
+  --readthedocs-search-result-icon-color: var(--pst-color-text-muted);
+  --readthedocs-search-result-heading-color: var(--pst-color-heading);
+  --readthedocs-search-result-subheading-color: var(
+    --readthedocs-search-result-section-subheading-color,
+    var(--pst-color-text-muted)
+  );
+  --readthedocs-search-result-active-background-color: var(
+    --pst-color-surface
+  );
+  --readthedocs-search-result-border-color: var(--pst-color-border);
+
+  --readthedocs-search-badge-background-color: var(--pst-color-primary-bg);
+  --readthedocs-search-badge-color: var(--pst-color-text-base);
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,6 +67,11 @@ html_theme = "sphinx_book_theme"
 html_static_path = ["_static"]
 html_favicon = "_static/jaqmc-light.svg"
 html_css_files = ["custom.css"]
+if os.environ.get("READTHEDOCS"):
+    html_css_files.append("rtd-search-theme.css")
+html_js_files = []
+if os.environ.get("READTHEDOCS"):
+    html_js_files.append("readthedocs.js")
 html_logo = "_static/jaqmc-light-large.svg"
 html_baseurl = "https://bytedance.github.io/jaqmc/"
 html_theme_options = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ html_js_files = []
 if os.environ.get("READTHEDOCS"):
     html_js_files.append("readthedocs.js")
 html_logo = "_static/jaqmc-light-large.svg"
-html_baseurl = "https://bytedance.github.io/jaqmc/"
+html_baseurl = "https://jaqmc.readthedocs.io/latest/"
 html_theme_options = {
     "repository_url": "https://github.com/bytedance/jaqmc",
     "use_source_button": True,

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,31 +18,30 @@ sd_hide_title: true
 :::::{grid} 1 2 2 2
 :gutter: 3
 :margin: 4 4 0 0
-:class-container: sd-rounded-3
 
 ::::{grid-item-card} {octicon}`package;1.5em` Modular by design
-:class-card: sd-rounded-3
+:class-card: sd-rounded-3 overflow-hidden
 :shadow: none
 
 Swap and extend wavefunctions, samplers, estimators, and optimizers — from config or from code.
 ::::
 
 ::::{grid-item-card} {octicon}`globe;1.5em` General-purpose
-:class-card: sd-rounded-3
+:class-card: sd-rounded-3 overflow-hidden
 :shadow: none
 
 Atoms, molecules, and crystals. Extends naturally to other quantum systems.
 ::::
 
 ::::{grid-item-card} {octicon}`terminal;1.5em` Ready to use, ready to modify
-:class-card: sd-rounded-3
+:class-card: sd-rounded-3 overflow-hidden
 :shadow: none
 
 Configure common neural network backbones and optimizers from the CLI or from code.
 ::::
 
 ::::{grid-item-card} {octicon}`zap;1.5em` Built on JAX
-:class-card: sd-rounded-3
+:class-card: sd-rounded-3 overflow-hidden
 :shadow: none
 
 Autodiff, JIT compilation, and multi-device parallelism for free.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ jaqmc = "jaqmc.app.cli:cli"
 [project.urls]
 Repository = "https://github.com/bytedance/jaqmc.git"
 Issues = "https://github.com/bytedance/jaqmc/issues"
-Documentation = "https://bytedance.github.io/jaqmc"
+Documentation = "https://jaqmc.readthedocs.io/latest"
 
 [dependency-groups]
 lint = [


### PR DESCRIPTION
Read the Docs offers many features that do not exist on GitHub Pages, such as multiple versions, PDF downloads, server-side searches, pull request previews, etc.

Here we add the configuration files, change the mentioned documentation URLs, and configure the search to use the one provided by Read the Docs.