### PR TITLE
warm up steps for timing

### DIFF
--- a/src/jaqmc/utils/time_tracker.py
+++ b/src/jaqmc/utils/time_tracker.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025-2026 Bytedance Ltd. and/or its affiliates
 # SPDX-License-Identifier: Apache-2.0
 
-"""Time-per-step tracker, excluding JAX JIT compilation overhead."""
+"""Time-per-step tracker with configurable warmup-step exclusion."""
 
 import logging
 import time
@@ -10,50 +10,77 @@ logger = logging.getLogger("tracker")
 
 
 class TimeTracker:
-    """Tracks time per step, excluding JAX JIT compilation overhead.
+    """Tracks time per step while excluding configurable warmup steps.
 
-    The tracker intentionally excludes the first step measurement because JAX
-    Just-In-Time (JIT) compilation typically occurs on the first execution of
-    jitted functions, which would skew the average time per step calculation.
+    Warmup steps are excluded for two startup effects. The exact first step may
+    include JAX Just-In-Time (JIT) compilation, which would skew the average.
+    Separately, JAX dispatch is asynchronous, so the next few steps can appear
+    artificially fast while work is still being queued rather than waited on.
+    The tracker discards a configurable number of initial steps and reports the
+    steady-state average after that warmup window.
 
     Example usage in a training loop::
 
         def training_loop(iterations: int):
-            time_tracker = TimeTracker()
+            time_tracker = TimeTracker(warmup_steps=10)
             logger = logging.getLogger("train")
+            time_tracker.start()
             for step in range(iterations):
                 execute_jitted_step()
                 time_tracker.tick()
             time_tracker.log_time_per_step(logger=logger)
     """
 
-    _start_time: float | None = None
-    _last_time: float | None = None
-    _ticks: int = 0
+    def __init__(self, warmup_steps: int = 10) -> None:
+        """Initialize the tracker.
+
+        Args:
+            warmup_steps: Number of initial completed steps to discard before
+                reporting the steady-state average time per step.
+
+        Raises:
+            ValueError: If ``warmup_steps`` is negative.
+        """
+        if warmup_steps < 0:
+            raise ValueError("warmup_steps must be >= 0")
+        self._warmup_steps = warmup_steps
+        self._boundary_time: float | None = None
+        self._last_time: float | None = None
+        self._ticks = 0
+        self.start()
+
+    def start(self) -> None:
+        """Reset the tracker baseline to the current time."""
+        self._boundary_time = time.perf_counter()
+        self._last_time = None
+        self._ticks = 0
 
     def tick(self) -> None:
-        """Record a time step.
+        """Record a completed step.
 
-        The first call initializes the start time but is excluded from
-        time-per-step calculations to account for JAX JIT compilation overhead.
+        The tracker resets its averaging boundary after each warmup step so the
+        reported average only includes measured steps.
         """
-        current_time = time.time()
-        self._start_time = self._start_time or current_time
+        current_time = time.perf_counter()
         self._last_time = current_time
         self._ticks += 1
+        if self._ticks <= self._warmup_steps:
+            self._boundary_time = current_time
 
     def time_per_step(self) -> float | None:
-        """Calculate average time per step, excluding the first (JIT) step.
+        """Calculate average time per measured step.
 
         Returns:
-            Average time per step in seconds, or None if fewer than 2 ticks.
+            Average time per step in seconds, or None if no measured steps have
+            completed yet.
         """
+        measured_steps = self._ticks - self._warmup_steps
         if (
-            self._start_time is not None
+            self._boundary_time is not None
             and self._last_time is not None
-            and self._ticks > 1
+            and measured_steps > 0
         ):
-            return (self._last_time - self._start_time) / (self._ticks - 1)
+            return (self._last_time - self._boundary_time) / measured_steps
         return None
 
     def log_time_per_step(
@@ -64,5 +91,6 @@ class TimeTracker:
         Args:
             logger: Logger instance to use.
         """
-        if time_per_step := self.time_per_step():
+        time_per_step = self.time_per_step()
+        if time_per_step is not None:
             logger.info("Time per step: %.3fs", time_per_step)

--- a/src/jaqmc/workflow/stage/base.py
+++ b/src/jaqmc/workflow/stage/base.py
@@ -60,6 +60,8 @@ class WorkStageConfig:
             ``save_step_interval`` are satisfied.
         save_step_interval: Save checkpoints only at steps that are
             multiples of this value.
+        timing_warmup_steps: Number of initial loop steps to exclude from
+            time-per-step logging.
         check_vma: Enable JAX validity checks during ``shard_map``.
     """
 
@@ -69,6 +71,7 @@ class WorkStageConfig:
     burn_in: int = 0
     save_time_interval: int = 10 * 60
     save_step_interval: int = 1000
+    timing_warmup_steps: int = 10
 
 
 class WorkStage(ABC):
@@ -147,12 +150,13 @@ class WorkStage(ABC):
         self.logger.info("Start %s %s steps.", remaining, self.name)
 
         last_save_time = time.time()
-        tracker = TimeTracker()
+        tracker = TimeTracker(warmup_steps=self.config.timing_warmup_steps)
 
         try:
             with self.writers.open(
                 save_dir, prefix, is_master=is_master, initial_step=initial_step
             ):
+                tracker.start()
                 for step, state in self.loop(state, initial_step, rngs):
                     tracker.tick()
 


### PR DESCRIPTION
Warmup steps are excluded for two startup effects. The exact first step may include JAX Just-In-Time (JIT) compilation, which would skew the average. Separately, JAX dispatch is asynchronous, so the next few steps can appear artificially fast while work is still being queued rather than waited on. The tracker discards a configurable number of initial steps and reports the steady-state average after that warmup window.