### PR TITLE
prefix config YAML file name and add back up

### DIFF
--- a/src/jaqmc/workflow/base.py
+++ b/src/jaqmc/workflow/base.py
@@ -83,6 +83,10 @@ class Workflow:
     cfg: ConfigManager
 
     config_class: ClassVar[type[WorkflowConfig]] = WorkflowConfig
+    # Train and evaluation can write their resolved configs into the same
+    # save_path. Without a workflow-specific prefix they would both write
+    # config.yaml and overwrite each other.
+    config_namespace: ClassVar[str | None] = None
     config: WorkflowConfig
     save_path: UPath
     restore_path: UPath
@@ -127,6 +131,26 @@ class Workflow:
             self.run()
         return self
 
+    def config_path(self) -> UPath:
+        """Return the path for the resolved workflow config snapshot."""
+        filename = "config.yaml"
+        if self.config_namespace:
+            filename = f"{self.config_namespace}_config.yaml"
+        return UPath(self.config.save_path) / filename
+
+    def config_backup_path(self) -> UPath:
+        """Return an unused backup path for the current config snapshot."""
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        config_stem = self.config_path().stem
+        history_dir = self.save_path / "config_history"
+        backup_stem = f"{config_stem}.backup_{timestamp}"
+        backup_path = history_dir / f"{backup_stem}.yaml"
+        suffix = 1
+        while backup_path.exists():
+            backup_path = history_dir / f"{backup_stem}_{suffix}.yaml"
+            suffix += 1
+        return backup_path
+
     def prepare(self, dry_run: bool = False) -> None:
         """Finalize config and log startup info.
 
@@ -135,15 +159,24 @@ class Workflow:
         """
         # Only write config and compare on the master process
         if jax.process_index() == 0:
-            config_path = UPath(self.config.save_path) / "config.yaml"
+            config_path = self.config_path()
+            previous_yaml = config_path.read_text() if config_path.exists() else None
             self.cfg.finalize(
                 raise_on_unused=not self.config.config.ignore_extra,
                 verbose=self.config.config.verbose,
-                compare_yaml=config_path.read_text() if config_path.exists() else None,
+                compare_yaml=previous_yaml,
             )
             if not dry_run:
+                current_yaml = self.cfg.to_yaml()
                 config_path.parent.mkdir(parents=True, exist_ok=True)
-                config_path.write_text(self.cfg.to_yaml())
+                if previous_yaml is not None and previous_yaml != current_yaml:
+                    # A rerun may update this workflow's resolved config in
+                    # place. Move the old snapshot into config_history first so
+                    # the previous YAML is still recoverable after overwrite.
+                    backup_path = self.config_backup_path()
+                    backup_path.parent.mkdir(parents=True, exist_ok=True)
+                    config_path.rename(backup_path)
+                config_path.write_text(current_yaml)
         if dry_run:
             return
         logger.info(

--- a/src/jaqmc/workflow/evaluation.py
+++ b/src/jaqmc/workflow/evaluation.py
@@ -46,6 +46,7 @@ class EvaluationWorkflow(Workflow):
     """
 
     config_class: ClassVar[type[EvaluationWorkflowConfig]] = EvaluationWorkflowConfig
+    config_namespace: ClassVar[str] = "evaluation"
     config: EvaluationWorkflowConfig
     evaluation_stage: EvaluationWorkStage
     data_init: Callable

--- a/src/jaqmc/workflow/vmc.py
+++ b/src/jaqmc/workflow/vmc.py
@@ -4,7 +4,7 @@
 import time
 from collections.abc import Callable
 from pathlib import Path
-from typing import Literal
+from typing import ClassVar, Literal
 
 import jax
 from jax.experimental import multihost_utils
@@ -64,6 +64,7 @@ class VMCWorkflow(Workflow):
         data_init: Function to initialize electron configurations.
     """
 
+    config_namespace: ClassVar[str] = "train"
     data_init: Callable[[int, PRNGKey], Data | BatchedData]
     pretrain_stage: VMCWorkStage | None = None
     train_stage: VMCWorkStage

--- a/tests/integration/checkpoint_test.py
+++ b/tests/integration/checkpoint_test.py
@@ -84,8 +84,8 @@ def test_checkpoint_restoration(tmp_path: Path):
     ckpts = list((tmp_path).glob("train_ckpt_*.npz"))
     assert ckpts, "Expected checkpoints to be created"
 
-    assert (tmp_path / "config.yaml").exists()
-    assert "iterations: 5" in (tmp_path / "config.yaml").read_text()
+    assert (tmp_path / "train_config.yaml").exists()
+    assert "iterations: 5" in (tmp_path / "train_config.yaml").read_text()
 
     ckpt_iterations = sorted(int(ckpt.stem.split("_")[-1]) for ckpt in ckpts)
     assert ckpt_iterations == [4], (
@@ -114,8 +114,11 @@ def test_checkpoint_restoration(tmp_path: Path):
         f"Expected checkpoints at 4 and 7, got {ckpt_iterations_after}"
     )
 
-    assert (tmp_path / "config.yaml").exists()
-    assert "iterations: 8" in (tmp_path / "config.yaml").read_text()
+    assert (tmp_path / "train_config.yaml").exists()
+    assert "iterations: 8" in (tmp_path / "train_config.yaml").read_text()
+    backups = sorted((tmp_path / "config_history").glob("train_config.backup_*.yaml"))
+    assert len(backups) == 1
+    assert "iterations: 5" in backups[0].read_text()
 
     # Verify restored run has 3 iterations (steps 5-7 inclusive)
     with h5py.File(tmp_path / "train_stats2.h5", "r") as f:

--- a/tests/utils/config_test.py
+++ b/tests/utils/config_test.py
@@ -627,8 +627,8 @@ def _yaml_roundtrip(
 class TestYamlRoundTrip:
     """Resolved YAML can be parsed back to produce identical configs.
 
-    This simulates the resume scenario: first run dumps config.yaml,
-    second run loads it via ``--yml config.yaml`` and optionally
+    This simulates the resume scenario: first run dumps a resolved YAML snapshot,
+    second run loads it via ``--yml ...`` and optionally
     overrides values with dotlist (e.g. ``train.run.iterations=200``).
     """
 

--- a/tests/workflow/workflow_config_test.py
+++ b/tests/workflow/workflow_config_test.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+import datetime as dt
+
+import pytest
+
+from jaqmc.utils.config import ConfigManager
+from jaqmc.workflow.base import Workflow
+from jaqmc.workflow.evaluation import EvaluationWorkflowConfig
+from jaqmc.workflow.stage.base import WorkStageConfig
+
+
+class NamespacedWorkflow(Workflow):
+    config_namespace = "custom"
+
+    def run(self) -> None:
+        raise NotImplementedError()
+
+
+class EvaluationNamespacedWorkflow(NamespacedWorkflow):
+    config_namespace = "evaluation"
+    config_class = EvaluationWorkflowConfig
+
+    def __init__(self, cfg: ConfigManager):
+        super().__init__(cfg)
+        self.run_config = cfg.get("run", WorkStageConfig)
+
+
+class _FixedDateTime(dt.datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2026, 6, 8, 12, 34, 56, tzinfo=tz)
+
+
+@pytest.fixture
+def freeze_backup_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    import jaqmc.workflow.base as workflow_base
+
+    monkeypatch.setattr(workflow_base.datetime, "datetime", _FixedDateTime)
+
+
+def _make_workflow(
+    workflow_cls: type[Workflow], tmp_path, *, seed: int, batch_size: int = 4096
+) -> Workflow:
+    return workflow_cls(
+        ConfigManager(
+            {
+                "workflow": {
+                    "save_path": str(tmp_path),
+                    "seed": seed,
+                    "batch_size": batch_size,
+                }
+            }
+        )
+    )
+
+
+def test_workflow_config_path_uses_namespace():
+    cfg = ConfigManager({"workflow": {"save_path": "/tmp/run"}})
+    workflow = NamespacedWorkflow(cfg)
+    assert str(workflow.config_path()) == "/tmp/run/custom_config.yaml"
+
+
+def test_prepare_skips_identical_backup_and_suffixes_same_second_collisions(
+    tmp_path, freeze_backup_time
+):
+    first = _make_workflow(NamespacedWorkflow, tmp_path, seed=1)
+    identical = _make_workflow(NamespacedWorkflow, tmp_path, seed=1)
+    second = _make_workflow(NamespacedWorkflow, tmp_path, seed=2)
+    third = _make_workflow(NamespacedWorkflow, tmp_path, seed=3)
+
+    first.prepare()
+    first_inode = (tmp_path / "custom_config.yaml").stat().st_ino
+    identical.prepare()
+    assert not (tmp_path / "config_history").exists()
+
+    second.prepare()
+    second_inode = (tmp_path / "custom_config.yaml").stat().st_ino
+    third.prepare()
+
+    history_dir = tmp_path / "config_history"
+    first_backup = history_dir / "custom_config.backup_20260608_123456.yaml"
+    second_backup = history_dir / "custom_config.backup_20260608_123456_1.yaml"
+
+    assert first_backup.exists()
+    assert second_backup.exists()
+    assert first_backup.read_text() == first.cfg.to_yaml()
+    assert second_backup.read_text() == second.cfg.to_yaml()
+    assert first_backup.stat().st_ino == first_inode
+    assert second_backup.stat().st_ino == second_inode
+    assert (tmp_path / "custom_config.yaml").read_text() == third.cfg.to_yaml()
+
+
+def test_prepare_tracks_evaluation_config_and_consumed_run_section(
+    tmp_path, freeze_backup_time
+):
+    first = EvaluationNamespacedWorkflow(
+        ConfigManager(
+            {
+                "workflow": {
+                    "save_path": str(tmp_path),
+                    "batch_size": 128,
+                    "source_path": "train-source",
+                },
+                "run": {"iterations": 2},
+            }
+        )
+    )
+    second = EvaluationNamespacedWorkflow(
+        ConfigManager(
+            {
+                "workflow": {
+                    "save_path": str(tmp_path),
+                    "batch_size": 128,
+                    "source_path": "train-source",
+                },
+                "run": {"iterations": 3},
+            }
+        )
+    )
+
+    first.prepare()
+    second.prepare()
+
+    config_path = tmp_path / "evaluation_config.yaml"
+    assert config_path.exists()
+    current_yaml = config_path.read_text()
+    assert "source_path: train-source" in current_yaml
+    assert "iterations: 3" in current_yaml
+
+    backup_path = (
+        tmp_path / "config_history" / "evaluation_config.backup_20260608_123456.yaml"
+    )
+    assert backup_path.exists()
+    backup_yaml = backup_path.read_text()
+    assert "source_path: train-source" in backup_yaml
+    assert "iterations: 2" in backup_yaml


### PR DESCRIPTION
Train and evaluation may share the same save directory, so writing both snapshots to config.yaml can make them overwrite each other. Prefix the saved config filename by workflow so both configs can coexist.

Also preserve the previous snapshot before replacing it. If config.yaml is overwritten accidentally, recovering the old contents is difficult; move changed configs into config_history with timestamped backup names.