### PR TITLE
pin pyproject schema verions in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,8 @@ repos:
     rev: v0.25
     hooks:
       - id: validate-pyproject
-        additional_dependencies: ["validate-pyproject-schema-store[all]"]
+        additional_dependencies:
+          - "validate-pyproject-schema-store[all]==2026.07.17"
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.7
     hooks:


### PR DESCRIPTION
We check the validity of `pyproject.toml` as part of the pre-commit hooks and CI checks. However, we only pinned the version of `validate-pyproject` and left the version of `validate-pyproject-schema-store` free. Now the latest version of `validate-pyproject-schema-store` has some problems, which are causing failures in CI.

See henryiii/validate-pyproject-schema-store#269 for more information.