### PR TITLE
extend hall laughlin wf and fix logging

### DIFF
--- a/src/jaqmc/app/hall/wavefunction/free.py
+++ b/src/jaqmc/app/hall/wavefunction/free.py
@@ -12,6 +12,8 @@ from jaqmc.array_types import Params
 from jaqmc.utils.wiring import runtime_dep
 from jaqmc.wavefunction.base import ComplexWFOutput, Wavefunction
 
+__all__ = ["Free"]
+
 
 def make_monopole_harm(q: float, ell: float, m: float):
     r"""Create a monopole harmonic function :math:`Y_{q,\ell,m}`.

--- a/src/jaqmc/app/hall/wavefunction/laughlin.py
+++ b/src/jaqmc/app/hall/wavefunction/laughlin.py
@@ -3,6 +3,8 @@
 
 """Exact Laughlin wavefunction on the Haldane sphere (for benchmarking)."""
 
+from collections.abc import Callable
+
 from jax import numpy as jnp
 
 from jaqmc.app.hall.data import HallData
@@ -10,9 +12,11 @@ from jaqmc.array_types import Params
 from jaqmc.utils.wiring import runtime_dep
 from jaqmc.wavefunction.base import ComplexWFOutput, Wavefunction
 
+__all__ = ["Laughlin"]
+
 
 class Laughlin(Wavefunction[HallData, ComplexWFOutput]):
-    """Laughlin wavefunction for ground states on the Haldane sphere.
+    """Laughlin wavefunction for ground and quasiparticle/quasihole states.
 
     Constructs the Laughlin state as a Slater determinant of composite
     fermion orbitals with an attached Jastrow factor.
@@ -20,16 +24,59 @@ class Laughlin(Wavefunction[HallData, ComplexWFOutput]):
     Args:
         nspins: ``(n_up, n_down)`` electron counts.
         flux: Magnetic flux :math:`2Q`.
-        cf_flux: Composite fermion flux attachment parameter :math:`p`.
+        flux_per_elec: Composite fermion flux attachment parameter :math:`p`.
+        excitation_lz: Target :math:`L_z` for a quasiparticle or quasihole
+            excitation. Ignored for ground-state fillings.
     """
 
     nspins: tuple[int, int] = runtime_dep()
     flux: int = runtime_dep()
-    cf_flux: int = 1
+    flux_per_elec: int = 1
+    excitation_lz: int = 0
 
-    def setup(self):
+    def setup(self) -> None:
+        nelec = sum(self.nspins)
         Q = self.flux / 2
-        self.Q1 = Q - self.cf_flux * (sum(self.nspins) - 1)
+        self.Q1 = Q - self.flux_per_elec * (nelec - 1)
+        self._cf_orbitals: Callable[[jnp.ndarray, jnp.ndarray], jnp.ndarray]
+        if nelec == 2 * self.Q1 + 1:
+            self._cf_orbitals = self._full_orbitals
+        elif nelec == 2 * self.Q1:
+            self._check_lz()
+            if not (-abs(self.Q1) <= self.excitation_lz <= abs(self.Q1)):
+                raise ValueError(
+                    f"excitation_lz={self.excitation_lz} out of range "
+                    f"[-{abs(self.Q1)}, {abs(self.Q1)}] for quasihole."
+                )
+            self._cf_orbitals = self._quasihole_orbitals
+        elif nelec == 2 * self.Q1 + 2:
+            self._check_lz()
+            if not (-abs(self.Q1) - 1 <= self.excitation_lz <= abs(self.Q1) + 1):
+                raise ValueError(
+                    f"excitation_lz={self.excitation_lz} out of range "
+                    f"[-{abs(self.Q1) + 1}, {abs(self.Q1) + 1}] for quasiparticle."
+                )
+            self._cf_orbitals = self._quasiparticle_orbitals
+        else:
+            raise ValueError(
+                f"Unsupported Laughlin filling: {nelec} electrons for "
+                f"flux={self.flux} and flux_per_elec={self.flux_per_elec} "
+                f"(Q1={self.Q1}). Expected nelec in "
+                f"{{2*Q1, 2*Q1+1, 2*Q1+2}} for quasihole, ground, or "
+                f"quasiparticle."
+            )
+
+    def _check_lz(self) -> None:
+        """Validate that ``excitation_lz`` is compatible with ``Q1``.
+
+        Raises:
+            ValueError: If ``excitation_lz - Q1`` is not an integer.
+        """
+        diff = self.excitation_lz - self.Q1
+        if int(diff) != diff:
+            raise ValueError(
+                f"Impossible excitation_lz={self.excitation_lz} for Q1={self.Q1}."
+            )
 
     def __call__(self, data: HallData) -> ComplexWFOutput:
         electrons = data.electrons
@@ -37,7 +84,7 @@ class Laughlin(Wavefunction[HallData, ComplexWFOutput]):
         u = (jnp.cos(theta / 2) * jnp.exp(0.5j * phi))[..., None]
         v = (jnp.sin(theta / 2) * jnp.exp(-0.5j * phi))[..., None]
 
-        orbitals = self._full_orbitals(u, v)
+        orbitals = self._cf_orbitals(u, v)
         signs, logdets = jnp.linalg.slogdet(orbitals)
         logmax = jnp.max(logdets)
         logpsi = jnp.log(jnp.sum(signs * jnp.exp(logdets - logmax))) + logmax
@@ -49,6 +96,34 @@ class Laughlin(Wavefunction[HallData, ComplexWFOutput]):
         element = u * v[:, 0] - u[:, 0] * v + jnp.eye(u.shape[0])
         jastrow = jnp.prod(element, axis=-1, keepdims=True)
         return u ** (Q + m) * v ** (Q - m) * jastrow
+
+    def _quasihole_orbitals(self, u: jnp.ndarray, v: jnp.ndarray) -> jnp.ndarray:
+        Q = self.Q1
+        m = jnp.concat(
+            [
+                jnp.arange(-Q, -self.excitation_lz),
+                jnp.arange(Q, -self.excitation_lz, -1),
+            ]
+        )
+        element = u * v[:, 0] - u[:, 0] * v + jnp.eye(u.shape[0])
+        jastrow = jnp.prod(element, axis=-1, keepdims=True)
+        return u ** (Q + m) * v ** (Q - m) * jastrow
+
+    def _quasiparticle_orbitals(self, u: jnp.ndarray, v: jnp.ndarray) -> jnp.ndarray:
+        Q = self.Q1
+        m = jnp.arange(-Q, Q + 1)
+        orbitals = u ** (Q + m) * v ** (Q - m)
+
+        element = u * v[:, 0] - u[:, 0] * v + jnp.eye(u.shape[0])
+        jastrow = jnp.prod(element, axis=-1, keepdims=True)
+        jastrow_dv = jastrow * (jnp.sum(-u[:, 0] / element, axis=-1, keepdims=True) + u)
+        jastrow_du = jastrow * (jnp.sum(v[:, 0] / element, axis=-1, keepdims=True) - v)
+
+        m1 = self.excitation_lz
+        excited = (u ** (Q + m1) * v ** (Q - m1)) * (
+            (Q + 1 + m1) * v * jastrow_dv - (Q + 1 - m1) * u * jastrow_du
+        )
+        return jnp.concat([orbitals * jastrow, excited], axis=-1)
 
     def logpsi(self, params: Params, data: HallData) -> jnp.ndarray:
         return self.evaluate(params, data)["logpsi"]

--- a/src/jaqmc/app/hall/workflow.py
+++ b/src/jaqmc/app/hall/workflow.py
@@ -39,7 +39,7 @@ class HallTrainWorkflow(VMCWorkflow):
         console_fields = (
             "pmove:.2f,"
             "energy=total_energy_real:.4f,"
-            "variance=total_energy_var:.4f,"
+            "variance=total_energy_real_var:.4f,"
             "Lz=angular_momentum_z:+.4f,"
             "L_square=angular_momentum_square:.4f"
         )

--- a/tests/app/hall/hall_test.py
+++ b/tests/app/hall/hall_test.py
@@ -14,6 +14,7 @@ from jaqmc.app.hall.estimator.penalized_loss import PenalizedLoss
 from jaqmc.app.hall.hamiltonian import SpherePotential
 from jaqmc.app.hall.wavefunction.free import Free
 from jaqmc.app.hall.wavefunction.jastrow import SphericalJastrow
+from jaqmc.app.hall.wavefunction.laughlin import Laughlin
 from jaqmc.app.hall.wavefunction.mhpo import MHPO
 from jaqmc.estimator.kinetic import LaplacianMode, SphericalKinetic
 from jaqmc.geometry.sphere import sphere_proposal
@@ -332,6 +333,90 @@ class TestFreeWavefunction:
         params = wf.init_params(data, jax.random.PRNGKey(1))
         out = wf.evaluate(params, data)
         assert jnp.isfinite(out["logpsi"])
+
+
+class TestLaughlinWavefunction:
+    """Laughlin wavefunction: filling validation and exact kinetic energy."""
+
+    def _make_laughlin(self, nspins, flux, flux_per_elec=1, excitation_lz=0):
+        wf = Laughlin(flux_per_elec=flux_per_elec, excitation_lz=excitation_lz)
+        wire(wf, nspins=nspins, flux=flux)
+        return wf
+
+    def test_unsupported_filling(self):
+        """Reject electron counts that do not match the ground-state filling."""
+        wf = self._make_laughlin(nspins=(2, 0), flux=6)
+        electrons = _sample(jax.random.PRNGKey(0), 1, 2)[0]
+        data = HallData(electrons=electrons)
+        with pytest.raises(ValueError, match="Unsupported Laughlin filling"):
+            wf.init_params(data, jax.random.PRNGKey(1))
+
+    @pytest.mark.parametrize("mode", LAPLACIAN_MODES)
+    @pytest.mark.parametrize("nelec,Q", [(3, 3), (4, 4.5)])
+    def test_kinetic_energy(self, mode, nelec, Q):
+        """Laughlin ground state reproduces exact kinetic and angular momentum."""
+        flux = int(2 * Q)
+        wf = self._make_laughlin(nspins=(nelec, 0), flux=flux)
+        electrons = _sample(jax.random.PRNGKey(1898), 2, nelec)
+        data = HallData(electrons=electrons[0])
+        wf.init_params(data, jax.random.PRNGKey(1))
+
+        def log_psi_fn(params, data):
+            return wf.logpsi({}, data)
+
+        estimator = SphericalKinetic(
+            mode=mode,
+            monopole_strength=float(Q),
+            radius=float(jnp.sqrt(Q)),
+            f_log_psi=log_psi_fn,
+        )
+        batch_eval = jax.jit(
+            jax.vmap(
+                lambda d: _eval_single(estimator, HallData(electrons=d)),
+                in_axes=0,
+            )
+        )
+        stats = batch_eval(electrons)
+        np.testing.assert_allclose(stats["energy:kinetic"], nelec / 2, atol=1e-3)
+        np.testing.assert_allclose(stats["angular_momentum_z"], 0, atol=1e-3)
+        np.testing.assert_allclose(stats["angular_momentum_z_square"], 0, atol=1e-3)
+        np.testing.assert_allclose(stats["angular_momentum_square"], 0, atol=1e-3)
+
+    @pytest.mark.parametrize("mode", LAPLACIAN_MODES)
+    @pytest.mark.parametrize(
+        "nelec,flux,excitation_lz",
+        [(4, 10, 2), (6, 14, 1)],
+    )
+    def test_excitation_kinetic_energy(self, mode, nelec, flux, excitation_lz):
+        """Quasihole and quasiparticle Laughlin states have exact kinetic energy."""
+        Q = flux / 2
+        wf = self._make_laughlin(
+            nspins=(nelec, 0), flux=flux, excitation_lz=excitation_lz
+        )
+        electrons = _sample(jax.random.PRNGKey(1898), 2, nelec)
+        data = HallData(electrons=electrons[0])
+        wf.init_params(data, jax.random.PRNGKey(1))
+
+        def log_psi_fn(params, data):
+            return wf.logpsi({}, data)
+
+        estimator = SphericalKinetic(
+            mode=mode,
+            monopole_strength=float(Q),
+            radius=float(jnp.sqrt(Q)),
+            f_log_psi=log_psi_fn,
+        )
+        batch_eval = jax.jit(
+            jax.vmap(
+                lambda d: _eval_single(estimator, HallData(electrons=d)),
+                in_axes=0,
+            )
+        )
+        stats = batch_eval(electrons)
+        np.testing.assert_allclose(stats["energy:kinetic"], nelec / 2, atol=1e-3)
+        np.testing.assert_allclose(
+            stats["angular_momentum_z"], excitation_lz, atol=1e-3
+        )
 
 
 class TestMHPO:

--- a/tests/cli_dry_run_test.py
+++ b/tests/cli_dry_run_test.py
@@ -293,6 +293,11 @@ train:
         "wf.flux_per_elec=2 workflow.batch_size=4 train.run.iterations=1",
     ),
     CliDryRunCase(
+        "hall_train_laughlin_module_dotlist",
+        "hall train wf.module=laughlin system.flux=10 system.nspins='[4,0]' "
+        "workflow.batch_size=4 train.run.iterations=1",
+    ),
+    CliDryRunCase(
         "molecule_evaluate_yaml",
         "molecule evaluate --yml eval.yml",
         {


### PR DESCRIPTION
Add `__all__` to the Laughlin and Free wavefunction modules so `wf.module=laughlin/free` shorthand resolves through module_resolver.

Extend the exact Laughlin benchmark wavefunction to quasihole and quasiparticle fillings via `excitation_lz`, with setup validation for supported electron counts. Rename `cf_flux` to `flux_per_elec` to align with MHPO's composite-fermion config field.

Add Hall tests for Laughlin ground and excited-state kinetic-energy checks.

Also fix the Hall train console variance field to `total_energy_real_var` for complex total energies, matching the solid workflow fix in #61.