### PR TITLE
fix kfac registration with enable_x64

### DIFF
--- a/docs/extending/wavefunctions.md
+++ b/docs/extending/wavefunctions.md
@@ -65,7 +65,9 @@ Minimal example:
 class MyWF(Wavefunction[MyData, jnp.ndarray]):
     @nn.compact
     def __call__(self, data: MyData) -> jnp.ndarray:
-        alpha = self.param("alpha", lambda *_: jnp.array(0.0))
+        alpha = self.param(
+            "alpha", nn.initializers.constant(0.0, dtype=jnp.float32), ()
+        )
         return alpha * jnp.linalg.norm(data.electrons)
 
 wf = MyWF()
@@ -73,6 +75,14 @@ params = wf.init_params(data, rngs)
 value = wf.evaluate(params, data)           # framework contract
 value2 = wf.apply(params, data)             # equivalent low-level Flax call
 ```
+
+The explicit `float32` dtype on `alpha` keeps its dtype consistent with other
+Flax-provided layers such as `nn.Dense`.
+Direct `self.param` calls without an explicit dtype can create `float64`
+parameters even when nearby Flax layer weights remain `float32`.
+Non-`float32` parameters are not inherently a problem, but they need extra care
+when you use KFAC, the default optimizer. Before relying on them, check that
+KFAC graph registration matches the `float32` case.
 
 ### Structured Return Types
 

--- a/docs/guide/optimizers/index.md
+++ b/docs/guide/optimizers/index.md
@@ -32,6 +32,12 @@ KFAC is the default optimizer, so no configuration change is needed. The key tun
 - `damping` (default `1e-3`) - regularization added to the curvature matrix.
 - `norm_constraint` (default `1e-3`) - scales the update down so that its approximate squared Fisher norm is at most this value.
 
+JaQMC's KFAC tags cover parameters and inputs that share the same dtype, as
+well as the common mixed case where `float32` parameters receive `float64`
+inputs or produce `float64` values. Other dtype combinations may need
+additional validation. Check that graph registration matches the `float32`
+case before relying on them.
+
 See the [configuration reference](#train-optim) for all KFAC options.
 
 ### Stochastic Reconfiguration (SR)
@@ -99,7 +105,7 @@ The optimizer controls how gradients are *applied*. Gradient *estimation*, inclu
 
 ## See Also
 
-- **Configuration:** [Molecule](#train-optim), [Solid](#solid-train-optim), [Hall](#hall-train-optim)
+- **Configuration:** {ref}`Molecule <train-optim>`, {ref}`Solid <solid-train-optim>`, {ref}`Hall <hall-train-optim>`
 - **Extending:** <project:/extending/custom-components/optimizers.md>
 - **API reference:** <project:/api-reference/optimizers.md>
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -30,6 +30,10 @@ By default, VMC training stops when `loss` becomes NaN
 - If only rare rows spike while most rows are finite, treat it as a local-energy
   tail problem rather than a generic optimizer failure. See
   [Rare Spikes or Heavy Energy Tails](#rare-spikes-or-heavy-energy-tails).
+- Try `jax.enable_x64=true` to check whether the issue is sensitive to
+  numerical precision by enabling `float64`. Note that model parameters remain
+  `float32` by default, but wavefunction inputs and values, determinant
+  calculations, and similar computations are still affected.
 
 If this started after adding custom code, check shapes early. Custom component
 shape bugs often show up first as NaNs or other errors; see

--- a/src/jaqmc/app/hall/wavefunction/jastrow.py
+++ b/src/jaqmc/app/hall/wavefunction/jastrow.py
@@ -37,7 +37,7 @@ class SphericalJastrow(nn.Module):
         )
 
         if r_ees_parallel.shape[0] > 0:
-            alpha_par = self.param("ee_par", nn.initializers.ones, (1,))
+            alpha_par = self.param("ee_par", nn.initializers.ones, (1,), jnp.float32)
             jastrow_ee_par = jnp.sum(
                 -(0.25 * alpha_par**2) / (alpha_par + r_ees_parallel)
             )
@@ -45,7 +45,7 @@ class SphericalJastrow(nn.Module):
             jastrow_ee_par = jnp.asarray(0.0)
 
         if r_ees[0][1].shape[0] > 0:
-            alpha_anti = self.param("ee_anti", nn.initializers.ones, (1,))
+            alpha_anti = self.param("ee_anti", nn.initializers.ones, (1,), jnp.float32)
             jastrow_ee_anti = jnp.sum(
                 -(0.5 * alpha_anti**2) / (alpha_anti + r_ees[0][1])
             )

--- a/src/jaqmc/optimizer/kfac/curvature_blocks.py
+++ b/src/jaqmc/optimizer/kfac/curvature_blocks.py
@@ -17,9 +17,33 @@ support complex numbers.
 
 from math import prod
 from string import ascii_lowercase
+from typing import cast
 
 import kfac_jax
 from jax import numpy as jnp
+
+
+def _update_factor(
+    factor: kfac_jax.utils.WeightedMovingAverage,
+    value: kfac_jax.utils.Array,
+    ema_old: kfac_jax.utils.Numeric,
+    ema_new: kfac_jax.utils.Numeric,
+):
+    """Update a KFAC moving average while preserving its state dtype.
+
+    KFAC initializes curvature factor state from parameter dtypes.  With x64
+    enabled, activations and tangents can produce float64 curvature estimates
+    for float32 parameter blocks, so the update is cast at the accumulator
+    boundary to keep JAX control-flow branch types stable.
+    """
+    assert factor.value is not None
+    factor_value = cast(kfac_jax.utils.Array, factor.value)
+    factor_weight = jnp.asarray(factor.weight)
+
+    value = jnp.asarray(value, dtype=factor_value.dtype)
+    ema_old = jnp.asarray(ema_old, dtype=factor_weight.dtype)
+    ema_new = jnp.asarray(ema_new, dtype=factor_weight.dtype)
+    factor.update(value, ema_old, ema_new)
 
 
 class RepeatedDenseBlock(kfac_jax.DenseTwoKroneckerFactored):
@@ -111,8 +135,8 @@ class RepeatedDenseBlock(kfac_jax.DenseTwoKroneckerFactored):
         input_stats = jnp.einsum("ay,az->yz", x, x) / batch_size
         output_stats = jnp.einsum("ay,az->yz", dy.conj(), dy).real / batch_size
 
-        state.factors[0].update(input_stats, ema_old, ema_new)
-        state.factors[1].update(output_stats, ema_old, ema_new)
+        _update_factor(state.factors[0], input_stats, ema_old, ema_new)
+        _update_factor(state.factors[1], output_stats, ema_old, ema_new)
 
         return state
 
@@ -147,8 +171,8 @@ class DenseTwoKroneckerFactored(kfac_jax.DenseTwoKroneckerFactored):
         # Take care of complex numbers
         output_stats = jnp.einsum("ay,az->yz", dy.conj(), dy).real / batch_size
 
-        state.factors[0].update(input_stats, ema_old, ema_new)
-        state.factors[1].update(output_stats, ema_old, ema_new)
+        _update_factor(state.factors[0], input_stats, ema_old, ema_new)
+        _update_factor(state.factors[1], output_stats, ema_old, ema_new)
 
         return state
 
@@ -169,7 +193,9 @@ class NaiveDiagonal(kfac_jax.NaiveDiagonal):
 
         for factor, dw in zip(state.diagonal_factors, estimation_data.tangents.params):
             # Take care of complex numbers
-            factor.update(jnp.real(dw.conj() * dw) / batch_size, ema_old, ema_new)
+            _update_factor(
+                factor, jnp.real(dw.conj() * dw) / batch_size, ema_old, ema_new
+            )
 
         return state
 
@@ -214,7 +240,9 @@ class ScaleAndShiftDiagonal(kfac_jax.ScaleAndShiftDiagonal):
                 / batch_size
             )
 
-            state.diagonal_factors[0].update(scale_diag_update, ema_old, ema_new)
+            _update_factor(
+                state.diagonal_factors[0], scale_diag_update, ema_old, ema_new
+            )
 
         if self.has_shift:
             shift_shape = estimation_data.primals.params[-1].shape
@@ -232,7 +260,9 @@ class ScaleAndShiftDiagonal(kfac_jax.ScaleAndShiftDiagonal):
                 / batch_size
             )
 
-            state.diagonal_factors[-1].update(shift_diag_update, ema_old, ema_new)
+            _update_factor(
+                state.diagonal_factors[-1], shift_diag_update, ema_old, ema_new
+            )
 
         return state
 

--- a/src/jaqmc/optimizer/kfac/tag_registration.py
+++ b/src/jaqmc/optimizer/kfac/tag_registration.py
@@ -19,7 +19,9 @@ import numpy as np
 
 
 def _flax_dense(
-    x: kfac_jax.utils.Array, params: Sequence[kfac_jax.utils.Array], axes: int
+    x: kfac_jax.utils.Array,
+    params: Sequence[kfac_jax.utils.Array],
+    axes: int,
 ) -> kfac_jax.utils.Array:
     """Example of a dense layer function.
 
@@ -40,10 +42,13 @@ def _flax_dense(
     )
     match params:
         case [w, b]:
+            w = w.astype(x.dtype)
+            b = b.astype(x.dtype)
             y = jax.lax.dot_general(x, w, (dimensions_in, ((), ())))
             # This reshape is required to match flax dense layer
             return y + b.reshape((1, *b.shape))
         case [w]:
+            w = w.astype(x.dtype)
             return jax.lax.dot_general(x, w, (dimensions_in, ((), ())))
         case _:
             raise ValueError("Unsupported parameters list")
@@ -80,38 +85,95 @@ def _make_flax_dense_pattern(
         parameters_extractor_func=functools.partial(
             kfac_jax.tag_graph_matcher._dense_parameter_extractor, variant=variant
         ),
-        example_args=[np.zeros(x_shape), [np.zeros(s) for s in p_shapes]],
+        example_args=[
+            np.zeros(x_shape),
+            [np.zeros(s, dtype=np.float32) for s in p_shapes],
+        ],
     )
 
 
-def _make_scalar_scale_pattern() -> kfac_jax.tag_graph_matcher.GraphPattern:
-    """Scale pattern for scalar (rank-0) parameters.
+def _scale_and_shift(
+    x: kfac_jax.utils.Array,
+    params: Sequence[kfac_jax.utils.Array],
+    has_scale: bool,
+    has_shift: bool,
+) -> kfac_jax.utils.Array:
+    if has_scale and has_shift:
+        scale, shift = params
+        return x * scale.astype(x.dtype) + shift.astype(x.dtype)
+    elif has_scale:
+        [scale] = params
+        return x * scale.astype(x.dtype)
+    elif has_shift:
+        [shift] = params
+        return x + shift.astype(x.dtype)
+    else:
+        raise ValueError("You must have either `has_scale` or `has_shift` set to True.")
 
-    KFAC-JAX's built-in scale patterns only cover rank >= 1.  This pattern
-    matches ``x * scale`` where both operands are scalars, enabling KFAC to
-    recognise scalar variational parameters (e.g. a single exponent alpha).
+
+def _make_scalar_scale_pattern(
+    x_ndim: int, has_scale: bool, has_shift: bool
+) -> kfac_jax.tag_graph_matcher.GraphPattern:
+    """Build a scale/shift pattern that handles mixed parameter dtypes.
 
     Returns:
-        A ``GraphPattern`` matching scalar multiplication.
+        A KFAC graph pattern for the requested broadcast rank and operations.
+
+    Raises:
+        ValueError: If neither scaling nor shifting is requested.
     """
+    assert x_ndim >= 0
+    assert has_scale or has_shift
+
+    x_shape = [i + 2 for i in range(x_ndim)]
+    p_shapes = (
+        [x_shape[-1:], x_shape[-1:]] if (has_scale and has_shift) else [x_shape[-1:]]
+    )
+
+    if has_scale and has_shift:
+        name = f"scale_and_shift_broadcast_{x_ndim}"
+    elif has_scale:
+        name = f"scale_only_broadcast_{x_ndim}"
+    elif has_shift:
+        name = f"shift_only_broadcast_{x_ndim}"
+    else:
+        raise ValueError("Unreachable.")
+
+    return kfac_jax.tag_graph_matcher.GraphPattern(
+        name=name,
+        tag_primitive=kfac_jax.layers_and_loss_tags.layer_tag,
+        compute_func=functools.partial(
+            _scale_and_shift, has_scale=has_scale, has_shift=has_shift
+        ),
+        parameters_extractor_func=kfac_jax.tag_graph_matcher._scale_and_shift_parameter_extractor,
+        example_args=[
+            np.zeros(x_shape),
+            [np.zeros(s, dtype=np.float32) for s in p_shapes],
+        ],
+    )
     # noinspection PyProtectedMember
     return kfac_jax.tag_graph_matcher.GraphPattern(
         name="scalar_scale",
         tag_primitive=kfac_jax.layers_and_loss_tags.layer_tag,
         compute_func=functools.partial(
-            kfac_jax.tag_graph_matcher._scale_and_shift,
-            has_scale=True,
-            has_shift=False,
+            _scale_and_shift, has_scale=True, has_shift=False
         ),
         parameters_extractor_func=kfac_jax.tag_graph_matcher._scale_and_shift_parameter_extractor,
-        example_args=[np.zeros(()), [np.zeros(())]],
+        example_args=[
+            np.zeros(()),
+            [np.zeros((), dtype=np.float32)],
+        ],
     )
 
 
 def make_graph_patterns():
     return (
-        _make_scalar_scale_pattern(),
-        *tuple(
+        tuple(
+            _make_scalar_scale_pattern(x_ndim, has_scale, has_shift)
+            for x_ndim in (0, 1, 2)
+            for has_scale, has_shift in [(True, True), (True, False), (False, True)]
+        )
+        + tuple(
             _make_flax_dense_pattern(
                 with_bias=with_bias,
                 num_repeated_axes=repeat,
@@ -121,6 +183,6 @@ def make_graph_patterns():
             for with_bias, repeat, n_ins, n_outs in itertools.product(
                 (True, False), range(3), range(1, 3), range(1, 3)
             )
-        ),
-        *kfac_jax.tag_graph_matcher.DEFAULT_GRAPH_PATTERNS,
+        )
+        + kfac_jax.tag_graph_matcher.DEFAULT_GRAPH_PATTERNS
     )

--- a/src/jaqmc/utils/runtime.py
+++ b/src/jaqmc/utils/runtime.py
@@ -65,8 +65,11 @@ class JaxConfig:
     """Configuration for JAX global runtime flags.
 
     Args:
-        enable_x64: Enable 64-bit types to be used.
-            Note that neural networks parameters in Flax will stay float32 by default.
+        enable_x64: Enable 64-bit types for JAX arrays that request them. Does not
+            upgrade existing parameters. In JaQMC wavefunctions (Flax modules), layer
+            weights stay ``float32`` by default and direct ``self.param`` calls use
+            ``float32`` by convention, so parameters remain ``float32`` even when
+            ``enable_x64=true``.
         debug_infs: Add inf checks to every operation.
             When an inf is detected on the output of a jit-compiled computation, call
             into the un-compiled version in an attempt to more precisely identify the

--- a/src/jaqmc/wavefunction/jastrow.py
+++ b/src/jaqmc/wavefunction/jastrow.py
@@ -58,7 +58,7 @@ class SimpleEEJastrow(nn.Module):
         n_up, n_down = self.nspins
 
         # Learnable decay parameters (initialized to alpha_init)
-        alpha_initializer = nn.initializers.constant(self.alpha_init)
+        alpha_initializer = nn.initializers.constant(self.alpha_init, dtype=jnp.float32)
         alpha_par = self.param("alpha_par", alpha_initializer, (1,))
         alpha_anti = self.param("alpha_anti", alpha_initializer, (1,))
 

--- a/src/jaqmc/wavefunction/output/envelope.py
+++ b/src/jaqmc/wavefunction/output/envelope.py
@@ -131,8 +131,8 @@ class _IsotropicEnvelope(nn.Module):
     def __call__(self, ae_vectors: Array, r_ae: Array) -> Array:
         _, n_atoms = r_ae.shape
         shape = (self.n_orbitals, n_atoms, self.ndets)
-        pi = self.param("pi", nn.initializers.ones, shape)
-        sigma = self.param("sigma", nn.initializers.ones, shape)
+        pi = self.param("pi", nn.initializers.ones, shape, jnp.float32)
+        sigma = self.param("sigma", nn.initializers.ones, shape, jnp.float32)
 
         r = r_ae[:, None, :, None]
         exponent = -jnp.abs(sigma * r) if self.is_abs else sigma * -r
@@ -152,8 +152,8 @@ class _DiagonalEnvelope(nn.Module):
         ndim_feat = ae_vectors.shape[-1]
         pi_shape = (self.n_orbitals, n_atoms, self.ndets)
         sigma_shape = (self.n_orbitals, n_atoms, ndim_feat, self.ndets)
-        pi = self.param("pi", nn.initializers.ones, pi_shape)
-        sigma = self.param("sigma", nn.initializers.ones, sigma_shape)
+        pi = self.param("pi", nn.initializers.ones, pi_shape, jnp.float32)
+        sigma = self.param("sigma", nn.initializers.ones, sigma_shape, jnp.float32)
 
         # ae_vectors: (n_elec, n_atoms, ndim_feat) -> (n_elec, 1, n_atoms, ndim_feat, 1)
         ae_expanded = ae_vectors[:, None, :, :, None]

--- a/tests/app/hall/hall_test.py
+++ b/tests/app/hall/hall_test.py
@@ -231,6 +231,14 @@ class TestPenalizedLoss:
 class TestSphericalJastrow:
     """SphericalJastrow: symmetric under same-spin swaps."""
 
+    @pytest.mark.x64_modes
+    def test_parameters_are_float32(self, x64_mode):
+        input_dtype = jnp.float64 if x64_mode else jnp.float32
+        electrons = _sample(jax.random.PRNGKey(0), 1, 3)[0].astype(input_dtype)
+        params = SphericalJastrow(nspins=(2, 1)).init(jax.random.PRNGKey(1), electrons)
+
+        assert all(param.dtype == jnp.float32 for param in jax.tree.leaves(params))
+
     def test_all_same_spin(self):
         """All electrons same spin: parallel pairs only, no antiparallel."""
         jastrow = SphericalJastrow(nspins=(3, 0))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import sys
 import warnings
 
 import chex
+import jax
 import pytest
 
 multiprocessing.set_start_method("spawn", force=True)
@@ -25,6 +26,10 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "integration: mark test as integration (runs full workflows)"
     )
+    config.addinivalue_line(
+        "markers",
+        "x64_modes: run the test with JAX x64 disabled and enabled (scoped)",
+    )
     if not config.getoption("keep_proxy_vars") and any(
         os.environ.get(var) for var in PROXY_VARS
     ):
@@ -37,6 +42,60 @@ def pytest_configure(config):
         for var in PROXY_VARS:
             if var in os.environ:
                 del os.environ[var]
+
+
+def _import_enable_x64():
+    if jax.__version_info__ >= (0, 8, 0):
+        try:
+            from jax import enable_x64
+        except ImportError:
+            from jax.experimental import enable_x64  # type: ignore[no-redef]
+        return enable_x64
+    try:
+        from jax.experimental import enable_x64  # type: ignore[no-redef]
+    except ImportError:
+        return None
+    return enable_x64
+
+
+def pytest_generate_tests(metafunc):
+    if metafunc.definition.get_closest_marker("x64_modes") is not None:
+        metafunc.parametrize(
+            "x64_mode",
+            [False, True],
+            ids=["x64_off", "x64_on"],
+            indirect=True,
+        )
+
+
+@pytest.fixture(autouse=True)
+def x64_mode(request):
+    """Scope JAX x64 mode for tests marked with ``x64_modes``.
+
+    Yields:
+        ``None`` for unmarked tests, otherwise ``False`` (x64 off) or ``True`` (x64 on).
+    """
+    mode = getattr(request, "param", None)
+    if mode is None:
+        yield None
+        return
+
+    enable_x64 = _import_enable_x64()
+    if mode:
+        if enable_x64 is None:
+            pytest.skip("requires JAX >= 0.8.0 for enable_x64")
+        with enable_x64(True):
+            assert jax.config.read("jax_enable_x64")
+            yield True
+    else:
+        if enable_x64 is None:
+            if jax.config.read("jax_enable_x64"):
+                pytest.skip("cannot scope-disable x64 on JAX < 0.8.0")
+            yield False
+            return
+        with enable_x64(False):
+            assert not jax.config.read("jax_enable_x64")
+            yield False
 
 
 @pytest.fixture(autouse=True)

--- a/tests/optimizer/kfac_test.py
+++ b/tests/optimizer/kfac_test.py
@@ -1,69 +1,449 @@
 # Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
 # SPDX-License-Identifier: Apache-2.0
 
+from dataclasses import dataclass
+from typing import Any, cast
+
 import flax.linen as nn
 import jax
 import jax.numpy as jnp
 import kfac_jax
 import pytest
 
+from jaqmc.app.molecule.data import MoleculeData
+from jaqmc.app.molecule.wavefunction.ferminet import FermiNetWavefunction
+from jaqmc.data import BatchedData
+from jaqmc.optimizer.kfac.complex_support import patch_block_diagonal_curvature
+from jaqmc.optimizer.kfac.curvature_blocks import make_tag_to_block_ctor
 from jaqmc.optimizer.kfac.tag_registration import make_graph_patterns
 from jaqmc.wavefunction.output.envelope import Envelope, EnvelopeType
 
 
-def get_tags(func, params, *args):
-    """Retrieves KFAC tags for the given function and parameters.
+def get_tag_tree(func, params, *args) -> Any:
+    """Return the parameter pytree with tag labels at each leaf.
 
-    Args:
-        func: The function to inspect.
-        params: The parameters of the function.
-        *args: Additional arguments to the function.
-
-    Returns:
-        A PyTree of tags with the same structure as `params`.
-        Each leaf contains the tag string (or None if no tag found).
+    Couples to kfac_jax ``auto_register_tags`` internals (``_param_labels``,
+    ``_func_graph``) because no public tag-introspection API exists.
     """
 
-    def _wrapped_func(p, *a):
+    def value_fn(p, *a):
         out = func(p, *a)
-        # We need to register a distribution for KFAC to trace the graph
-        kfac_jax.register_normal_predictive_distribution(out.ravel()[:, None])
+        kfac_jax.register_normal_predictive_distribution(jnp.reshape(out, (-1, 1)))
         return out
 
     tagged_func = kfac_jax.tag_graph_matcher.auto_register_tags(
-        _wrapped_func, (params, *args), graph_patterns=make_graph_patterns()
+        value_fn, (params, *args), graph_patterns=make_graph_patterns()
     )
     labels = [
         "|".join(tagged_func._param_labels.get(p, ["Orphan"]))
         for p in tagged_func._func_graph.params_vars
     ]
-    return jax.tree_util.tree_unflatten(tagged_func._func_graph.params_tree, labels)
+    tag_tree = jax.tree_util.tree_unflatten(tagged_func._func_graph.params_tree, labels)
+    return tag_tree
+
+
+def assert_tag(tag: str, *, variant: str, match_type: str) -> None:
+    assert tag != "Orphan"
+    assert "Auto[generic(" not in tag
+    assert f"tag_variant={variant}" in tag
+    assert f"match_type={match_type}" in tag
+
+
+def assert_params_f32(params: Any) -> None:
+    assert all(
+        isinstance(param, jax.Array) and param.dtype == jnp.float32
+        for param in jax.tree_util.tree_leaves(params)
+    )
+
+
+def activation_dtype(x64_mode: bool | None) -> jnp.dtype:
+    return jnp.float64 if x64_mode else jnp.float32
 
 
 def test_single_dense_layer_registration():
     model = nn.Dense(5)
     x = jnp.ones((1, 3))
     params = model.init(jax.random.PRNGKey(0), x)
+    tag_tree = get_tag_tree(model.apply, params, x)
 
-    tags = get_tags(model.apply, params, x)
-    dense_tags = tags["params"]
+    assert_tag(
+        tag_tree["params"]["kernel"],
+        variant="dense",
+        match_type="flax_dense_with_bias",
+    )
+    assert "tag_variant=dense(0)" in tag_tree["params"]["bias"]
 
-    assert "tag_variant=dense(0)" in dense_tags["kernel"]
-    assert "match_type=flax_dense_with_bias" in dense_tags["kernel"]
-    assert "tag_variant=dense(0)" in dense_tags["bias"]
 
-
-def test_repeated_dense_layer_registration():
+@pytest.mark.x64_modes
+def test_vmapped_repeated_dense_layer_registration_mixed_x64_activations(x64_mode):
     model = nn.Dense(5)
-    x = jnp.ones((1, 2, 3))
+    act_dtype = activation_dtype(x64_mode)
+    x = jnp.ones((2, 3), dtype=act_dtype)
     params = model.init(jax.random.PRNGKey(0), x)
+    batch = jnp.ones((4, *x.shape), dtype=act_dtype)
+    assert_params_f32(params)
 
-    tags = get_tags(model.apply, params, x)
-    dense_tags = tags["params"]
+    def apply_batch(p, xb):
+        return jax.vmap(model.apply, in_axes=(None, 0))(p, xb)
 
-    assert "tag_variant=repeated_dense(0)" in dense_tags["kernel"]
-    assert "match_type=repeated[1]_dense_with_bias_with_reshape" in dense_tags["kernel"]
-    assert "tag_variant=repeated_dense(0)" in dense_tags["bias"]
+    tag_tree = get_tag_tree(apply_batch, params, batch)
+
+    assert params["params"]["kernel"].dtype == jnp.float32
+    assert batch.dtype == act_dtype
+    assert_tag(
+        tag_tree["params"]["kernel"],
+        variant="repeated_dense",
+        match_type="repeated[1]_flax_dense_with_bias",
+    )
+    assert_tag(
+        tag_tree["params"]["bias"],
+        variant="repeated_dense",
+        match_type="repeated[1]_flax_dense_with_bias",
+    )
+
+
+@pytest.mark.x64_modes
+def test_scalar_scale_registration_mixed_x64_activation(x64_mode):
+    params = {"alpha": jnp.asarray(2.0, dtype=jnp.float32)}
+
+    def apply_scale(p, x):
+        return p["alpha"] * x
+
+    x = jnp.asarray(3.0, dtype=activation_dtype(x64_mode))
+    tag_tree = get_tag_tree(apply_scale, params, x)
+
+    assert x.dtype == activation_dtype(x64_mode)
+    assert_tag(
+        tag_tree["alpha"],
+        variant="scale_and_shift",
+        match_type="scale_only_broadcast_0",
+    )
+
+
+@pytest.mark.x64_modes
+def test_cast_scale_only_broadcast_registration(x64_mode):
+    params = {"scale": jnp.asarray(jnp.arange(13.0), dtype=jnp.float32)}
+
+    def apply_scale(p, x):
+        return x * p["scale"].astype(x.dtype)
+
+    x = jnp.ones((2, 13), dtype=activation_dtype(x64_mode))
+    tag_tree = get_tag_tree(apply_scale, params, x)
+
+    assert x.dtype == activation_dtype(x64_mode)
+    assert_tag(
+        tag_tree["scale"],
+        variant="scale_and_shift",
+        match_type="scale_only_broadcast_2",
+    )
+
+
+class KfacPatternComposite(nn.Module):
+    """Compact graph exercising JaQMC flax dense and scalar-scale patterns."""
+
+    hidden: int = 5
+    out_features: tuple[int, int] = (4, 5)
+
+    @nn.compact
+    def __call__(self, x: jax.Array) -> jax.Array:
+        flat = x.reshape(x.shape[0], -1)
+        h = nn.Dense(self.hidden)(flat)
+        h = nn.Dense(self.hidden, use_bias=False)(h)
+        h2 = nn.Dense(self.hidden)(x)
+        h3 = nn.DenseGeneral(self.out_features, axis=(-2, -1), use_bias=True)(x)
+        alpha = self.param("alpha", nn.initializers.ones, (), jnp.float32)
+        return alpha * (h.sum() + h2.sum() + h3.sum())
+
+
+@pytest.mark.x64_modes
+def test_kfac_pattern_composite_vmapped(x64_mode):
+    model = KfacPatternComposite()
+    x = jnp.ones((7, 2, 3))
+    params = model.init(jax.random.PRNGKey(0), x)
+    batch_x = jnp.ones((4, *x.shape), dtype=activation_dtype(x64_mode))
+    assert_params_f32(params)
+
+    def apply_batch(p, xb):
+        return jax.vmap(model.apply, in_axes=(None, 0))(p, xb)
+
+    tag_tree = get_tag_tree(apply_batch, params, batch_x)
+
+    assert_tag(
+        tag_tree["params"]["Dense_0"]["kernel"],
+        variant="repeated_dense",
+        match_type="repeated[1]_flax_dense_with_bias",
+    )
+    assert_tag(
+        tag_tree["params"]["Dense_0"]["bias"],
+        variant="repeated_dense",
+        match_type="repeated[1]_flax_dense_with_bias",
+    )
+    assert_tag(
+        tag_tree["params"]["Dense_1"]["kernel"],
+        variant="repeated_dense",
+        match_type="repeated[1]_flax_dense_no_bias",
+    )
+    assert_tag(
+        tag_tree["params"]["Dense_2"]["kernel"],
+        variant="repeated_dense",
+        match_type="repeated[2]_flax_dense_with_bias",
+    )
+    assert_tag(
+        tag_tree["params"]["Dense_2"]["bias"],
+        variant="repeated_dense",
+        match_type="repeated[2]_flax_dense_with_bias",
+    )
+    assert_tag(
+        tag_tree["params"]["DenseGeneral_0"]["kernel"],
+        variant="repeated_dense",
+        match_type="repeated[1]_flax_dense_with_bias",
+    )
+    assert_tag(
+        tag_tree["params"]["DenseGeneral_0"]["bias"],
+        variant="repeated_dense",
+        match_type="repeated[1]_flax_dense_with_bias",
+    )
+    assert_tag(
+        tag_tree["params"]["alpha"],
+        variant="scale_and_shift",
+        match_type="scale_only_broadcast_0",
+    )
+
+
+@pytest.mark.x64_modes
+@pytest.mark.parametrize(
+    "envelope_type",
+    [EnvelopeType.abs_isotropic, EnvelopeType.diagonal],
+)
+def test_envelope_mixed_dtype_registration(x64_mode, envelope_type):
+    n_elec = 3
+    n_atoms = 2
+    model = Envelope(
+        envelope_type=envelope_type,
+        ndets=4,
+        nspins=(1, 2),
+        orbitals_spin_split=True,
+    )
+    ae_vectors = jnp.zeros((n_elec, n_atoms, 3))
+    r_ae = jnp.zeros((n_elec, n_atoms))
+    params = model.init(jax.random.PRNGKey(0), ae_vectors, r_ae)
+    act_dtype = activation_dtype(x64_mode)
+    assert_params_f32(params)
+    tag_tree = get_tag_tree(
+        model.apply,
+        params,
+        ae_vectors.astype(act_dtype),
+        r_ae.astype(act_dtype),
+    )
+    for env_tags in tag_tree["params"].values():
+        assert_tag(
+            env_tags["pi"],
+            variant="scale_and_shift",
+            match_type="scale_only_broadcast_2",
+        )
+        assert_tag(
+            env_tags["sigma"],
+            variant="scale_and_shift",
+            match_type="scale_only_broadcast_2",
+        )
+
+
+@pytest.mark.x64_modes
+def test_ferminet_registration_smoke(x64_mode):
+    wf = FermiNetWavefunction(
+        nspins=(1, 1),
+        ndets=1,
+        hidden_dims_single=[4, 4],
+        hidden_dims_double=[2, 2],
+    )
+    act_dtype = activation_dtype(x64_mode)
+    walker = MoleculeData(
+        electrons=jnp.array([[0.5, 0.0, 0.0], [-0.5, 0.0, 0.0]], dtype=act_dtype),
+        atoms=jnp.array([[0.0, 0.0, 0.0]]),
+        charges=jnp.array([2.0]),
+    )
+    batch = BatchedData(
+        MoleculeData(
+            jnp.stack([walker.electrons, walker.electrons + 0.1]),
+            walker.atoms,
+            walker.charges,
+        ),
+        ["electrons"],
+    )
+    params = wf.init_params(
+        MoleculeData(
+            walker.electrons.astype(jnp.float32),
+            walker.atoms,
+            walker.charges,
+        ),
+        jax.random.PRNGKey(0),
+    )
+    assert_params_f32(params)
+
+    def apply_logpsi(p, batched_data):
+        return jax.vmap(wf.logpsi, in_axes=(None, batched_data.vmap_axis))(
+            p, batched_data.data
+        )
+
+    tag_tree = get_tag_tree(apply_logpsi, params, batch)
+    for env_tags in tag_tree["params"]["envelope_layer"].values():
+        for key in ("pi", "sigma"):
+            assert_tag(
+                env_tags[key],
+                variant="scale_and_shift",
+                match_type="scale_only_broadcast_2",
+            )
+    for layer_tags in tag_tree["params"]["backbone_layer"].values():
+        for key in ("kernel", "bias"):
+            tag = layer_tags[key]
+            assert "tag_variant=repeated_dense" in tag
+            assert "match_type=repeated[" in tag
+            assert "_flax_dense" in tag
+            assert "Auto[generic(" not in tag
+    for split_channel_tags in tag_tree["params"]["orbital_layer"].values():
+        for dense_general_tags in split_channel_tags.values():
+            tag = dense_general_tags["kernel"]
+            assert "tag_variant=repeated_dense" in tag
+            assert "match_type=repeated[" in tag
+            assert "_flax_dense" in tag
+            assert "Auto[generic(" not in tag
+
+
+class CurvatureProbe(nn.Module):
+    """Synthetic graph covering dense, repeated_dense, scale, and generic blocks."""
+
+    @nn.compact
+    def __call__(self, x_flat: jax.Array, x_rep: jax.Array) -> jax.Array:
+        scale = self.param("scale", lambda *_: jnp.asarray(1.5, jnp.float32), ())
+        w_generic = self.param(
+            "w_generic", lambda *_: jnp.asarray(0.7, jnp.float32), ()
+        )
+        y0 = nn.Dense(1, use_bias=False)(x_flat)[..., 0]
+        y1 = nn.Dense(1, use_bias=False)(x_rep).mean(axis=1)[..., 0]
+        y2 = scale * jnp.ones(x_flat.shape[0])
+        y3 = jnp.broadcast_to(jnp.sin(w_generic), x_flat.shape[:1])
+        return y0 + y1 + y2 + y3
+
+
+@dataclass(frozen=True)
+class FactorSnapshot:
+    block_index: int
+    variant: str
+    factor_index: int
+    shape: tuple[int, ...]
+    dtype: jnp.dtype
+    weight: float
+    value: jax.Array
+
+
+def _weighted_factors(
+    block_state: Any,
+) -> list[kfac_jax.utils.WeightedMovingAverage]:
+    if hasattr(block_state, "factors"):
+        return list(block_state.factors)
+    if hasattr(block_state, "diagonal_factors"):
+        return list(block_state.diagonal_factors)
+    raise AssertionError(f"unsupported KFAC block state layout: {type(block_state)!r}")
+
+
+def _snapshot_preconditioner_factors(
+    precon: kfac_jax.OptaxPreconditioner,
+    state: kfac_jax.OptaxPreconditionState,
+) -> dict[tuple[int, str, int], FactorSnapshot]:
+    estimator = precon.estimator
+    snapshots: dict[tuple[int, str, int], FactorSnapshot] = {}
+    for block_index, (block_state, tag_eqn) in enumerate(
+        zip(
+            state.estimator_state.blocks_states,
+            estimator.jaxpr.layer_tags,
+            strict=True,
+        )
+    ):
+        variant = tag_eqn.params["meta"].variant
+        for factor_index, factor in enumerate(_weighted_factors(block_state)):
+            assert factor.value is not None
+            value = cast(jax.Array, factor.value)
+            key = (block_index, variant, factor_index)
+            snapshots[key] = FactorSnapshot(
+                block_index=block_index,
+                variant=variant,
+                factor_index=factor_index,
+                shape=value.shape,
+                dtype=value.dtype,
+                weight=float(factor.weight),
+                value=value,
+            )
+    return snapshots
+
+
+@pytest.mark.x64_modes
+def test_curvature_updates_all_block_variants(x64_mode):
+    probe = CurvatureProbe()
+    act_dtype = activation_dtype(x64_mode)
+    x_flat = jnp.linspace(0.1, 1.0, 4 * 3, dtype=act_dtype).reshape(4, 3)
+    x_rep = jnp.linspace(0.2, 1.0, 4 * 2 * 3, dtype=act_dtype).reshape(4, 2, 3)
+    params = probe.init(jax.random.PRNGKey(0), x_flat[0], x_rep[0])
+    assert_params_f32(params)
+
+    tag_tree = get_tag_tree(probe.apply, params, x_flat, x_rep)
+    assert "Auto[generic(" in tag_tree["params"]["w_generic"]
+    for tag, variant in (
+        (tag_tree["params"]["Dense_0"]["kernel"], "dense"),
+        (tag_tree["params"]["Dense_1"]["kernel"], "repeated_dense"),
+        (tag_tree["params"]["scale"], "scale_and_shift"),
+    ):
+        assert f"tag_variant={variant}" in tag
+        assert "Auto[generic(" not in tag
+
+    def value_func(p, xb_flat, xb_rep):
+        out = cast(jax.Array, probe.apply(p, xb_flat, xb_rep))
+        kfac_jax.register_normal_predictive_distribution(out[:, None])
+        return out
+
+    def batch_size_extractor(xb_flat: jax.Array) -> int:
+        return xb_flat.shape[0]
+
+    precon = kfac_jax.OptaxPreconditioner(
+        value_func,
+        damping=1e-3,
+        l2_reg=0.0,
+        estimation_mode="fisher_exact",
+        layer_tag_to_block_ctor=make_tag_to_block_ctor(),
+        auto_register_kwargs=dict(graph_patterns=make_graph_patterns()),
+        batch_size_extractor=batch_size_extractor,
+        distributed_inverses=False,
+        distributed_precon_apply=False,
+    )
+    patch_block_diagonal_curvature(precon.estimator)
+
+    rng = jax.random.PRNGKey(0)
+    state = precon.init((params, x_flat, x_rep), rng)
+    found_variants = {
+        eqn.params["meta"].variant for eqn in precon.estimator.jaxpr.layer_tags
+    }
+    assert {"dense", "repeated_dense", "scale_and_shift", "generic"}.issubset(
+        found_variants
+    )
+
+    before = _snapshot_preconditioner_factors(precon, state)
+    for snapshot in before.values():
+        assert jnp.all(jnp.isfinite(snapshot.value))
+        assert snapshot.weight == 0
+
+    state = precon.maybe_update_estimator_curvature(
+        state, (params, x_flat, x_rep), rng, sync=False
+    )
+    after = _snapshot_preconditioner_factors(precon, state)
+
+    assert set(after) == set(before)
+    for key, before_snapshot in before.items():
+        after_snapshot = after[key]
+        assert before_snapshot.shape == after_snapshot.shape
+        assert before_snapshot.dtype == after_snapshot.dtype
+        assert after_snapshot.dtype == jnp.float32
+        assert after_snapshot.weight > 0
+        assert jnp.all(jnp.isfinite(after_snapshot.value))
+        assert jnp.any(after_snapshot.value != 0)
 
 
 @pytest.mark.parametrize(
@@ -86,15 +466,14 @@ def test_envelope_layer_registration(envelope_type, orbitals_spin_split, env_key
         nspins=(1, 2),
         orbitals_spin_split=orbitals_spin_split,
     )
-    # Use 3D ae_vectors for compatibility with all envelope types
     ae_vectors = jnp.zeros((n_elec, n_atoms, 3))
     r_ae = jnp.zeros((n_elec, n_atoms))
     params = model.init(jax.random.PRNGKey(0), ae_vectors, r_ae)
 
-    tags = get_tags(model.apply, params, ae_vectors, r_ae)
+    tag_tree = get_tag_tree(model.apply, params, ae_vectors, r_ae)
     for env_key in env_keys:
-        assert "tag_variant=scale_and_shift" in tags["params"][env_key]["pi"]
-        assert "tag_variant=scale_and_shift" in tags["params"][env_key]["sigma"]
+        assert "tag_variant=scale_and_shift" in tag_tree["params"][env_key]["pi"]
+        assert "tag_variant=scale_and_shift" in tag_tree["params"][env_key]["sigma"]
 
 
 @pytest.mark.parametrize(
@@ -103,14 +482,6 @@ def test_envelope_layer_registration(envelope_type, orbitals_spin_split, env_key
 )
 @pytest.mark.parametrize("ndim_feat", [3, 6])
 def test_envelope_layer_registration_variable_dim(envelope_type, ndim_feat):
-    """Test K-FAC tag registration for Envelope with variable feature dimensions.
-
-    This tests that Envelope works with different input dimensions (e.g., 3 for
-    nu_distance, 6 for tri_distance in PBC).
-
-    Note: DIAGONAL envelope uses einsum which falls back to generic K-FAC,
-    so we only test isotropic variants here.
-    """
     n_elec = 3
     n_atoms = 2
     ndets = 4
@@ -125,6 +496,13 @@ def test_envelope_layer_registration_variable_dim(envelope_type, ndim_feat):
     r_ae = jnp.zeros((n_elec, n_atoms))
     params = model.init(jax.random.PRNGKey(0), ae_vectors, r_ae)
 
-    tags = get_tags(model.apply, params, ae_vectors, r_ae)
-    assert "tag_variant=scale_and_shift" in tags["params"]["_env"]["pi"]
-    assert "tag_variant=scale_and_shift" in tags["params"]["_env"]["sigma"]
+    tag_tree = get_tag_tree(model.apply, params, ae_vectors, r_ae)
+    assert "tag_variant=scale_and_shift" in tag_tree["params"]["_env"]["pi"]
+    assert "tag_variant=scale_and_shift" in tag_tree["params"]["_env"]["sigma"]
+
+
+@pytest.mark.x64_modes
+def test_x64_mode_fixture_scopes_off_under_process_x64(x64_mode):
+    """Lightweight check that scoped x64-off works when the process starts x64-on."""
+    if not x64_mode:
+        assert not jax.config.read("jax_enable_x64")

--- a/tests/wavefunction/jastrow_test.py
+++ b/tests/wavefunction/jastrow_test.py
@@ -5,6 +5,7 @@
 
 import jax
 import jax.numpy as jnp
+import pytest
 
 from jaqmc.wavefunction.jastrow import SimpleEEJastrow, _cusp_function
 
@@ -44,6 +45,14 @@ class TestCuspFunction:
 
 class TestSimpleEEJastrow:
     """Tests for SimpleEEJastrow module."""
+
+    @pytest.mark.x64_modes
+    def test_parameters_are_float32(self, x64_mode):
+        input_dtype = jnp.float64 if x64_mode else jnp.float32
+        r_ee = jnp.zeros((2, 2), dtype=input_dtype)
+        params = SimpleEEJastrow(nspins=(1, 1)).init(jax.random.PRNGKey(0), r_ee)
+
+        assert all(param.dtype == jnp.float32 for param in jax.tree.leaves(params))
 
     def test_jastrow_cusp_derivative_parallel_spins(self):
         """Test Jastrow provides correct cusp for parallel spins (dJ/dr = 0.25)."""


### PR DESCRIPTION
Enabling JAX x64 caused some operations to fall back to generic KFAC handling because Flax-provided layer parameters remain float32 while inputs and intermediate values may become float64. That inserts dtype promotion operations into the traced graph.

Extend the KFAC patterns to cover the promoted float32-parameter path and keep JaQMC-created wavefunction parameters on the same float32 convention as Flax layers. This avoids treating direct self.param parameters as an accidental x64-only special case.

Document the dtype convention in the wavefunction and optimizer guides, and clarify that enable_x64 affects requested arrays and computations but does not upgrade model parameters by default.

The tests cover both jax.enable_x64=True and False across the supported KFAC blocks.