### PR TITLE
clip with median absolute deviation by default

### DIFF
--- a/docs/api-reference/utilities.md
+++ b/docs/api-reference/utilities.md
@@ -30,8 +30,9 @@ Wrappers for extracting real/imaginary parts and handling complex-valued JAX fun
 ## Clipping
 
 ```{eval-rst}
+.. autofunction:: jaqmc.utils.clip.clip_observable
+.. autofunction:: jaqmc.utils.clip.mad_clip
 .. autofunction:: jaqmc.utils.clip.iqr_clip
-.. autofunction:: jaqmc.utils.clip.iqr_clip_real
 ```
 
 ## Units

--- a/docs/guide/estimators/loss-grad.md
+++ b/docs/guide/estimators/loss-grad.md
@@ -24,11 +24,15 @@ The $\langle E_L \rangle$ baseline arises from differentiating the ratio $\langl
 
 ## Outlier clipping
 
-Before computing the gradient, local energies are clipped using the interquartile range (IQR) to suppress extreme outliers. Any local energy falling outside $[Q_1 - s \cdot \mathrm{IQR},\; Q_3 + s \cdot \mathrm{IQR}]$ is clamped to the nearest boundary, where $Q_1$ and $Q_3$ are the first and third quartiles and $s$ is the `clip_scale` parameter.
+Before computing the gradient, `LossAndGrad` can clip local energies to suppress extreme outliers. This affects the gradient only; the reported loss remains the unclipped energy average. The following methods can be chosen via `clip_method`:
 
-The default `clip_scale` of 5 is permissive enough to leave most walkers untouched while preventing rare walkers in low-probability regions from dominating the gradient. Decreasing it clips more aggressively, which stabilises gradients but biases the energy estimate. Setting a very large value (e.g. `1e8`) effectively disables clipping.
+- `mad` (Default): clips to $[\mathrm{median}(E_L) - s \cdot \mathrm{median}(|E_L - \mathrm{median}(E_L)|),\; \mathrm{median}(E_L) + s \cdot \mathrm{median}(|E_L - \mathrm{median}(E_L)|)]$.
+- `iqr`: clips to $[Q_1 - s \cdot \mathrm{IQR},\; Q_3 + s \cdot \mathrm{IQR}]$, where $Q_1$ and $Q_3$ are the quartiles and `s` is `clip_scale`.
+- `none`: disables clipping entirely.
+
+It's also possible to decrease `clip_scale` to clip more aggressively, which stabilises gradients but biases the estimator. Setting `clip_method="none"` disables clipping explicitly.
 
 ## See also
 
-- Configuration: [Molecule](#train-grads), [Solid](#solid-train-grads)
+- Configuration: [Molecule](#train-grads), [Solid](#solid-train-grads), [Hall](../../systems/hall/train.md)
 - API: {class}`~jaqmc.estimator.loss_grad.LossAndGrad`

--- a/docs/guide/optimizers/index.md
+++ b/docs/guide/optimizers/index.md
@@ -91,7 +91,7 @@ train.optim.learning_rate.rate=0.01 train.optim.learning_rate.delay=5000
 **`schedule:Constant`** - fixed learning rate throughout training. Override with `train.optim.learning_rate.rate` (default 0.05).
 
 ```{note}
-The optimizer controls how gradients are *applied*. Gradient *estimation*, including outlier clipping via `clip_scale`, is handled separately. See <project:../estimators/loss-grad.md> for how gradients are computed and stabilised before the optimizer sees them.
+The optimizer controls how gradients are *applied*. Gradient *estimation*, including loss clipping via `train.grads.clip_method` and `train.grads.clip_scale`, is handled separately. See <project:../estimators/loss-grad.md> for how gradients are computed and stabilised before the optimizer sees them.
 ```
 
 ## See Also

--- a/docs/systems/hall/train.md
+++ b/docs/systems/hall/train.md
@@ -152,13 +152,15 @@ The train stage enables `console`, `csv`, and `hdf5` writers by default.
    :prefix: train.writers.hdf5
 ```
 
-### Loss gradients
+### Loss gradients (`train.grads.*`)
 
-The workflow wires {py:obj}`~jaqmc.estimator.loss_grad.LossAndGrad`
-automatically. When angular momentum penalties are enabled
-(`system.lz_penalty` or `system.l2_penalty`), the loss key is set to
-`penalized_loss`; otherwise it defaults to `total_energy`. There is no
-user-facing `train.grads.*` schema for hall workflows.
+The workflow resolves {py:obj}`~jaqmc.estimator.loss_grad.LossAndGrad`
+from `train.grads.*`. See [Loss and gradient](../../guide/estimators/loss-grad.md) for the clipping formulas.
+
+```{eval-rst}
+.. config-defaults:: jaqmc.estimator.loss_grad.LossAndGrad
+   :prefix: train.grads
+```
 
 ---
 

--- a/src/jaqmc/app/hall/workflow.py
+++ b/src/jaqmc/app/hall/workflow.py
@@ -47,6 +47,7 @@ class HallTrainWorkflow(VMCWorkflow):
             "train": {
                 "run": {"iterations": 200_000},
                 "writers": {"console": {"fields": console_fields}},
+                "grads": {"clip_scale": 100, "clip_method": "iqr"},
             }
         }
 
@@ -67,7 +68,8 @@ class HallTrainWorkflow(VMCWorkflow):
         train.configure_optimizer(default=KFACOptimizer, f_log_psi=wf.logpsi)
         train.configure_estimators(**estimators)
         train.configure_loss_grads(
-            LossAndGrad(loss_key=loss_key, clip_scale=100), f_log_psi=wf.logpsi
+            cfg.scoped("train").get("grads", LossAndGrad(loss_key=loss_key)),
+            f_log_psi=wf.logpsi,
         )
         self.train_stage = train.build()
 

--- a/src/jaqmc/estimator/loss_grad.py
+++ b/src/jaqmc/estimator/loss_grad.py
@@ -3,7 +3,7 @@
 
 from collections.abc import Mapping
 from functools import partial
-from typing import Any
+from typing import Any, Literal
 
 import jax
 import optax
@@ -14,7 +14,7 @@ from jaqmc.data import Data
 from jaqmc.estimator.base import PerWalkerEstimator, mean_reduce
 from jaqmc.utils import parallel_jax
 from jaqmc.utils.array import match_first_axis_of
-from jaqmc.utils.clip import iqr_clip
+from jaqmc.utils.clip import clip_observable
 from jaqmc.utils.config import configurable_dataclass
 from jaqmc.utils.func_transform import transform_maybe_complex
 from jaqmc.utils.wiring import runtime_dep
@@ -41,26 +41,29 @@ class LossAndGrad(PerWalkerEstimator):
 
     1. ``evaluate_single_walker`` — evaluates :math:`\log\psi` and its
        parameter gradient for each walker, and reads the loss value.
-    2. ``reduce`` — applies IQR clipping to the local energies for
-       outlier robustness, then forms the per-walker product
+    2. ``reduce`` — optionally clips the local energies for outlier
+       robustness, then forms the per-walker product
        :math:`\nabla\log\psi \cdot E_L^{\text{clipped}}`.
     3. ``finalize`` — averages over walkers and subtracts the baseline
        to assemble the final gradient.
 
     Args:
         loss_key: Key in prev_walker_stats to use as the loss.
-        clip_scale: Multiplier on the interquartile range (IQR) that sets
-            the clipping window for local energies. A walker whose energy
-            falls outside :math:`[Q_1 - s \cdot \text{IQR},\;
-            Q_3 + s \cdot \text{IQR}]` is clipped to that boundary.
+        clip_method: Outlier clipping rule used for gradient weighting.
+            ``"iqr"`` clips to :math:`[Q_1 - s \cdot \text{IQR},\;
+            Q_3 + s \cdot \text{IQR}]`. ``"mad"`` clips to
+            :math:`\mathrm{median}(E_L) \pm s \cdot
+            \mathrm{median}(|E_L - \mathrm{median}(E_L)|)`.
+            ``"none"`` disables clipping.
+        clip_scale: Width multiplier for the selected clipping window.
             Smaller values clip more aggressively, which stabilises
-            gradients but biases the energy estimate. The default of 5.0
-            is a common choice; set to a large value (e.g. 1e8) to
-            effectively disable clipping.
+            gradients but biases the estimator. Ignored when
+            ``clip_method="none"``.
         f_log_psi: Log-psi function to differentiate (runtime dep).
     """
 
     loss_key: str = "total_energy"
+    clip_method: Literal["iqr", "mad", "none"] = "mad"
     clip_scale: float = 5.0
     f_log_psi: NumericWavefunctionEvaluate = runtime_dep()
 
@@ -91,7 +94,9 @@ class LossAndGrad(PerWalkerEstimator):
         }, state
 
     def reduce(self, walker_stats: Mapping[str, Any]) -> dict[str, Any]:
-        clipped_loss = iqr_clip(walker_stats["loss"], scale=self.clip_scale)
+        clipped_loss = clip_observable(
+            walker_stats["loss"], self.clip_method, scale=self.clip_scale
+        )
         grad_logpsi_and_loss = jax.tree.map(
             lambda x: jnp.real(jnp.conj(x) * match_first_axis_of(clipped_loss, x)),
             walker_stats["grad_logpsi"],

--- a/src/jaqmc/utils/clip.py
+++ b/src/jaqmc/utils/clip.py
@@ -1,14 +1,24 @@
 # Copyright (c) 2025-2026 Bytedance Ltd. and/or its affiliates
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Literal
+
 import jax
 from jax import numpy as jnp
 
 from jaqmc.utils.parallel_jax import BATCH_AXIS_NAME
 
 
-def iqr_clip_real(x: jnp.ndarray, scale=100.0) -> jnp.ndarray:
-    """Returns the clipped the observables based on interquartile range (IQR)."""
+def iqr_clip(x: jnp.ndarray, scale: float = 100.0) -> jnp.ndarray:
+    """Clip observables using an interquartile-range window.
+
+    For complex numbers, the clip is applied on real and imag parts separately.
+
+    Returns:
+        Values clipped to the IQR-based window.
+    """
+    if jnp.iscomplexobj(x):
+        return iqr_clip(x.real, scale) + 1j * iqr_clip(x.imag, scale)
     all_x = jax.lax.all_gather(x, axis_name=BATCH_AXIS_NAME, tiled=True)
     q1 = jnp.nanquantile(all_x, 0.25)
     q3 = jnp.nanquantile(all_x, 0.75)
@@ -16,11 +26,44 @@ def iqr_clip_real(x: jnp.ndarray, scale=100.0) -> jnp.ndarray:
     return jnp.clip(x, q1 - scale * iqr, q3 + scale * iqr)
 
 
-def iqr_clip(x: jnp.ndarray, scale=100.0) -> jnp.ndarray:
-    """Returns the clipped complex observables by applying IQR clip.
+def mad_clip(x: jnp.ndarray, scale: float = 100.0) -> jnp.ndarray:
+    """Clip observables using a median absulute deviation window.
 
-    The clip is applied on real and imag parts separately.
+    For complex numbers, the clip is applied on real and imag parts separately.
+
+    Returns:
+        Values clipped to the median-centered mean-abs-deviation window.
     """
-    if jnp.isrealobj(x):
-        return iqr_clip_real(x, scale)
-    return iqr_clip_real(x.real, scale) + 1j * iqr_clip_real(x.imag, scale)
+    if jnp.iscomplexobj(x):
+        return mad_clip(x.real, scale) + 1j * mad_clip(x.imag, scale)
+    all_x = jax.lax.all_gather(x, axis_name=BATCH_AXIS_NAME, tiled=True)
+    median = jnp.nanmedian(all_x)
+    absdev = jnp.nanmedian(jnp.abs(all_x - median))
+    return jnp.clip(x, median - scale * absdev, median + scale * absdev)
+
+
+def clip_observable(
+    x: jnp.ndarray,
+    method: Literal["iqr", "mad", "none"],
+    scale: float = 100.0,
+) -> jnp.ndarray:
+    """Clip observables with a named method.
+
+    Args:
+        x: Observable values to clip.
+        method: One of ``"iqr"``, ``"mad"``, or ``"none"``.
+        scale: Width multiplier for methods that use a clipping window.
+
+    Returns:
+        Clipped values, or the original values when ``method`` is ``"none"``.
+
+    Raises:
+        ValueError: If ``method`` is unknown.
+    """
+    if method == "iqr":
+        return iqr_clip(x, scale)
+    if method == "mad":
+        return mad_clip(x, scale)
+    if method == "none":
+        return x
+    raise ValueError(f"Unknown clip method {method!r}.")

--- a/tests/estimator/loss_grad_test.py
+++ b/tests/estimator/loss_grad_test.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2025-2026 Bytedance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import yaml
+from jax import lax
+from jax import numpy as jnp
+
+from jaqmc.app.hall import HallTrainWorkflow
+from jaqmc.estimator.loss_grad import LossAndGrad
+from jaqmc.utils.clip import clip_observable
+from jaqmc.utils.config import ConfigManager
+
+
+def _mock_all_gather_identity(monkeypatch):
+    monkeypatch.setattr(
+        lax,
+        "all_gather",
+        lambda x, axis_name, tiled=True: x,
+    )
+
+
+def test_clip_observable_iqr(monkeypatch):
+    _mock_all_gather_identity(monkeypatch)
+    x = jnp.array([0.0, 1.0, 2.0, 100.0])
+    q1 = jnp.nanquantile(x, 0.25)
+    q3 = jnp.nanquantile(x, 0.75)
+    expected = jnp.clip(x, q1 - (q3 - q1), q3 + (q3 - q1))
+
+    clipped = clip_observable(x, "iqr", scale=1.0)
+
+    np.testing.assert_allclose(clipped, expected)
+
+
+def test_clip_observable_mad_complex(monkeypatch):
+    _mock_all_gather_identity(monkeypatch)
+    x = jnp.array([0.0 + 100.0j, 1.0 + 1.0j, 2.0 + 2.0j, 100.0 + 0.0j])
+    real = x.real
+    imag = x.imag
+    real_median = jnp.nanmedian(real)
+    imag_median = jnp.nanmedian(imag)
+    real_absdev = jnp.nanmedian(jnp.abs(real - real_median))
+    imag_absdev = jnp.nanmedian(jnp.abs(imag - imag_median))
+    expected = jnp.clip(
+        real, real_median - real_absdev, real_median + real_absdev
+    ) + 1j * jnp.clip(imag, imag_median - imag_absdev, imag_median + imag_absdev)
+
+    clipped = clip_observable(x, "mad", scale=1.0)
+
+    np.testing.assert_allclose(clipped, expected)
+
+
+def test_clip_observable_none_is_noop(monkeypatch):
+    _mock_all_gather_identity(monkeypatch)
+    x = jnp.array([0.0, 1.0, 2.0, 100.0])
+
+    clipped = clip_observable(x, "none", scale=0.01)
+
+    np.testing.assert_allclose(clipped, x)
+
+
+def test_loss_and_grad_reduce_uses_selected_clip_method(monkeypatch):
+    _mock_all_gather_identity(monkeypatch)
+    losses = jnp.array([0.0, 1.0, 2.0, 100.0])
+    grads = {"w": jnp.array([1.0, 2.0, 3.0, 4.0])}
+    estimator = LossAndGrad(clip_method="mad", clip_scale=1.0)
+    expected_clipped = clip_observable(losses, "mad", scale=1.0)
+
+    reduced = estimator.reduce({"loss": losses, "grad_logpsi": grads})
+
+    np.testing.assert_allclose(reduced["loss"], jnp.mean(losses))
+    np.testing.assert_allclose(reduced["clipped_loss"], jnp.mean(expected_clipped))
+    np.testing.assert_allclose(
+        reduced["grad_logpsi_and_loss"]["w"],
+        jnp.mean(grads["w"] * expected_clipped),
+    )
+
+
+def test_loss_and_grad_config_roundtrip_preserves_clip_method():
+    cfg = ConfigManager({"grads": {"clip_method": "mad", "clip_scale": 7.0}})
+    grads = cfg.get("grads", LossAndGrad())
+
+    assert grads.clip_method == "mad"
+    np.testing.assert_allclose(grads.clip_scale, 7.0)
+
+    cfg2 = ConfigManager(yaml.safe_load(cfg.to_yaml()))
+    grads2 = cfg2.get("grads", LossAndGrad())
+
+    assert grads2.clip_method == "mad"
+    np.testing.assert_allclose(grads2.clip_scale, 7.0)
+    cfg2.finalize()
+
+
+def test_hall_workflow_default_loss_grads():
+    workflow = HallTrainWorkflow(ConfigManager({}))
+    grads = workflow.train_stage.estimators.estimators["grads"]
+
+    assert isinstance(grads, LossAndGrad)
+    assert grads.loss_key == "total_energy"
+    assert grads.clip_method == "iqr"
+    assert grads.clip_scale == 100
+
+
+def test_hall_workflow_penalty_default_loss_key():
+    workflow = HallTrainWorkflow(ConfigManager({"system": {"lz_penalty": 1.0}}))
+    grads = workflow.train_stage.estimators.estimators["grads"]
+
+    assert grads.loss_key == "penalized_loss"
+
+
+def test_hall_workflow_train_grads_override():
+    workflow = HallTrainWorkflow(
+        ConfigManager(
+            {
+                "train": {
+                    "grads": {
+                        "clip_method": "none",
+                        "clip_scale": 7.0,
+                    }
+                }
+            }
+        )
+    )
+    grads = workflow.train_stage.estimators.estimators["grads"]
+
+    assert grads.clip_method == "none"
+    np.testing.assert_allclose(grads.clip_scale, 7.0)


### PR DESCRIPTION
Clip the energy based on median and mean absolute deviation from the median before sending them to gradient calculations. This aligns with common practices in FermiNet, LapNet, etc. for molecules.