### PR TITLE
add wandb scalar writer

### DIFF
--- a/docs/api-reference/writers.md
+++ b/docs/api-reference/writers.md
@@ -1,6 +1,10 @@
 # Writers
 
-Writers record training statistics at each step. JaQMC ships with console, CSV, and HDF5 writers. See <project:../guide/writers.md> for background on output files and customizing console output.
+Writers record training statistics at each step. JaQMC includes console, CSV,
+HDF5, and Weights & Biases writers. Install the `wandb` package separately in
+the same environment as JaQMC before using the W&B writer. See
+<project:../guide/writers.md> for background on output files and configuring
+writers.
 
 ## Configuration
 
@@ -31,6 +35,10 @@ For writer config keys, see the configuration reference: [Molecule](#train-write
    :show-inheritance:
 
 .. autoclass:: jaqmc.writer.hdf5.HDF5Writer
+   :members:
+   :show-inheritance:
+
+.. autoclass:: jaqmc.writer.wandb.WandbWriter
    :members:
    :show-inheritance:
 ```

--- a/docs/extending/custom-components/writers.md
+++ b/docs/extending/custom-components/writers.md
@@ -57,6 +57,7 @@ class MyWriter(Writer):
 - {class}`~jaqmc.writer.console.ConsoleWriter` — simplest writer. Shows `to_scalar()` usage and selective field display.
 - {class}`~jaqmc.writer.csv.CSVWriter` — file-based writer. Shows `open()` with file handle management and header writing.
 - {class}`~jaqmc.writer.hdf5.HDF5Writer` — chunked array writes. Shows `initial_step` handling for checkpoint truncation.
+- {class}`~jaqmc.writer.wandb.WandbWriter` — external service writer. Shows scalar filtering, W&B run lifecycle, and an optional dependency that must be installed separately.
 
 ## See Also
 

--- a/docs/guide/writers.md
+++ b/docs/guide/writers.md
@@ -5,12 +5,14 @@ Writers record statistics produced during training. The built-in writers are:
 - **Console** — Prints selected fields to the terminal.
 - **CSV** — Appends scalar statistics to a CSV file (e.g., `train_stats.csv`) in the output directory.
 - **HDF5** — Appends all statistics (including array-valued fields) to an HDF5 file (e.g., `train_stats.h5`) in the output directory.
+- **W&B** — Sends scalar statistics to Weights & Biases.
 
 Which writers are active depends on the workflow. Use `--dry-run` to see the resolved config — the `writers` section shows what is enabled. To disable a writer, set it to `null`; to re-enable one that isn't active, set its module path:
 
 ```bash
 train.writers.hdf5=null                              # disable HDF5 for train
 train.writers.csv.module=jaqmc.writer.csv:CSVWriter   # enable CSV for train
+train.writers.wandb.module=jaqmc.writer.wandb:WandbWriter  # enable W&B for train
 pretrain.writers.console.interval=10                  # configure pretrain's console writer
 ```
 
@@ -46,6 +48,32 @@ head -n 1 runs/my-run/train_stats.csv
 ```
 
 Array-valued outputs, such as histograms, do not appear in CSV and cannot be printed in the console. Use the HDF5 file to inspect those keys instead.
+
+## Weights & Biases
+
+The W&B writer logs real-valued scalar statistics to Weights & Biases. It is
+not enabled by default.
+
+Install `wandb` manually in the same Python environment where JaQMC is
+installed:
+
+```bash
+uv pip install wandb
+# or, after activating the JaQMC environment:
+pip install wandb
+```
+
+Then enable the writer and set the W&B project metadata you want:
+
+```bash
+train.writers.wandb.module=jaqmc.writer.wandb:WandbWriter
+train.writers.wandb.project=my-project
+train.writers.wandb.run_name=my-run
+```
+
+When enabled, the W&B writer creates a W&B run for the stage and logs the stage
+name as the W&B job type. In advanced programmatic setups, if a W&B run is
+already active before JaQMC starts the stage, the writer reuses that run.
 
 ## Output Files
 

--- a/src/jaqmc/writer/wandb.py
+++ b/src/jaqmc/writer/wandb.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2025-2026 Bytedance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+from collections.abc import Mapping
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from jax import numpy as jnp
+from upath import UPath
+
+from jaqmc.utils.config import configurable_dataclass
+from jaqmc.writer.base import Writer
+
+__all__ = ["WandbWriter"]
+
+
+@configurable_dataclass
+class WandbWriter(Writer):
+    """Logs scalar statistics to Weights & Biases.
+
+    The writer starts one W&B run for the JaQMC stage and sends the stage name
+    as the W&B job type so training and evaluation runs can be filtered by
+    stage. In advanced programmatic setups, if a W&B run is already active
+    before JaQMC starts the stage, the writer reuses that run.
+
+    Advanced W&B settings should stay in W&B's normal configuration layer:
+    use ``WANDB_ENTITY`` for the account or team, ``WANDB_MODE=offline`` for
+    offline logging, and ``WANDB_RUN_ID``/``WANDB_RESUME`` for resuming a run.
+
+    Args:
+        project: W&B project that contains related JaQMC runs. Use the same
+            project when you want runs to appear together for comparison. If
+            omitted, W&B uses its configured default or infers one.
+        run_name: Optional display name for this run inside the project. If
+            omitted, W&B generates a short readable name.
+    """
+
+    project: str | None = None
+    run_name: str | None = None
+
+    def __post_init__(self) -> None:
+        self._run: Any | None = None
+
+    @contextmanager
+    def open(
+        self,
+        working_dir: UPath | Path,
+        stage_name: str,
+        initial_step: int = 0,
+    ):
+        del initial_step
+        wandb = self._import_wandb()
+        active_run = getattr(wandb, "run", None)
+
+        if active_run is not None:
+            self._run = active_run
+            try:
+                yield
+            finally:
+                self._run = None
+        else:
+            init_kwargs = self._init_kwargs(working_dir, stage_name)
+            self._run = wandb.init(**init_kwargs)
+            try:
+                yield
+            finally:
+                self._run.finish()
+                self._run = None
+
+    @staticmethod
+    def _import_wandb() -> Any:
+        try:
+            return importlib.import_module("wandb")
+        except ImportError as e:
+            raise ImportError(
+                "WandbWriter requires the 'wandb' package. Install it with "
+                "`uv add wandb` or include it in your runtime environment."
+            ) from e
+
+    def _init_kwargs(
+        self, working_dir: UPath | Path, stage_name: str
+    ) -> dict[str, Any]:
+        init_kwargs: dict[str, Any] = {
+            "dir": str(working_dir),
+            "job_type": stage_name,
+        }
+        optional_kwargs = {
+            "project": self.project,
+            "name": self.run_name,
+        }
+        init_kwargs.update(
+            {key: value for key, value in optional_kwargs.items() if value is not None}
+        )
+        return init_kwargs
+
+    def write(self, step: int, stats: Mapping[str, Any]) -> None:
+        """Log scalar statistics to the active W&B run.
+
+        Args:
+            step: Current iteration step.
+            stats: Statistics dictionary. Python scalars and scalar arrays are
+                logged; non-scalar values are skipped.
+
+        Raises:
+            ValueError: If called outside the :meth:`open` context manager.
+        """
+        if not self._run:
+            raise ValueError("Writing on closed W&B run.")
+
+        scalar_stats = {}
+        for key, value in stats.items():
+            if jnp.isscalar(value) and jnp.isrealobj(value):
+                scalar_stats[key] = self.to_scalar(value)
+
+        if scalar_stats:
+            self._run.log(scalar_stats, step=step)

--- a/tests/writer/writer_test.py
+++ b/tests/writer/writer_test.py
@@ -1,13 +1,41 @@
 # Copyright (c) 2025-2026 Bytedance Ltd. and/or its affiliates
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
 from pathlib import Path
+from types import ModuleType
 
 import h5py
 import pytest
+from jax import numpy as jnp
 
 from jaqmc.writer.csv import CSVWriter
 from jaqmc.writer.hdf5 import HDF5Writer
+from jaqmc.writer.wandb import WandbWriter
+
+
+class FakeWandbRun:
+    def __init__(self):
+        self.logs = []
+        self.finished = False
+
+    def log(self, data, step=None):
+        self.logs.append((data, step))
+
+    def finish(self):
+        self.finished = True
+
+
+class FakeWandb(ModuleType):
+    def __init__(self):
+        super().__init__("wandb")
+        self.run = None
+        self.init_kwargs = None
+
+    def init(self, **kwargs):
+        self.init_kwargs = kwargs
+        self.run = FakeWandbRun()
+        return self.run
 
 
 def test_csv_writer_path_template(tmp_path: Path):
@@ -37,3 +65,37 @@ def test_csv_writer_rejects_unknown_template_field(tmp_path: Path):
         writer.open(tmp_path, "train"),
     ):
         pass
+
+
+def test_wandb_writer_logs_only_scalars(tmp_path: Path, monkeypatch):
+    fake_wandb = FakeWandb()
+    monkeypatch.setitem(sys.modules, "wandb", fake_wandb)
+
+    writer = WandbWriter(project="project", run_name="run")
+
+    with writer.open(tmp_path, "train"):
+        writer.write(3, {"loss": 1.5, "vector": jnp.ones(2), "acceptance": 0.25})
+
+    assert fake_wandb.init_kwargs == {
+        "dir": str(tmp_path),
+        "job_type": "train",
+        "project": "project",
+        "name": "run",
+    }
+    assert fake_wandb.run.logs == [({"loss": 1.5, "acceptance": 0.25}, 3)]
+    assert fake_wandb.run.finished
+
+
+def test_wandb_writer_reuses_active_run(tmp_path: Path, monkeypatch):
+    fake_wandb = FakeWandb()
+    fake_wandb.run = FakeWandbRun()
+    monkeypatch.setitem(sys.modules, "wandb", fake_wandb)
+
+    writer = WandbWriter(project="unused")
+
+    with writer.open(tmp_path, "train"):
+        writer.write(2, {"loss": 1.0})
+
+    assert fake_wandb.init_kwargs is None
+    assert fake_wandb.run.logs == [({"loss": 1.0}, 2)]
+    assert not fake_wandb.run.finished


### PR DESCRIPTION
The W&B writer logs real-valued scalar statistics to Weights & Biases. It is not enabled by default, and the users should install `wandb` manually.