### PR TITLE
fix zero seed handling

### DIFF
--- a/src/jaqmc/workflow/evaluation.py
+++ b/src/jaqmc/workflow/evaluation.py
@@ -74,8 +74,8 @@ class EvaluationWorkflow(Workflow):
         # We must use the same seed across all processes to ensure that replicated
         # parameters are initialized identically. Generation of different keys on
         # different devices (across processes) happens later. So no fold_in here.
-        rngs = jax.random.PRNGKey(self.config.seed or int(time.time()))
-        rngs = multihost_utils.broadcast_one_to_all(rngs)
+        seed = self.config.seed if self.config.seed is not None else int(time.time())
+        rngs = multihost_utils.broadcast_one_to_all(jax.random.PRNGKey(seed))
         context = self.run_context
 
         source_path = UPath(self.config.source_path)

--- a/src/jaqmc/workflow/vmc.py
+++ b/src/jaqmc/workflow/vmc.py
@@ -96,8 +96,8 @@ class VMCWorkflow(Workflow):
         # We must use the same seed across all processes to ensure that replicated
         # parameters are initialized identically. Generation of different keys on
         # different devices (across processes) happens later. So no fold_in here.
-        rngs = jax.random.PRNGKey(self.config.seed or int(time.time()))
-        rngs = multihost_utils.broadcast_one_to_all(rngs)
+        seed = self.config.seed if self.config.seed is not None else int(time.time())
+        rngs = multihost_utils.broadcast_one_to_all(jax.random.PRNGKey(seed))
         context = self.run_context
 
         rngs, data_rngs = jax.random.split(rngs)


### PR DESCRIPTION
Treat only a missing seed as nondeterministic so seed 0 remains a valid reproducible choice for workflows.