### PR TITLE
distinguish device and process all-gather

### DIFF
--- a/docs/api-reference/utilities.md
+++ b/docs/api-reference/utilities.md
@@ -89,6 +89,7 @@ Wrappers for extracting real/imaginary parts and handling complex-valued JAX fun
 .. autofunction:: jaqmc.utils.parallel_jax.pvary
 .. autofunction:: jaqmc.utils.parallel_jax.pmean
 .. autofunction:: jaqmc.utils.parallel_jax.all_gather
+.. autofunction:: jaqmc.utils.parallel_jax.process_allgather
 .. autofunction:: jaqmc.utils.parallel_jax.addressable_data
 ```
 

--- a/docs/extending/runtime-data-conventions.md
+++ b/docs/extending/runtime-data-conventions.md
@@ -144,7 +144,7 @@ JaQMC uses it to drive real framework behavior:
   batch size
 - {meth}`~jaqmc.data.BatchedData.fully_batched_data` can broadcast shared
   fields across the batch
-- {meth}`~jaqmc.data.BatchedData.all_gather` gathers batched fields from
+- {meth}`~jaqmc.data.BatchedData.process_allgather` gathers batched fields from
   sharded execution
 
 Built-in molecule, solid, and Hall apps all currently batch only `electrons`.

--- a/src/jaqmc/data.py
+++ b/src/jaqmc/data.py
@@ -11,7 +11,7 @@ import jax.core
 from jax import numpy as jnp
 
 from jaqmc.utils.jax_dataclass import JAXDataclassMeta
-from jaqmc.utils.parallel_jax import BATCH_AXIS_NAME, all_gather
+from jaqmc.utils.parallel_jax import BATCH_AXIS_NAME, process_allgather
 
 
 class Data(metaclass=JAXDataclassMeta):
@@ -256,7 +256,7 @@ class BatchedData[DataT: Data]:
             },
         )
 
-    def all_gather(self) -> Self:
+    def process_allgather(self) -> Self:
         """Gather distributed arrays from all devices to each local node.
 
         For fields that are batched (sharded along the batch axis), this
@@ -269,7 +269,7 @@ class BatchedData[DataT: Data]:
         gathered = dataclasses.replace(
             self.data,
             **{
-                name: jax.tree.map(all_gather, self.data[name])
+                name: jax.tree.map(process_allgather, self.data[name])
                 for name in self.data.field_names
                 if name in self.fields_with_batch
             },

--- a/src/jaqmc/utils/clip.py
+++ b/src/jaqmc/utils/clip.py
@@ -3,10 +3,9 @@
 
 from typing import Literal
 
-import jax
 from jax import numpy as jnp
 
-from jaqmc.utils.parallel_jax import BATCH_AXIS_NAME
+from jaqmc.utils import parallel_jax
 
 
 def iqr_clip(x: jnp.ndarray, scale: float = 100.0) -> jnp.ndarray:
@@ -19,7 +18,7 @@ def iqr_clip(x: jnp.ndarray, scale: float = 100.0) -> jnp.ndarray:
     """
     if jnp.iscomplexobj(x):
         return iqr_clip(x.real, scale) + 1j * iqr_clip(x.imag, scale)
-    all_x = jax.lax.all_gather(x, axis_name=BATCH_AXIS_NAME, tiled=True)
+    all_x = parallel_jax.all_gather(x)
     q1 = jnp.nanquantile(all_x, 0.25)
     q3 = jnp.nanquantile(all_x, 0.75)
     iqr = q3 - q1
@@ -36,7 +35,7 @@ def mad_clip(x: jnp.ndarray, scale: float = 100.0) -> jnp.ndarray:
     """
     if jnp.iscomplexobj(x):
         return mad_clip(x.real, scale) + 1j * mad_clip(x.imag, scale)
-    all_x = jax.lax.all_gather(x, axis_name=BATCH_AXIS_NAME, tiled=True)
+    all_x = parallel_jax.all_gather(x)
     median = jnp.nanmedian(all_x)
     absdev = jnp.nanmedian(jnp.abs(all_x - median))
     return jnp.clip(x, median - scale * absdev, median + scale * absdev)

--- a/src/jaqmc/utils/parallel_jax.py
+++ b/src/jaqmc/utils/parallel_jax.py
@@ -115,7 +115,20 @@ def pmean[ValueT](x: ValueT) -> ValueT:
         return x
 
 
-def all_gather[ValueT](x: ValueT) -> ValueT:
+def all_gather(x):
+    """Gather ``x`` from every device along the batch axis and tile the result.
+
+    Args:
+        x: Per-device shard to gather across ``BATCH_AXIS_NAME``.
+
+    Returns:
+        Array containing the concatenated shards from all devices, with the
+        gathered axis merged into the existing leading batch dimension.
+    """
+    return jax.lax.all_gather(x, axis_name=BATCH_AXIS_NAME, tiled=True)
+
+
+def process_allgather[ValueT](x: ValueT) -> ValueT:
     """Gather arrays from all devices along the batch axis.
 
     Collects arrays sharded across devices and materializes the complete
@@ -138,20 +151,17 @@ def all_gather[ValueT](x: ValueT) -> ValueT:
     Type Parameters:
         ValueT: Arbitrary pytree-like value type preserved across the call.
     """
-    mesh = make_mesh()
+    with suppress(ImportError, AttributeError):
+        from jax.experimental import multihost_utils
 
-    def gather_fn(y):
-        return jax.lax.all_gather(y, axis_name=BATCH_AXIS_NAME, tiled=True)
-
-    # Determine partition specs based on input structure
-    in_spec = jax.tree.map(lambda _: jax.sharding.PartitionSpec(BATCH_AXIS_NAME), x)
-    out_spec = jax.tree.map(lambda _: jax.sharding.PartitionSpec(), x)
+        return multihost_utils.process_allgather(x, tiled=True)
 
     return shard_map(
-        gather_fn,
-        mesh=mesh,
-        in_specs=in_spec,
-        out_specs=out_spec,
+        all_gather,
+        mesh=make_mesh(),
+        # Determine partition specs based on input structure
+        in_specs=jax.tree.map(lambda _: jax.sharding.PartitionSpec(BATCH_AXIS_NAME), x),
+        out_specs=jax.tree.map(lambda _: jax.sharding.PartitionSpec(), x),
         check_vma=False,
     )(x)
 

--- a/src/jaqmc/workflow/stage/base.py
+++ b/src/jaqmc/workflow/stage/base.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Self
 
 import jax
 from upath import UPath
@@ -38,10 +38,20 @@ class RunContext:
     signal_handler: GracefulKiller
 
 
-class StageAbort(Exception):
+class StageState(ABC):
+    @abstractmethod
+    def partition(self) -> Self:
+        """Return a matching pytree of :class:`~jax.sharding.PartitionSpec`."""
+
+    @abstractmethod
+    def process_allgather(self) -> Self:
+        """Gather distributed arrays from all devices to each local node."""
+
+
+class StageAbort[StateT: StageState](Exception):
     """Raised by loop() to request a graceful abort (e.g. NaN detected)."""
 
-    def __init__(self, step: int, state: Any):
+    def __init__(self, step: int, state: StateT):
         self.step = step
         self.state = state
         super().__init__()
@@ -74,7 +84,7 @@ class WorkStageConfig:
     timing_warmup_steps: int = 10
 
 
-class WorkStage(ABC):
+class WorkStage[StateT: StageState](ABC):
     """Base class for work stages with generator-based run loop.
 
     Subclasses implement :meth:`loop` as a generator yielding ``(step, state)``
@@ -109,7 +119,7 @@ class WorkStage(ABC):
             NumPyCheckpointManager(save_dir, restore_path, prefix=prefix),
         )
 
-    def run(self, state: Any, context: RunContext, rngs: PRNGKey) -> Any:
+    def run(self, state: StateT, context: RunContext, rngs: PRNGKey) -> StateT:
         """Execute the full run loop.
 
         Resumes from checkpoint, opens writers, iterates the generator from
@@ -141,8 +151,8 @@ class WorkStage(ABC):
             parallel_jax.make_sharding(parallel_jax.DATA_PARTITION),
         )
 
-        def save(step: int, st: Any) -> None:
-            gathered = st.all_gather()
+        def save(step: int, st: StateT) -> None:
+            gathered = st.process_allgather()
             if is_master:
                 ckpt.save(step, gathered)
 
@@ -181,8 +191,8 @@ class WorkStage(ABC):
 
     @abstractmethod
     def loop(
-        self, state: Any, initial_step: int, rngs: PRNGKey
-    ) -> Iterator[tuple[int, Any]]:
+        self, state: StateT, initial_step: int, rngs: PRNGKey
+    ) -> Iterator[tuple[int, StateT]]:
         """Yield ``(step, state)`` tuples for each iteration.
 
         Subclasses must implement this generator. Raise :class:`StageAbort` to
@@ -198,7 +208,7 @@ class WorkStage(ABC):
         """
 
     @abstractmethod
-    def create_state(self, rngs: PRNGKey, **kwargs: Any) -> Any:
+    def create_state(self, rngs: PRNGKey, **kwargs: Any) -> StateT:
         """Create sharded state for this stage.
 
         Args:

--- a/src/jaqmc/workflow/stage/sampling.py
+++ b/src/jaqmc/workflow/stage/sampling.py
@@ -24,12 +24,12 @@ from jaqmc.wavefunction import WavefunctionLike
 from jaqmc.wavefunction.base import NumericWavefunctionEvaluate
 from jaqmc.writer import Writers
 
-from .base import WorkStage, WorkStageConfig
+from .base import StageState, WorkStage, WorkStageConfig
 
 logger = logging.getLogger(__name__)
 
 
-class SamplingState(metaclass=JAXDataclassMeta):
+class SamplingState(StageState, metaclass=JAXDataclassMeta):
     """Base state for sampling-based work stages.
 
     Contains the common fields shared across VMC and evaluation stages.
@@ -56,8 +56,8 @@ class SamplingState(metaclass=JAXDataclassMeta):
             estimator_state=parallel_jax.DATA_PARTITION,
         )
 
-    def all_gather(self) -> Self:
-        return replace(self, batched_data=self.batched_data.all_gather())
+    def process_allgather(self) -> Self:
+        return replace(self, batched_data=self.batched_data.process_allgather())
 
 
 class SamplingStageBuilder:

--- a/tests/utils/parallel_jax_test.py
+++ b/tests/utils/parallel_jax_test.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for parallel JAX utilities, especially all_gather.
+"""Tests for parallel JAX utilities, especially process_allgather.
 
-These tests verify that the all_gather function correctly gathers distributed
-arrays from all devices and materializes them on each device.
+These tests verify that the process_allgather function correctly gathers
+distributed arrays from all devices and materializes them on each device.
 
 Test Coverage:
 - Single-process multi-device tests (simulated with XLA_FLAGS)
@@ -30,17 +30,51 @@ from .distributed import find_free_port, redirect_stdout_stderr, setup_envs
 
 
 def test_all_gather_single_process():
-    """Test all_gather in single-process multi-device setting.
+    """Test all_gather inside shard_map returns the full leading batch."""
+    import jax
+    from jax import numpy as jnp
+    from jax.sharding import NamedSharding, PartitionSpec
+
+    from jaqmc.utils.parallel_jax import (
+        BATCH_AXIS_NAME,
+        all_gather,
+        make_mesh,
+        shard_map,
+    )
+
+    mesh = make_mesh()
+    sharding = NamedSharding(mesh, PartitionSpec(BATCH_AXIS_NAME))
+    per_device_width = 3
+    full_array = jnp.arange(
+        jax.device_count() * per_device_width, dtype=jnp.int32
+    ).reshape(jax.device_count(), per_device_width)
+    sharded = jax.device_put(full_array, sharding)
+
+    gather = shard_map(
+        all_gather,
+        mesh=mesh,
+        in_specs=PartitionSpec(BATCH_AXIS_NAME),
+        out_specs=PartitionSpec(),
+        check_vma=False,
+    )
+
+    result = gather(sharded)
+
+    np.testing.assert_array_equal(np.array(result), np.array(full_array))
+
+
+def test_process_allgather_single_process():
+    """Test process_allgather in single-process multi-device setting.
 
     Uses XLA_FLAGS to simulate multiple devices on a single machine.
-    This tests the basic all_gather functionality without true distribution,
+    This tests the basic process_allgather functionality without true distribution,
     including various shapes, dtypes, and pytrees.
     """
     import jax
     from jax import numpy as jnp
     from jax.sharding import NamedSharding, PartitionSpec
 
-    from jaqmc.utils.parallel_jax import BATCH_AXIS_NAME, all_gather, make_mesh
+    from jaqmc.utils.parallel_jax import BATCH_AXIS_NAME, make_mesh, process_allgather
 
     if jax.device_count() < 2:
         pytest.skip("More than one devices are required to test gathering")
@@ -65,7 +99,7 @@ def test_all_gather_single_process():
 
     for test_array in test_cases:
         sharded = shard_array(test_array)
-        result = all_gather(sharded)
+        result = process_allgather(sharded)
         assert result.shape == test_array.shape
         assert jnp.allclose(test_array, result, rtol=1e-6)
 
@@ -81,8 +115,8 @@ def test_all_gather_single_process():
     # Shard all arrays in the pytree
     sharded_pytree = jax.tree.map(shard_array, pytree_test)
 
-    # Apply all_gather to the whole pytree
-    result_pytree = jax.tree.map(all_gather, sharded_pytree)
+    # Apply process_allgather to the whole pytree
+    result_pytree = jax.tree.map(process_allgather, sharded_pytree)
 
     # Compare all leaves in the pytree
     leaves_orig, _ = jax.tree.flatten(pytree_test)
@@ -101,7 +135,7 @@ def test_all_gather_single_process():
 def parallel_jax_worker(
     process_id, num_processes, coordinator_address, queue, env_vars, test_arrays
 ):
-    """Worker function for distributed all_gather tests.
+    """Worker function for distributed process_allgather tests.
 
     Args:
         process_id: Process ID.
@@ -109,7 +143,7 @@ def parallel_jax_worker(
         coordinator_address: Coordinator address.
         queue: multiprocessing.Queue to send results back.
         env_vars: Dictionary of environment variables to set.
-        test_arrays: List of arrays to test all_gather on.
+        test_arrays: List of arrays to test process_allgather on.
 
     Raises:
         AssertionError: If sharding is not working as expected.
@@ -123,7 +157,11 @@ def parallel_jax_worker(
             import jax
             from jax.sharding import NamedSharding, PartitionSpec
 
-            from jaqmc.utils.parallel_jax import BATCH_AXIS_NAME, all_gather, make_mesh
+            from jaqmc.utils.parallel_jax import (
+                BATCH_AXIS_NAME,
+                make_mesh,
+                process_allgather,
+            )
 
             # Initialize distributed runtime
             DistributedConfig(
@@ -147,7 +185,7 @@ def parallel_jax_worker(
                         raise AssertionError("Sharding not working!")
                     except RuntimeError:
                         pass
-                gathered_results.append(np.array(all_gather(sharded_data)))
+                gathered_results.append(np.array(process_allgather(sharded_data)))
 
             exit_code = 0
         except Exception:
@@ -161,7 +199,7 @@ def parallel_jax_worker(
 
 
 def run_parallel_jax_test(num_processes, test_arrays, mode="cpu"):
-    """Run distributed all_gather test using multiprocessing.
+    """Run distributed process_allgather test using multiprocessing.
 
     Returns:
         Sorted list of worker results.
@@ -198,8 +236,8 @@ def run_parallel_jax_test(num_processes, test_arrays, mode="cpu"):
 
 
 @pytest.mark.parametrize("mode", ["cpu", "gpu"])
-def test_all_gather_distributed_two_processes(mode: str):
-    """Test all_gather in a true multi-process distributed setting with 2 processes."""
+def test_process_allgather_distributed_two_processes(mode: str):
+    """Test process_allgather in a true two-process distributed setting."""
     pytest.importorskip("jax", minversion="0.5.0")
 
     # Verify gathered data


### PR DESCRIPTION
`all_gather` was doing two different jobs.

Some code only needed the JAX collective inside `shard_map`. Other code, such as checkpoint saving, needed the full value gathered onto each process. This change separates those two cases and gives them clearer names.

`all_gather` now stays as the low-level collective helper. `process_allgather` is used when code needs the fully gathered result.