### PR TITLE
set default periodic feature to tri

### DIFF
--- a/docs/guide/periodic-boundaries.md
+++ b/docs/guide/periodic-boundaries.md
@@ -54,11 +54,32 @@ $\mathbf{b}_i$,
 $$
 \omega_i = \mathbf{b}_i \cdot \mathbf{r},
 $$
-and wraps each $\omega_i$ into $[-\pi, \pi]$. It then applies one of two periodic
-distance constructions. Each one defines a scalar periodic distance together with
-the periodic displacement features used to represent pair geometry:
+It then applies one of two periodic distance constructions. Each one defines a
+scalar periodic distance together with the periodic displacement features used to
+represent pair geometry:
 
-- **`nu`** (default) uses smooth polynomials
+- **`tri`** (default) uses trigonometric features directly. Its scalar periodic
+  distance is
+  $$
+  d(\mathbf{r}) =
+  \sqrt{
+    \sum_{i,j}
+    \left[
+      \sin(\omega_i)\sin(\omega_j) +
+      (1 - \cos(\omega_i))(1 - \cos(\omega_j))
+    \right]
+    (\mathbf{a}_i \cdot \mathbf{a}_j)
+  }.
+  $$
+  The associated periodic displacement feature concatenates
+  $\sum_i \sin(\omega_i)\,\mathbf{a}_i$ and
+  $\sum_i \cos(\omega_i)\,\mathbf{a}_i$, producing a 6D vector feature per pair.
+  This gives the network a richer periodic representation at the cost of a larger
+  feature dimension. The sine and cosine functions are periodic by construction, so
+  `tri` does not need an explicit wrap of $\omega_i$.
+
+- **`nu`** uses smooth polynomials after wrapping each $\omega_i$ into
+  $[-\pi, \pi]$:
   $$
   f(\omega) = |\omega|\left(1 - \tfrac{1}{4}|\omega/\pi|^3\right), \qquad
   g(\omega) = \omega\left(1 - \tfrac{3}{2}|\omega/\pi| + \tfrac{1}{2}|\omega/\pi|^2\right).
@@ -75,27 +96,8 @@ the periodic displacement features used to represent pair geometry:
   $\sum_i g(\omega_i)\,\mathbf{a}_i$, so the vector part stays 3D and remains
   close in shape to the open-boundary representation.
 
-- **`tri`** uses trigonometric features directly. Its scalar periodic distance is
-  $$
-  d(\mathbf{r}) =
-  \sqrt{
-    \sum_{i,j}
-    \left[
-      \sin(\omega_i)\sin(\omega_j) +
-      (1 - \cos(\omega_i))(1 - \cos(\omega_j))
-    \right]
-    (\mathbf{a}_i \cdot \mathbf{a}_j)
-  }.
-  $$
-  The associated periodic displacement feature concatenates
-  $\sum_i \sin(\omega_i)\,\mathbf{a}_i$ and
-  $\sum_i \cos(\omega_i)\,\mathbf{a}_i$, producing a 6D vector feature per pair.
-  This gives the network a richer periodic representation at the cost of a larger
-  feature dimension.
-
 Both choices are smooth at the boundary and differentiable everywhere JaQMC needs
-them for gradient-based optimization. `nu` is the default because it works well for
-most systems.
+them for gradient-based optimization.
 
 ### Symmetry expansion (`wf.sym_type`)
 

--- a/src/jaqmc/app/solid/wavefunction.py
+++ b/src/jaqmc/app/solid/wavefunction.py
@@ -31,7 +31,9 @@ class SolidWavefunction(Wavefunction[SolidData, ComplexLogDetOutput]):
         klist: K-point list for Bloch phases.
         hidden_dims_single: Hidden dimensions for single-electron streams.
         hidden_dims_double: Hidden dimensions for pairwise streams.
-        distance_type: Method to compute distances (e.g., 'nu' for nearest image).
+        distance_type: Periodic distance representation for pair features.
+            ``tri`` (default) uses trigonometric features with 6D displacement
+            vectors; ``nu`` uses polynomial features with 3D displacement vectors.
         envelope_type: Type of envelope function to use.
         sym_type: Symmetry type for features.
         orbitals_spin_split: If True, use separate orbital layer and envelope
@@ -47,7 +49,7 @@ class SolidWavefunction(Wavefunction[SolidData, ComplexLogDetOutput]):
     hidden_dims_single: list[int] = field(default_factory=lambda: [256] * 4)
     hidden_dims_double: list[int] = field(default_factory=lambda: [32] * 4)
     ndets: int = 16
-    distance_type: DistanceType = DistanceType.nu
+    distance_type: DistanceType = DistanceType.tri
     envelope_type: EnvelopeType = EnvelopeType.abs_isotropic
     sym_type: SymmetryType = SymmetryType.minimal
     orbitals_spin_split: bool = True

--- a/src/jaqmc/geometry/pbc.py
+++ b/src/jaqmc/geometry/pbc.py
@@ -17,11 +17,30 @@ class DistanceType(StrEnum):
     periodicity. Both functions take an (over-complete) set of real-space
     lattice vectors :math:`\mathbf{a}_i` and reciprocal vectors
     :math:`\mathbf{b}_i` produced by :func:`get_symmetry_lat`, and compute
-    fractional projections :math:`\omega_i = \mathbf{b}_i \cdot \mathbf{r}`
-    (wrapped to :math:`[-\pi, \pi]`).
+    fractional projections :math:`\omega_i = \mathbf{b}_i \cdot \mathbf{r}`.
 
     Attributes:
-        nu: Polynomial distance. Defines two smooth, periodic-compatible
+        tri: Trigonometric distance. Uses the metric tensor
+            :math:`G_{ij} = \mathbf{a}_i \cdot \mathbf{a}_j` and:
+
+            .. math::
+                V_{ij} = \sin(\omega_i)\sin(\omega_j)
+                    + (1 - \cos(\omega_i))(1 - \cos(\omega_j))
+
+            to compute:
+
+            .. math::
+                d(\mathbf{r}) = \sqrt{\sum_{ij} V_{ij}\, G_{ij}}
+
+            Produces 6D relative coordinates by concatenating
+            :math:`\sum_i \sin(\omega_i)\,\mathbf{a}_i` and
+            :math:`\sum_i \cos(\omega_i)\,\mathbf{a}_i`.
+            Default for solid workflows. More expressive than ``nu`` at the
+            cost of doubling the feature dimension. Sine and cosine are
+            periodic by construction, so no explicit wrap of :math:`\omega_i`
+            is required.
+        nu: Polynomial distance. Wraps each :math:`\omega_i` to
+            :math:`[-\pi, \pi]` and defines two smooth, periodic-compatible
             polynomials:
 
             .. math::
@@ -44,28 +63,11 @@ class DistanceType(StrEnum):
 
             Produces 3D relative coordinates
             :math:`\sum_i g(\omega_i)\,\mathbf{a}_i`.
-            Works well for most systems.
-        tri: Trigonometric distance. Uses the metric tensor
-            :math:`G_{ij} = \mathbf{a}_i \cdot \mathbf{a}_j` and:
-
-            .. math::
-                V_{ij} = \sin(\omega_i)\sin(\omega_j)
-                    + (1 - \cos(\omega_i))(1 - \cos(\omega_j))
-
-            to compute:
-
-            .. math::
-                d(\mathbf{r}) = \sqrt{\sum_{ij} V_{ij}\, G_{ij}}
-
-            Produces 6D relative coordinates by concatenating
-            :math:`\sum_i \sin(\omega_i)\,\mathbf{a}_i` and
-            :math:`\sum_i \cos(\omega_i)\,\mathbf{a}_i`.
-            More expressive than ``nu`` at the cost of doubling the feature
-            dimension.
+            Smaller feature dimension than ``tri``.
     """
 
-    nu = "nu"
     tri = "tri"
+    nu = "nu"
 
 
 class SymmetryType(StrEnum):
@@ -300,7 +302,10 @@ def tri_distance(
         w_i = \mathbf{b_i} \cdot \mathbf{r}
 
     .. math::
-        \text{rel} = \sum_i (g(w_i) a_i)
+        \text{rel} = \left[
+            \sum_i \sin(w_i)\,\mathbf{a}_i,\;
+            \sum_i \cos(w_i)\,\mathbf{a}_i
+        \right]
 
     Returns:
         (sd, rel) tuple of distances and relative coordinates.

--- a/src/jaqmc/wavefunction/input/atomic.py
+++ b/src/jaqmc/wavefunction/input/atomic.py
@@ -85,13 +85,15 @@ class SolidFeatures(nn.Module):
     Attributes:
         simulation_lattice: Lattice vectors of the simulation cell (nelectrons).
         primitive_lattice: Lattice vectors of the primitive cell (natoms).
-        distance_type: Type of periodic distance to use ('nu' or 'tri').
+        distance_type: Periodic distance representation. ``tri`` (default) uses
+            trigonometric features with 6D displacement vectors; ``nu`` uses
+            polynomial features with 3D displacement vectors.
         sym_type: Symmetry type for auxiliary lattice vectors.
     """
 
     simulation_lattice: jnp.ndarray
     primitive_lattice: jnp.ndarray
-    distance_type: DistanceType = DistanceType.nu
+    distance_type: DistanceType = DistanceType.tri
     sym_type: SymmetryType = SymmetryType.minimal
 
     def setup(self):


### PR DESCRIPTION
The distance feature `tri` performs better than `nu` in most systems and should be the default.