### PR TITLE
support union for module_config

### DIFF
--- a/docs/config_reference.py
+++ b/docs/config_reference.py
@@ -207,6 +207,13 @@ def _format_compact_type(field_type, mc) -> str | None:
         Compact RST-formatted type string, or ``None`` if unavailable.
     """
     if mc is not None:
+        direct_type = (
+            _type_name(mc.direct_value_type)
+            if mc.direct_value_type is not None
+            else None
+        )
+        if direct_type:
+            return f"``{direct_type}`` or swappable"
         return "swappable"
     name = _type_name(field_type)
     return f"``{name}``" if name else None
@@ -464,8 +471,14 @@ def _merge_dicts(base: dict[str, Any], override: dict[str, Any]) -> dict[str, An
     return result
 
 
-def _module_config_package(default_module: str) -> str | None:
+def _module_config_package(
+    default_module: str | None, module_import_base: str | None = None
+) -> str | None:
     """Return the package used for relative resolution of ``module_config``."""
+    if module_import_base is not None:
+        return module_import_base
+    if default_module is None:
+        return None
     if "." not in default_module:
         return None
     return default_module[: default_module.rfind(".")]
@@ -492,6 +505,35 @@ def _format_module_value(module_name: str, package: str | None = None) -> str:
     return f":py:obj:`{display} <{target}>`"
 
 
+def _format_module_default(module_name: str, kwargs: dict[str, Any]) -> str:
+    """Format a module-config default as a constructor-style object reference.
+
+    Returns:
+        RST-formatted module default string.
+    """
+    target = module_name.replace(":", ".")
+    class_short = module_name.rsplit(":", 1)[1]
+    kwargs_str = ", ".join(f"{k}={v!r}" for k, v in kwargs.items())
+    display = f"{class_short}({kwargs_str})" if kwargs_str else f"{class_short}()"
+    return f":py:obj:`{display} <{target}>`"
+
+
+def _format_field_default(field) -> str:
+    """Format a dataclass field default or default factory output.
+
+    Returns:
+        RST-formatted default value string.
+    """
+    if field.default is not MISSING:
+        return _format_value(field.default)
+    if field.default_factory is not MISSING:
+        try:
+            return _format_value(field.default_factory())
+        except Exception:
+            return "*(factory)*"
+    return "*(required)*"
+
+
 def _format_default(field, mc, override: Any = _NO_OVERRIDE) -> str:
     """Format a field's default value for display.
 
@@ -501,34 +543,18 @@ def _format_default(field, mc, override: Any = _NO_OVERRIDE) -> str:
     if override is not _NO_OVERRIDE:
         if mc is not None and isinstance(override, dict):
             module_name = override.get("module", mc.default)
-            target = module_name.replace(":", ".")
-            class_short = module_name.rsplit(":", 1)[1]
             kwargs = _merge_dicts(
                 mc.kwargs, {k: v for k, v in override.items() if k != "module"}
             )
-            kwargs_str = ", ".join(f"{k}={v!r}" for k, v in kwargs.items())
-            display = (
-                f"{class_short}({kwargs_str})" if kwargs_str else f"{class_short}()"
-            )
-            return f":py:obj:`{display} <{target}>`"
+            return _format_module_default(module_name, kwargs)
         return _format_value(override)
 
     if mc is not None:
-        target = mc.default.replace(":", ".")
-        class_short = mc.default.rsplit(":", 1)[1]
-        kwargs_str = ", ".join(f"{k}={v!r}" for k, v in mc.kwargs.items())
-        display = f"{class_short}({kwargs_str})" if kwargs_str else f"{class_short}()"
-        return f":py:obj:`{display} <{target}>`"
+        if mc.default is None:
+            return _format_field_default(field)
+        return _format_module_default(mc.default, mc.kwargs)
 
-    if field.default is not MISSING:
-        return _format_value(field.default)
-    if field.default_factory is not MISSING:
-        try:
-            val = field.default_factory()
-            return _format_value(val)
-        except Exception:
-            return "*(factory)*"
-    return "*(required)*"
+    return _format_field_default(field)
 
 
 class ConfigContext(SphinxDirective):
@@ -615,7 +641,11 @@ class ConfigDefaults(ConfigDirectiveBase):
     }
 
     def _module_group_description(
-        self, description: str | None, field_key: str, module_str: str
+        self,
+        description: str | None,
+        field_key: str,
+        module_str: str | None,
+        direct_value_type: str | None = None,
     ) -> str:
         """Build the explanatory line for a swappable component block.
 
@@ -625,11 +655,28 @@ class ConfigDefaults(ConfigDirectiveBase):
         parts: list[str] = []
         if description:
             parts.append(description.rstrip("."))
-        parts.append(
-            "Swappable component; the nested keys below are the options for the "
-            f"current module {module_str} and change when "
-            f"``{field_key}.module`` changes."
-        )
+        if module_str is None:
+            if direct_value_type:
+                parts.append(
+                    f"Accepts direct ``{direct_value_type}`` values by default. "
+                    f"Set ``{field_key}.module`` to switch to a configurable "
+                    "component."
+                )
+            else:
+                parts.append(
+                    f"Set ``{field_key}.module`` to choose a configurable component."
+                )
+        else:
+            prefix = (
+                f"Accepts direct ``{direct_value_type}`` values too. "
+                if direct_value_type
+                else ""
+            )
+            parts.append(
+                f"{prefix}Swappable component; the nested keys below are the "
+                f"options for the current module {module_str} and change when "
+                f"``{field_key}.module`` changes."
+            )
         return ". ".join(parts)
 
     def _meta_text(self, entry: ConfigDefaultEntry) -> str:
@@ -759,50 +806,74 @@ class ConfigDefaults(ConfigDirectiveBase):
         Returns:
             Parent entry with nested current-module options.
         """
+        direct_value_type = (
+            _type_name(module_config.direct_value_type)
+            if module_config.direct_value_type is not None
+            else None
+        )
         module_name = (
             override.get("module", module_config.default)
             if isinstance(override, dict)
             else module_config.default
         )
-        package = _module_config_package(module_config.default)
-        module_default_str = _format_module_value(module_name, package=package)
-        nested_obj = resolve_object(module_name, package=package)
+        package = _module_config_package(
+            module_config.default, module_config.module_import_base
+        )
         nested_overrides = (
             {k: v for k, v in override.items() if k != "module"}
             if isinstance(override, dict)
             else {}
         )
-        nested_items: list[ConfigDefaultEntry] = [
-            ConfigDefaultEntry(
-                key=f"{field_key}.module",
-                default_str=module_default_str,
-                type_str="module path",
-                description="Select the implementation used for this component.",
-                anchor_scope=anchor_scope,
+        nested_items: list[ConfigDefaultEntry] = []
+        module_default_str = _format_default(field, module_config, override=override)
+        if module_name is not None:
+            module_default_str = _format_module_value(module_name, package=package)
+            nested_items.append(
+                ConfigDefaultEntry(
+                    key=f"{field_key}.module",
+                    default_str=module_default_str,
+                    type_str="module path",
+                    description="Select the implementation used for this component.",
+                    anchor_scope=anchor_scope,
+                )
             )
-        ]
-        nested_scope = _merge_anchor_scopes(
-            anchor_scope,
-            _scope_from_module_name(module_name),
-        )
-        if is_dataclass(nested_obj):
-            nested_items.extend(
-                self._collect_dataclass_items(
-                    nested_obj,
-                    field_key,
-                    nested_overrides,
-                    importlib.import_module(nested_obj.__module__),
-                    anchor_scope=nested_scope,
+            nested_obj = resolve_object(module_name, package=package)
+            nested_scope = _merge_anchor_scopes(
+                anchor_scope,
+                _scope_from_module_name(module_name),
+            )
+            if is_dataclass(nested_obj):
+                nested_items.extend(
+                    self._collect_dataclass_items(
+                        nested_obj,
+                        field_key,
+                        nested_overrides,
+                        importlib.import_module(nested_obj.__module__),
+                        anchor_scope=nested_scope,
+                    )
+                )
+        else:
+            nested_items.append(
+                ConfigDefaultEntry(
+                    key=f"{field_key}.module",
+                    default_str="*(optional)*",
+                    type_str="module path",
+                    description=(
+                        "Set this to switch from a direct value to a configurable "
+                        "component."
+                    ),
+                    anchor_scope=anchor_scope,
                 )
             )
         return ConfigDefaultEntry(
             key=field_key,
-            default_str=module_default_str,
-            type_str="swappable",
+            default_str=_format_default(field, module_config, override=override),
+            type_str=_format_compact_type(field.type, module_config),
             description=self._module_group_description(
                 self._description(descriptions, field.name, mod),
                 field_key,
-                module_default_str,
+                module_default_str if module_name is not None else None,
+                direct_value_type,
             ),
             children=nested_items,
             classes=("config-defaults-item-group",),

--- a/docs/extending/configuration.md
+++ b/docs/extending/configuration.md
@@ -139,6 +139,28 @@ train:
       decay_steps: 1000
 ```
 
+If you want a field to accept either a direct scalar value or an explicit nested
+module, add `direct_value_type`:
+
+```python
+@configurable_dataclass
+class MyOptimizer:
+    damping: Any = module_config(
+        1e-3,
+        direct_value_type=float,
+        module_import_base="my_lib.schedules",
+    )
+```
+
+With this form, users can write either `damping: 1e-3` or an explicit module
+mapping such as:
+
+```yaml
+damping:
+  module: Constant
+  rate: 1e-3
+```
+
 ## Collections (`get_collection`)
 
 `get_collection` allows you to retrieve a dynamic set of named modules. This is useful for plugins like writers or estimators where the user might want to enable/disable specific ones or add their own.

--- a/src/jaqmc/optimizer/kfac/kfac.py
+++ b/src/jaqmc/optimizer/kfac/kfac.py
@@ -75,7 +75,7 @@ class KFACOptimizer:
     internal parts of original `kfac_jax <https://github.com/google-deepmind/kfac-jax>`_.
 
     Args:
-        learning_rate: The learning rate.
+        learning_rate: Step size (scalar or schedule).
         norm_constraint: The update is scaled down so that its approximate squared
             Fisher norm :math:`v^T F v` is at most the specified value.
         curvature_ema: Decay factor used when calculating the covariance estimate
@@ -86,7 +86,7 @@ class KFACOptimizer:
         damping: Fixed damping parameter.
     """
 
-    learning_rate: Any = module_config(Standard)
+    learning_rate: Any = module_config(Standard, direct_value_type=float)
     norm_constraint: float = 1e-3
     curvature_ema: float = 0.95
     l2_reg: float = 0.0

--- a/src/jaqmc/optimizer/optax.py
+++ b/src/jaqmc/optimizer/optax.py
@@ -9,7 +9,7 @@ from typing import Any
 import jax
 import optax
 
-from jaqmc.optimizer.schedule import Constant, Standard
+from jaqmc.optimizer.schedule import Standard
 from jaqmc.utils.config import configurable_dataclass, module_config
 
 
@@ -43,9 +43,13 @@ def _make_optax_dataclass(name: str, factory):
         annotation = param.annotation
         if annotation == optax.ScalarOrSchedule:
             if isinstance(param.default, (int, float)):
-                mc = module_config(Constant, rate=param.default)
+                mc = module_config(
+                    param.default,
+                    direct_value_type=float,
+                    module_import_base="jaqmc.optimizer",
+                )
             else:
-                mc = module_config(Standard)
+                mc = module_config(Standard, direct_value_type=float)
             fields_list.append((param.name, Any, mc))
         elif annotation == jax.typing.ArrayLike:
             if param.default is not inspect.Parameter.empty:

--- a/src/jaqmc/optimizer/sr/sr.py
+++ b/src/jaqmc/optimizer/sr/sr.py
@@ -7,7 +7,7 @@ import optax
 
 from jaqmc.array_types import Params
 from jaqmc.data import BatchedData
-from jaqmc.optimizer.schedule import Constant, Standard
+from jaqmc.optimizer.schedule import Standard
 from jaqmc.utils import parallel_jax
 from jaqmc.utils.config import configurable_dataclass, module_config
 from jaqmc.utils.wiring import runtime_dep
@@ -64,12 +64,20 @@ class SROptimizer:
             when forming the SR system.
     """
 
-    learning_rate: Any = module_config(Standard)
-    max_norm: Any = module_config(Constant, rate=0.1)
-    damping: Any = module_config(Constant, rate=1e-3)
+    learning_rate: Any = module_config(Standard, direct_value_type=float)
+    max_norm: Any = module_config(
+        0.1, direct_value_type=float, module_import_base="jaqmc.optimizer"
+    )
+    damping: Any = module_config(
+        1e-3, direct_value_type=float, module_import_base="jaqmc.optimizer"
+    )
     max_cond_num: float | None = 1e7
-    spring_mu: Any = module_config(Constant, rate=0.9)
-    march_beta: Any = module_config(Constant, rate=0.5)
+    spring_mu: Any = module_config(
+        0.9, direct_value_type=float, module_import_base="jaqmc.optimizer"
+    )
+    march_beta: Any = module_config(
+        0.5, direct_value_type=float, module_import_base="jaqmc.optimizer"
+    )
     march_mode: Literal["var", "diff"] = "var"
     eps: float = 1e-8
     mixed_precision: bool = True

--- a/src/jaqmc/utils/config.py
+++ b/src/jaqmc/utils/config.py
@@ -68,79 +68,127 @@ def configurable_dataclass(cls=None, *, frozen: bool = False, kw_only: bool = Tr
 
 @dataclass
 class ModuleConfig:
-    """Metadata for a module_config field."""
+    """Metadata describing how a ``module_config`` field is deserialized."""
 
-    default: str
+    default: str | None
     kwargs: dict[str, Any]
+    direct_value_type: Any = None
+    module_import_base: str | None = None
 
 
-def module_config(default_factory, **kwargs):
+def module_config(
+    default_factory,
+    direct_value_type=None,
+    module_import_base: str | None = None,
+    **kwargs,
+):
     """Create a serde field for polymorphic module configuration.
 
     This allows a field to be configured with different implementations
-    at runtime via YAML/dict configuration.
+    at runtime via YAML/dict configuration, while optionally accepting
+    direct scalar values for simple cases.
 
     Args:
-        default_factory: The default class or callable.
-        **kwargs: Default keyword arguments for the factory.
+        default_factory: The default class/callable, or a direct default value when
+            ``direct_value_type`` is enabled.
+        direct_value_type: Optional serde type/schema used when the config value is
+            provided directly instead of as a module-config mapping. Non-dict inputs
+            are deserialized with this type. Pass a normal type expression such as
+            ``float`` or ``float | int`` rather than a runtime tuple like
+            ``(float, int)``. When ``default_factory`` is not callable, dict inputs
+            must include ``module`` explicitly to select an implementation.
+        module_import_base: Base package for module import. Omit to infer from
+            ``default_factory`` if it's callable.
+        **kwargs: Default keyword arguments for the resolved module/dataclass.
 
     Returns:
         A serde field descriptor.
 
     Raises:
         ValueError: If default_factory is not importable by its module path.
+
+    Example::
+
+        learning_rate: Any = module_config(Standard, direct_value_type=float)
+        damping: Any = module_config(Standard, direct_value_type=float | int)
     """
-    default_module = f"{default_factory.__module__}:{default_factory.__name__}"
-    if resolve_object(default_module) is not default_factory:
-        raise ValueError(
-            f'Expected default_factory to be importable via "{default_module}". '
-            f"Got {default_factory}."
-        )
-    base_package = (
-        default_module[: default_module.rfind(".")] if "." in default_module else None
+    default_module = (
+        f"{default_factory.__module__}:{default_factory.__name__}"
+        if callable(default_factory)
+        else None
     )
-    mc = ModuleConfig(default_module, kwargs)
 
     def deserializer(data):
         if not isinstance(data, dict):
-            raise ValueError(
-                f"Something when wrong. Internal representations of dataclasses "
-                f"should be dicts. Got {type(data)}."
-            )
+            return serde.from_dict(direct_value_type, data)
         mod = data.get("module", default_module)
-        cls = resolve_object(mod, package=base_package)
+        if mod is None:
+            raise ValueError(
+                "module_config dict inputs must include 'module' when there is no "
+                "default module."
+            )
+        cls = resolve_object(mod, package=module_import_base)
         config_data = {k: v for k, v in data.items() if k != "module"}
         merged = deep_merge(kwargs, config_data)
         if not is_dataclass(cls):
-            raise ValueError(f"module_config expected dataclasses, not {cls}.")
+            raise ValueError(
+                f"module_config expected a dataclass, but {mod!r} resolved to {cls!r}."
+            )
         return serde.from_dict(cls, merged)
 
     def serializer(instance):
-        if not is_dataclass(instance):
-            raise ValueError(
-                f"module_config expected dataclasses, not {type(instance)}."
-            )
-        result = {
-            "module": f"{type(instance).__module__}:{type(instance).__name__}",
-            **serde.to_dict(instance),
-        }
-        return result
+        return (
+            serde.to_dict(instance)
+            if not is_dataclass(instance)
+            else {
+                "module": f"{type(instance).__module__}:{type(instance).__name__}",
+                **serde.to_dict(instance),
+            }
+        )
 
     def factory():
         # When kwargs are provided, the default_factory must apply them so that
         # pyserde uses the correct defaults when no user config is given.
         if kwargs and is_dataclass(default_factory):
             return serde.from_dict(default_factory, kwargs)
-        elif kwargs:
-            return default_factory(**kwargs)
-        else:
-            return default_factory()
+        return default_factory(**(kwargs or {}))
 
+    metadata = {
+        "module_config": ModuleConfig(
+            default=default_module,
+            kwargs=kwargs,
+            direct_value_type=direct_value_type,
+            module_import_base=module_import_base,
+        )
+    }
+    if not callable(default_factory):
+        return serde_field(
+            default=default_factory,
+            serializer=serializer,
+            deserializer=deserializer,
+            metadata=metadata,
+        )
+    default_module = f"{default_factory.__module__}:{default_factory.__name__}"
+    if resolve_object(default_module) is not default_factory:
+        raise ValueError(
+            f'Expected default_factory to be importable via "{default_module}". '
+            f"Got {default_factory}."
+        )
+    module_import_base = module_import_base or (
+        default_module[: default_module.rfind(".")] if "." in default_module else None
+    )
     return serde_field(
         default_factory=factory,
         serializer=serializer,
         deserializer=deserializer,
-        metadata={"module_config": mc},
+        metadata={
+            "module_config": ModuleConfig(
+                default=default_module,
+                kwargs=kwargs,
+                direct_value_type=direct_value_type,
+                module_import_base=module_import_base,
+            )
+        },
     )
 
 

--- a/tests/hydrogen/atom_test.py
+++ b/tests/hydrogen/atom_test.py
@@ -34,7 +34,7 @@ def test_simple_run(tmp_path, optimizer, lr):
             "workflow": {"save_path": str(tmp_path), "batch_size": 128},
             "train": {
                 "run": {},
-                "optim": {"module": optimizer, "learning_rate": {"rate": lr}},
+                "optim": {"module": optimizer, "learning_rate": lr},
             },
         }
     )

--- a/tests/utils/config_test.py
+++ b/tests/utils/config_test.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 import yaml
+from serde.compat import SerdeError
 
 from jaqmc.utils.config import ConfigManager, configurable_dataclass, module_config
 
@@ -399,6 +400,21 @@ class OuterClass:
     mid: Any = module_config(MidClass)
 
 
+@configurable_dataclass
+class DirectValueLeaf:
+    rate: float = 0.5
+
+
+@configurable_dataclass
+class DirectValueUnionConfig:
+    value: Any = module_config(DirectValueLeaf, direct_value_type=int | float)
+
+
+@configurable_dataclass
+class DirectValueScalarDefaultConfig:
+    plain_default_value: Any = module_config(1.0, direct_value_type=float)
+
+
 def _module_ref(obj: type | Any) -> str:
     return f"{__name__}:{obj.__name__}"
 
@@ -473,6 +489,96 @@ def test_nesed_module_missing_field(recursive_module_mock):
     assert mid_instance.one.y == 999
 
     cfg.finalize()
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "expected_type"),
+    [(4, int), (3.75, float)],
+)
+def test_module_config_direct_value_union_accepts_scalars(raw_value, expected_type):
+    cfg = ConfigManager({"section": {"value": raw_value}})
+
+    result = cfg.get("section", default=DirectValueUnionConfig())
+
+    assert type(result.value) is expected_type
+    assert result.value == raw_value
+    assert cfg.resolved_config["section"] == {"value": raw_value}
+
+    cfg2 = _yaml_roundtrip(cfg)
+    result2 = cfg2.get("section", default=DirectValueUnionConfig())
+    assert type(result2.value) is expected_type
+    assert result2.value == raw_value
+    cfg2.finalize()
+
+
+def test_module_config_direct_value_union_keeps_dict_input_as_module_config():
+    cfg = ConfigManager({"section": {"value": {"rate": 1.25}}})
+
+    result = cfg.get("section", default=DirectValueUnionConfig())
+
+    assert isinstance(result.value, DirectValueLeaf)
+    assert result.value.rate == pytest.approx(1.25)
+    assert cfg.resolved_config["section"] == {
+        "value": {
+            "module": _module_ref(DirectValueLeaf),
+            "rate": 1.25,
+        }
+    }
+
+    cfg2 = _yaml_roundtrip(cfg)
+    result2 = cfg2.get("section", default=DirectValueUnionConfig())
+    assert isinstance(result2.value, DirectValueLeaf)
+    assert result2.value.rate == pytest.approx(1.25)
+    cfg2.finalize()
+
+
+def test_module_config_direct_value_union_rejects_string_input():
+    cfg = ConfigManager({"section": {"value": "4.5"}})
+
+    with pytest.raises(SerdeError, match=r"Union\[int, float\]"):
+        cfg.get("section", default=DirectValueUnionConfig())
+
+
+def test_module_config_plain_default_value_supports_noncallable_default():
+    cfg = ConfigManager({})
+
+    result = cfg.get("section", default=DirectValueScalarDefaultConfig())
+
+    assert type(result.plain_default_value) is float
+    assert result.plain_default_value == pytest.approx(1.0)
+    assert cfg.resolved_config["section"] == {"plain_default_value": 1.0}
+
+
+def test_module_config_uses_explicit_module_import_base(mocker):
+    relative_module = "relative_leaf:DirectValueLeaf"
+    resolve_object = mocker.patch(
+        "jaqmc.utils.config.resolve_object",
+        return_value=DirectValueLeaf,
+    )
+
+    @configurable_dataclass
+    class RelativeModuleConfig:
+        value: Any = module_config(
+            DirectValueLeaf,
+            module_import_base="custom.base",
+        )
+
+    cfg = ConfigManager(
+        {
+            "section": {
+                "value": {
+                    "module": relative_module,
+                    "rate": 1.25,
+                }
+            }
+        }
+    )
+
+    result = cfg.get("section", default=RelativeModuleConfig())
+
+    assert isinstance(result.value, DirectValueLeaf)
+    assert result.value.rate == pytest.approx(1.25)
+    resolve_object.assert_any_call(relative_module, package="custom.base")
 
 
 # --- YAML round-trip tests (resume-from-yaml scenario) ---


### PR DESCRIPTION
Let module_config fields accept plain scalar values like `0.1` or `"fixed"` as well as nested `module: ...` configs. This makes optimizer settings such as learning rates and damping easier to write.