### PR TITLE
custom data fields in density and spin estimators

### DIFF
--- a/src/jaqmc/app/hall/estimator/pair_correlation.py
+++ b/src/jaqmc/app/hall/estimator/pair_correlation.py
@@ -21,6 +21,7 @@ from jaqmc.array_types import PRNGKey
 from jaqmc.data import BatchedData, Data
 from jaqmc.estimator.base import Estimator
 from jaqmc.utils.config import configurable_dataclass
+from jaqmc.utils.wiring import runtime_dep
 
 
 @configurable_dataclass
@@ -33,9 +34,12 @@ class PairCorrelation(Estimator):
 
     Args:
         bins: Number of histogram bins.
+        data_field: Name of the coordinate field (runtime dep, default
+            ``"electrons"``).
     """
 
     bins: int = 200
+    data_field: str = runtime_dep(default="electrons")
 
     def init(self, data: Data, rngs: PRNGKey) -> jnp.ndarray:
         return jnp.zeros(self.bins)
@@ -49,7 +53,7 @@ class PairCorrelation(Estimator):
         rngs: PRNGKey,
     ) -> tuple[dict[str, Any], jnp.ndarray]:
         del params, prev_walker_stats, rngs
-        electrons = batched_data.data.electrons
+        electrons = batched_data.data[self.data_field]
         batch_size, nelec, _ = electrons.shape
         theta, phi = electrons[..., 0], electrons[..., 1]
 

--- a/src/jaqmc/estimator/density/cartesian.py
+++ b/src/jaqmc/estimator/density/cartesian.py
@@ -10,6 +10,7 @@ from jax import numpy as jnp
 from jaqmc.data import Data
 from jaqmc.estimator.histogram import HistogramEstimator
 from jaqmc.utils.config import configurable_dataclass
+from jaqmc.utils.wiring import runtime_dep
 
 
 @configurable_dataclass
@@ -44,9 +45,12 @@ class CartesianDensity(HistogramEstimator):
             Set a value to ``None`` to disable an axis inherited from
             defaults (e.g. when the workflow provides x/y/z but you
             only want z).
+        data_field: Field name holding Cartesian coordinates in the
+            structured :class:`~jaqmc.data.Data` object.
     """
 
     axes: dict[str, CartesianAxis | None] = field(default_factory=dict)
+    data_field: str = runtime_dep(default="electrons")
 
     def _sorted_axes(self) -> list[CartesianAxis]:
         return [a for a in self.axes.values() if a is not None]
@@ -63,4 +67,4 @@ class CartesianDensity(HistogramEstimator):
         axes = self._sorted_axes()
         dirs = jnp.array([a.direction for a in axes])
         dirs = dirs / jnp.linalg.norm(dirs, axis=-1, keepdims=True)
-        return data["electrons"] @ dirs.T
+        return data[self.data_field] @ dirs.T

--- a/src/jaqmc/estimator/density/fractional.py
+++ b/src/jaqmc/estimator/density/fractional.py
@@ -50,10 +50,14 @@ class FractionalDensity(HistogramEstimator):
             defaults.
         inv_lattice: Inverse lattice matrix, shape ``(3, 3)``.
             Set by the workflow via :func:`~jaqmc.utils.wiring.wire`.
+        data_field: Field name holding Cartesian coordinates in the
+            structured :class:`~jaqmc.data.Data` object.
     """
 
     axes: dict[str, FractionalAxis | None] = field(default_factory=dict)
     inv_lattice: jnp.ndarray = runtime_dep()
+    data_field: str = runtime_dep(default="electrons")
+    name: str = "density"
 
     def _sorted_axes(self) -> list[FractionalAxis]:
         return sorted(
@@ -70,6 +74,6 @@ class FractionalDensity(HistogramEstimator):
         return bins, ranges
 
     def extract(self, data: Data) -> jnp.ndarray:
-        frac = data["electrons"] @ self.inv_lattice.T % 1.0
+        frac = data[self.data_field] @ self.inv_lattice.T % 1.0
         indices = jnp.array([a.lattice_index for a in self._sorted_axes()])
         return frac[..., indices]

--- a/src/jaqmc/estimator/density/spherical.py
+++ b/src/jaqmc/estimator/density/spherical.py
@@ -10,6 +10,7 @@ from jax import numpy as jnp
 from jaqmc.data import Data
 from jaqmc.estimator.histogram import HistogramEstimator
 from jaqmc.utils.config import configurable_dataclass
+from jaqmc.utils.wiring import runtime_dep
 
 
 @configurable_dataclass
@@ -26,10 +27,13 @@ class SphericalDensity(HistogramEstimator):
         bins_theta: Number of bins for the polar angle.
         bins_phi: Number of bins for the azimuthal angle.
             ``None`` (default) produces a 1-D theta-only histogram.
+        data_field: Field name holding spherical coordinates in the
+            structured :class:`~jaqmc.data.Data` object.
     """
 
     bins_theta: int = 50
     bins_phi: int | None = None
+    data_field: str = runtime_dep(default="electrons")
 
     def _histogram_spec(
         self,
@@ -40,4 +44,4 @@ class SphericalDensity(HistogramEstimator):
 
     def extract(self, data: Data) -> jnp.ndarray:
         ndim = 1 if self.bins_phi is None else 2
-        return data["electrons"][..., :ndim]
+        return data[self.data_field][..., :ndim]

--- a/src/jaqmc/estimator/spin.py
+++ b/src/jaqmc/estimator/spin.py
@@ -46,11 +46,14 @@ class SpinSquared(PerWalkerEstimator):
         n_down: Number of spin-down electrons.
         phase_logpsi: Wavefunction evaluate function returning
             ``(sign, log|psi|)`` (runtime dep).
+        data_field: Name of the coordinate field (runtime dep, default
+            ``"electrons"``).
     """
 
     n_up: int = runtime_dep()
     n_down: int = runtime_dep()
     phase_logpsi: Any = runtime_dep()
+    data_field: str = runtime_dep(default="electrons")
 
     def init(self, data: Data, rngs: PRNGKey) -> None:
         n_up, n_down = self.n_up, self.n_down
@@ -133,11 +136,11 @@ class SpinSquared(PerWalkerEstimator):
         Returns:
             Stacked data with shape ``[n_majority, ...]``.
         """
-        electrons: jnp.ndarray = data["electrons"]
+        electrons: jnp.ndarray = data[self.data_field]
 
         def _swap_one(maj_idx: jnp.ndarray) -> Data:
             perm = self._idx_all.at[min_idx].set(maj_idx)
             perm = perm.at[maj_idx].set(min_idx)
-            return data.merge({"electrons": electrons[perm]})
+            return data.merge({self.data_field: electrons[perm]})
 
         return jax.vmap(_swap_one)(self._majority_idx)

--- a/tests/estimator/density_test.py
+++ b/tests/estimator/density_test.py
@@ -25,10 +25,23 @@ class _TestData(Data):
     electrons: jnp.ndarray
 
 
+class _PositionData(Data):
+    """Minimal data container with a custom positions field."""
+
+    positions: jnp.ndarray
+
+
 def _make_batched(electrons: jnp.ndarray) -> BatchedData:
     return BatchedData(
         data=_TestData(electrons=electrons),
         fields_with_batch=["electrons"],
+    )
+
+
+def _make_batched_positions(positions: jnp.ndarray) -> BatchedData:
+    return BatchedData(
+        data=_PositionData(positions=positions),
+        fields_with_batch=["positions"],
     )
 
 
@@ -152,6 +165,17 @@ class TestSphericalDensity:
         }
         assert SphericalDensity().finalize_stats({}, state) == {}
 
+    def test_custom_data_field(self):
+        est = SphericalDensity(bins_theta=4, data_field="positions")
+        positions = jnp.array([[[math.pi / 8, 0.0], [5 * math.pi / 8, 0.0]]])
+        batched = _make_batched_positions(positions)
+        data = _PositionData(positions=jnp.zeros((1, 2)))
+        state = est.init(data, KEY)
+        _, state = est.evaluate_batch_walkers({}, batched, {}, state, KEY)
+        hist = state["histogram"][0]
+        _assert_bin(hist, 0, 1.0)
+        _assert_bin(hist, 2, 1.0)
+
 
 # -------------------------------------------------------------------
 # CartesianDensity
@@ -255,6 +279,20 @@ class TestCartesianDensity:
         assert state["histogram"].shape == (n, 10)
         _assert_bin(state["histogram"][0], 5, 1.0)
 
+    def test_custom_data_field(self):
+        est = CartesianDensity(
+            axes={
+                "z": CartesianAxis(direction=(0, 0, 1), bins=10, range=(0, 10)),
+            },
+            data_field="positions",
+        )
+        positions = jnp.array([[[0.0, 0.0, 5.5]]])
+        batched = _make_batched_positions(positions)
+        data = _PositionData(positions=jnp.zeros((1, 3)))
+        state = est.init(data, KEY)
+        _, state = est.evaluate_batch_walkers({}, batched, {}, state, KEY)
+        _assert_bin(state["histogram"][0], 5, 1.0)
+
 
 # -------------------------------------------------------------------
 # FractionalDensity
@@ -352,4 +390,18 @@ class TestFractionalDensity:
         _, state = est.evaluate_batch_walkers({}, batched, {}, state, KEY)
         n = jax.device_count()
         assert state["histogram"].shape == (n, 10)
+        _assert_bin(state["histogram"][0], 5, 1.0)
+
+    def test_custom_data_field(self):
+        inv_lattice = jnp.linalg.inv(10.0 * jnp.eye(3))
+        est = FractionalDensity(
+            axes={"c": FractionalAxis(lattice_index=2, bins=10)},
+            inv_lattice=inv_lattice,
+            data_field="positions",
+        )
+        positions = jnp.array([[[0.0, 0.0, 5.0]]])
+        batched = _make_batched_positions(positions)
+        data = _PositionData(positions=jnp.zeros((1, 3)))
+        state = est.init(data, KEY)
+        _, state = est.evaluate_batch_walkers({}, batched, {}, state, KEY)
         _assert_bin(state["histogram"][0], 5, 1.0)

--- a/tests/estimator/spin_test.py
+++ b/tests/estimator/spin_test.py
@@ -28,6 +28,12 @@ class _ElectronData(Data):
     electrons: jnp.ndarray
 
 
+class _PositionData(Data):
+    """Minimal Data subclass with a custom positions field."""
+
+    positions: jnp.ndarray
+
+
 def _make_spin_estimator(n_up, n_down, ndim=3):
     """Create a SpinSquared estimator with a constant mock wavefunction.
 
@@ -148,3 +154,25 @@ def test_s2_swap_indices_correct():
     # When n_up > n_down, minority = down (indices n_up..n_elec-1)
     np.testing.assert_array_equal(est_unbalanced._minority_idx, jnp.array([3]))
     np.testing.assert_array_equal(est_unbalanced._majority_idx, jnp.array([0, 1, 2]))
+
+
+def test_s2_custom_data_field():
+    """SpinSquared should swap coordinates from the configured data field."""
+    est = SpinSquared(data_field="positions")
+
+    def phase_logpsi(params, data):
+        del params
+        positions = data["positions"]
+        return jnp.array(1.0), positions[0, 0] - positions[1, 0]
+
+    wire(est, n_up=1, n_down=1, phase_logpsi=phase_logpsi)
+
+    data = _PositionData(positions=jnp.array([[2.0], [0.0]]))
+    key = jax.random.key(0)
+    est.init(data, key)
+    stats, _ = est.evaluate_single_walker(
+        params={}, data=data, prev_walker_stats={}, state=None, rngs=key
+    )
+
+    expected = 1.0 - np.exp(-4.0)
+    np.testing.assert_allclose(float(stats["spin:s2"]), expected, atol=1e-6)


### PR DESCRIPTION
Allow estimators to read coordinates from a configurable data field instead of assuming `electrons`.

This enables workflows with custom particle types or custom data layout using density and spin estimators.