### PR TITLE
rename spherical kinetic mode to hessian

### DIFF
--- a/docs/guide/estimators/kinetic.md
+++ b/docs/guide/estimators/kinetic.md
@@ -62,7 +62,7 @@ $$
 
 where $\nabla^2_S = \frac{1}{\sin\theta}\partial_\theta(\sin\theta\,\partial_\theta) + \frac{1}{\sin^2\theta}\partial^2_\phi$ is the spherical Laplacian and $R$ is the sphere radius (defaults to $\sqrt{Q}$). The formulas follow section 3.10.3 of *Composite Fermions* (Jain).
 
-In `scan` or `fori_loop` mode, the full Hessian of $\log\psi$ with respect to $(\theta, \phi)$ is computed. This also yields the angular momentum observables $L_z$ and $L^2$ as byproducts. The estimator reports these as `angular_momentum_z`, `angular_momentum_z_square`, and `angular_momentum_square`; the default console formatting may display shorter aliases such as `Lz` and `L_square`. In `forward_laplacian` mode, the Hessian is not available, so $L^2$ is computed by applying the angular momentum operator $\hat{L}$ twice ($L^2 = \hat{\mathbf{L}} \cdot \hat{\mathbf{L}}$) in a separate pass.
+In `hessian` mode, the full Hessian of $\log\psi$ with respect to $(\theta, \phi)$ is computed. This also yields the angular momentum observables $L_z$ and $L^2$ as byproducts. The estimator reports these as `angular_momentum_z`, `angular_momentum_z_square`, and `angular_momentum_square`; the default console formatting may display shorter aliases such as `Lz` and `L_square`. In `forward_laplacian` mode, the Hessian is not available, so $L^2$ is computed by applying the angular momentum operator $\hat{L}$ twice ($L^2 = \hat{\mathbf{L}} \cdot \hat{\mathbf{L}}$) in a separate pass.
 
 ## See also
 

--- a/src/jaqmc/estimator/kinetic/spherical.py
+++ b/src/jaqmc/estimator/kinetic/spherical.py
@@ -10,7 +10,7 @@ strength :math:`Q`.
 """
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Literal
 
 import jax
 from jax import numpy as jnp
@@ -23,8 +23,6 @@ from jaqmc.utils.config import configurable_dataclass
 from jaqmc.utils.func_transform import with_imag, with_real
 from jaqmc.utils.wiring import runtime_dep
 from jaqmc.wavefunction.base import NumericWavefunctionEvaluate
-
-from ._common import LaplacianMode
 
 
 def _angular_momentum_operator(f, Q: float):
@@ -127,16 +125,15 @@ class SphericalKinetic(PerWalkerEstimator):
     Also computes angular momentum observables.
 
     Args:
-        mode: Laplacian computation mode. ``scan`` and ``fori_loop`` use a
-            Hessian-based approach; ``forward_laplacian`` uses the forward
-            Laplacian.
+        mode: Laplacian computation mode. ``hessian`` use a Hessian-based approach;
+            ``forward_laplacian`` uses the Forward Laplacian.
         monopole_strength: Half the magnetic flux (:math:`Q = \text{flux}/2`).
         radius: Sphere radius. Defaults to :math:`\sqrt{Q}`.
         f_log_psi: Complex log-psi function (runtime dep).
         data_field: Name of the data field (runtime dep, default ``"electrons"``).
     """
 
-    mode: LaplacianMode = LaplacianMode.scan
+    mode: Literal["hessian", "forward_laplacian"] = "hessian"
     monopole_strength: float = 1.0
     radius: float | None = None
     f_log_psi: NumericWavefunctionEvaluate = runtime_dep()
@@ -151,9 +148,11 @@ class SphericalKinetic(PerWalkerEstimator):
         rngs: PRNGKey,
     ) -> tuple[dict[str, Any], None]:
         del prev_walker_stats, rngs
-        if self.mode == LaplacianMode.forward_laplacian:
+        if self.mode == "forward_laplacian":
             return self._evaluate_forward_laplacian(params, data, state)
-        return self._evaluate_hessian(params, data, state)
+        if self.mode == "hessian":
+            return self._evaluate_hessian(params, data, state)
+        raise ValueError(f"Unsupported Laplacian mode {self.mode}.")
 
     def _evaluate_hessian(
         self, params: Params, data: Data, state: None

--- a/tests/app/hall/hall_test.py
+++ b/tests/app/hall/hall_test.py
@@ -3,6 +3,8 @@
 
 """Tests for the quantum Hall workflow components."""
 
+from typing import Literal
+
 import jax
 import numpy as np
 import pytest
@@ -15,7 +17,7 @@ from jaqmc.app.hall.hamiltonian import SpherePotential
 from jaqmc.app.hall.wavefunction.free import Free
 from jaqmc.app.hall.wavefunction.jastrow import SphericalJastrow
 from jaqmc.app.hall.wavefunction.mhpo import MHPO
-from jaqmc.estimator.kinetic import LaplacianMode, SphericalKinetic
+from jaqmc.estimator.kinetic import SphericalKinetic
 from jaqmc.geometry.sphere import sphere_proposal
 from jaqmc.laplacian import forward_laplacian, make_laplacian_input
 from jaqmc.utils.wiring import wire
@@ -83,9 +85,9 @@ def _supports_forward_laplacian() -> bool:
     return jax.__version_info__ >= (0, 7, 1)
 
 
-LAPLACIAN_MODES = [LaplacianMode.scan]
+LAPLACIAN_MODES: list[Literal["hessian", "forward_laplacian"]] = ["hessian"]
 if _supports_forward_laplacian():
-    LAPLACIAN_MODES.append(LaplacianMode.forward_laplacian)
+    LAPLACIAN_MODES.append("forward_laplacian")
 
 
 class TestSphericalKinetic:


### PR DESCRIPTION
Replace the obsolete `scan/fori_loop` names with hessian because the spherical estimator always materializes a full Hessian in that path. Keep `forward_laplacian` as the alternative and update Hall tests/docs.