### PR TITLE
log selected k-points for solids

### DIFF
--- a/src/jaqmc/app/solid/workflow.py
+++ b/src/jaqmc/app/solid/workflow.py
@@ -103,6 +103,13 @@ class SolidTrainWorkflow(VMCWorkflow):
     def run(self) -> None:
         self.scf.run()
         self.wf.klist = self.scf.get_orbital_kpoints()
+        logger.info(
+            "Using following k-points:\n%s",
+            "\n".join(
+                f"{alpha=}, {beta=}: {np.asarray(kpt).tolist()}"
+                for kpt, alpha, beta in self.scf.get_kpoint_occupancies()
+            ),
+        )
         super().run()
 
 
@@ -129,6 +136,13 @@ class SolidEvalWorkflow(EvaluationWorkflow):
     def run(self) -> None:
         self.scf.run()
         self.wf.klist = self.scf.get_orbital_kpoints()
+        logger.info(
+            "Using following k-points:\n%s",
+            "\n".join(
+                f"{alpha=}, {beta=}: {np.asarray(kpt).tolist()}"
+                for kpt, alpha, beta in self.scf.get_kpoint_occupancies()
+            ),
+        )
         super().run()
 
 

--- a/src/jaqmc/utils/atomic/scf.py
+++ b/src/jaqmc/utils/atomic/scf.py
@@ -687,13 +687,10 @@ class PeriodicSCF:
         if self._mo_coeff is None:
             raise RuntimeError("Mean-field calculation has not been run.")
 
-        alpha_coeffs, beta_coeffs = self._mo_coeff
+        occupancies = self.get_kpoint_occupancies()
         kpts = self.kpts
-
-        # Count occupied orbitals per k-point for each spin
-        # coeff.shape[1] is the number of occupied orbitals at that k-point
-        alpha_counts = jnp.array([c.shape[1] for c in alpha_coeffs])
-        beta_counts = jnp.array([c.shape[1] for c in beta_coeffs])
+        alpha_counts = jnp.array([alpha for _, alpha, _ in occupancies])
+        beta_counts = jnp.array([beta for _, _, beta in occupancies])
 
         # Build k-point indices by repeating each k-index by its orbital count
         # e.g., counts=[1,2,1] -> indices=[0,1,1,2]
@@ -702,3 +699,18 @@ class PeriodicSCF:
         beta_indices = jnp.repeat(k_indices, beta_counts)
 
         return jnp.concatenate([kpts[alpha_indices], kpts[beta_indices]])
+
+    def get_kpoint_occupancies(self) -> list[tuple[jnp.ndarray, int, int]]:
+        """Return occupied alpha and beta orbital counts for each k-point.
+
+        Raises:
+            RuntimeError: If Hartree-Fock calculation has not been performed.
+        """
+        if self._mo_coeff is None:
+            raise RuntimeError("Mean-field calculation has not been run.")
+
+        alpha_coeffs, beta_coeffs = self._mo_coeff
+        return [
+            (self.kpts[k], alpha_coeffs[k].shape[1], beta_coeffs[k].shape[1])
+            for k in range(len(self.kpts))
+        ]

--- a/tests/utils/atomic/scf_test.py
+++ b/tests/utils/atomic/scf_test.py
@@ -167,11 +167,13 @@ def test_get_orbital_kpoints_h2_supercell():
     pbc_scf.run()
 
     orbital_kpts = pbc_scf.get_orbital_kpoints()
+    occupancies = pbc_scf.get_kpoint_occupancies()
 
     # Should have 4 orbitals total: 2 alpha + 2 beta
     assert orbital_kpts.shape == (4, 3), (
         f"Expected shape (4, 3), got {orbital_kpts.shape}"
     )
+    assert len(occupancies) == len(kpts)
 
     # First 2 rows should be alpha orbitals (k0, k1)
     # Last 2 rows should be beta orbitals (k0, k1)
@@ -181,6 +183,11 @@ def test_get_orbital_kpoints_h2_supercell():
     np.testing.assert_allclose(
         orbital_kpts[2:], kpts, atol=1e-10, err_msg="Beta k-points mismatch"
     )
+    for occupancy, kpt in zip(occupancies, kpts, strict=True):
+        occupancy_kpt, alpha_count, beta_count = occupancy
+        np.testing.assert_allclose(occupancy_kpt, kpt, atol=1e-10)
+        assert alpha_count == 1
+        assert beta_count == 1
 
 
 def test_molecular_scf_accepts_mixed_pseudopotential_atoms():


### PR DESCRIPTION
A quick check of which k-points are occupied and whether k-points are equally occupied is useful to diagnose the SCF run.