### PR TITLE
allow checkpoint-free analytic wf evaluation

### DIFF
--- a/docs/extending/writing-workflows.md
+++ b/docs/extending/writing-workflows.md
@@ -129,7 +129,13 @@ Evaluation uses {class}`~jaqmc.workflow.evaluation.EvaluationWorkflow` instead o
 
 The structure mirrors the training workflow but without ``configure_optimizer`` and ``configure_loss_grads``. The conditional block at the end adds an optional density estimator when enabled via config — ``cfg.get("estimators.enabled.density", False)`` reads a boolean flag, and the ``CartesianDensity`` default defines the histogram grid.
 
-``EvaluationWorkflow`` loads ``params``, ``batched_data``, and ``sampler_state`` from the training checkpoint. Point it to the training output directory by setting ``workflow.source_path`` in your config:
+``EvaluationWorkflow`` creates fresh state before deciding how to initialize
+the run. When ``workflow.source_path`` is set, it loads ``params``,
+``batched_data``, and ``sampler_state`` from that training checkpoint. Without
+one, evaluation can proceed only when the initialized parameter PyTree is
+empty; it then uses the fresh parameters, walkers, and sampler state.
+Wavefunctions with parameter leaves therefore require ``workflow.source_path``.
+Point evaluation at a training output directory by setting it in your config:
 
 ```yaml
 workflow:

--- a/docs/guide/running-workflows.md
+++ b/docs/guide/running-workflows.md
@@ -108,8 +108,8 @@ jaqmc <app> train ... \
   train.run.iterations=<larger_value>
 ```
 
-Run evaluation in a separate directory by pointing `workflow.source_path` at the training
-run you want to evaluate:
+For a trained wavefunction, run evaluation in a separate directory by pointing
+`workflow.source_path` at the training run you want to evaluate:
 
 ```bash
 jaqmc <app> evaluate ... \
@@ -128,7 +128,9 @@ These three path settings do different jobs:
 - `workflow.restore_path`: where the current command looks for its own checkpoints; if
   unset, it defaults to `workflow.save_path`
 - `workflow.source_path`: training run or checkpoint used by `evaluate` to load trained
-  parameters, walker data, and sampler state
+  parameters, walkers, and sampler state. It is required when the wavefunction has
+  trainable parameters. Analytic wavefunctions with no parameters can instead start
+  evaluation from freshly initialized walkers; system pages document those workflows.
 ```
 
 When you rerun a command with the same `workflow.save_path`, JaQMC resumes from the
@@ -160,8 +162,9 @@ What *is* shared across apps is the command contract:
 - **`jaqmc <app> train`** runs that app's training workflow and writes its outputs under
   `workflow.save_path`.
 - **`jaqmc <app> evaluate`** runs an app's evaluation workflow when the app exposes
-  one, loading trained state from `workflow.source_path` and writing evaluation
-  outputs under its own `workflow.save_path`. The production system apps
+  one and writes evaluation outputs under its own `workflow.save_path`. It loads trained
+  state from `workflow.source_path` when the wavefunction has trainable parameters;
+  parameter-free analytic wavefunctions start from fresh state. The production system apps
   (`molecule`, `solid`, and `hall`) expose evaluation commands; the
   `hydrogen-atom` tutorial command is train-only on the CLI.
 - Training-stage keys are workflow-specific, so their structure lives in the app's config
@@ -220,9 +223,10 @@ A few details are worth keeping straight:
 - `*_stats.csv` is writer-dependent, so it may or may not be present.
 - `evaluation_digest.npz` is the compact summary produced at the end of evaluation.
 
-Evaluation loads from `workflow.source_path`. If that path is a directory, JaQMC restores
-the latest `train_ckpt_*.npz` it finds there. If it is a specific checkpoint file, JaQMC
-uses that file directly.
+When `workflow.source_path` is set, evaluation loads trained parameters,
+walkers, and sampler state from that path. If the path is a directory, JaQMC
+restores the latest `train_ckpt_*.npz` it finds there. If it is a specific
+checkpoint file, JaQMC uses that file directly.
 
 Checkpoint saves follow one rule: the last iteration is always saved, and intermediate
 checkpoints are written only when both `save_time_interval` and `save_step_interval` are

--- a/docs/systems/hall/eval.md
+++ b/docs/systems/hall/eval.md
@@ -16,6 +16,11 @@ shared by all commands. See <project:../../guide/runtime-configuration.md>.
 
 These keys control evaluation-wide settings and checkpoint loading.
 
+`workflow.source_path` selects the trained parameters and sampler state to
+evaluate. It is required for MHPO and other trainable wavefunctions. The
+analytic `laughlin` and `free` wavefunctions have no parameters, so they can
+start evaluation from fresh walkers without a source path.
+
 ```{eval-rst}
 .. config-defaults:: jaqmc.workflow.evaluation.EvaluationWorkflowConfig
    :prefix: workflow
@@ -23,13 +28,16 @@ These keys control evaluation-wide settings and checkpoint loading.
 
 ## System (`system.*`)
 
-Must match the training run. The effective defaults are identical to the
-[training system config](#hall-train-system).
+When evaluating a training checkpoint, these settings must match the training
+run. For direct `laughlin` or `free` evaluation, they define the target system.
+The effective defaults are identical to the [training system config](#hall-train-system).
 
 ## Wavefunction (`wf.*`)
 
-Must match the training run. The effective defaults and built-in module choices
-are identical to the [training wavefunction config](#hall-train-wf).
+When evaluating a training checkpoint, these settings must match the training
+run. For direct `laughlin` or `free` evaluation, select the analytic module
+with `wf.module`. The effective defaults and built-in module choices are
+identical to the [training wavefunction config](#hall-train-wf).
 
 ## Run Options (`run.*`)
 

--- a/docs/systems/hall/index.md
+++ b/docs/systems/hall/index.md
@@ -126,6 +126,19 @@ jaqmc hall evaluate workflow.save_path=./runs/hall-eval \
   workflow.source_path=./runs/hall-train
 ```
 
+The built-in `laughlin` and `free` wavefunctions are fixed analytic ansätze with
+no learnable parameters. Evaluate them directly with `jaqmc hall evaluate` — no
+training checkpoint is required:
+
+```bash
+jaqmc hall evaluate workflow.save_path=./runs/laughlin-n3 \
+  system.flux=6 system.nspins='[3,0]' \
+  wf.module=laughlin run.iterations=100000
+```
+
+See <project:eval.md> for all evaluation options. `jaqmc hall train` does not
+support `laughlin` or `free`.
+
 ### Additional Evaluation Estimators
 
 The hall app includes estimators for observables beyond energy. They are disabled by default and can be enabled via config flags:

--- a/docs/systems/hall/train.md
+++ b/docs/systems/hall/train.md
@@ -46,6 +46,9 @@ Selects and configures the neural network ansatz.
   architectures are listed below. Built-in choices are `mhpo`, `laughlin`,
   and `free`.
 
+Built-in `laughlin` and `free` are analytic benchmarks; use
+<project:eval.md> rather than training.
+
 See <project:index.md> for background on each architecture.
 
 ### MHPO options (`wf.*`)

--- a/src/jaqmc/workflow/evaluation.py
+++ b/src/jaqmc/workflow/evaluation.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
 # SPDX-License-Identifier: Apache-2.0
 
-"""Evaluation workflow that loads trained params from a checkpoint."""
+"""Evaluation workflow for MCMC sampling and observable estimation."""
 
+import logging
 import time
 from collections.abc import Callable
 from dataclasses import replace
@@ -17,6 +18,10 @@ from jaqmc.utils.config import configurable_dataclass
 from .base import Workflow, WorkflowConfig, init_batched_data
 from .stage.evaluation import EvaluationWorkStage
 
+logger = logging.LoggerAdapter(
+    logging.getLogger(__name__), extra={"category": "workflow"}
+)
+
 
 @configurable_dataclass
 class EvaluationWorkflowConfig(WorkflowConfig):
@@ -25,23 +30,27 @@ class EvaluationWorkflowConfig(WorkflowConfig):
     Extends :class:`~jaqmc.workflow.base.WorkflowConfig`.
 
     Args:
-        source_path: Path to the training run directory or checkpoint file
-            to load parameters from.
+        source_path: Training run directory or checkpoint file to load
+            parameters, walkers, and sampler state from. Required when the
+            initialized parameter tree has leaves; otherwise evaluation uses
+            freshly initialized state.
     """
 
-    source_path: str
+    source_path: str | None = None
 
 
 class EvaluationWorkflow(Workflow):
-    """Evaluation workflow that loads params from a training checkpoint.
+    """Evaluation workflow for sampling and observable estimation.
 
-    Creates fresh evaluation state (data, estimator_state), then loads
-    ``params``, ``batched_data``, and ``sampler_state`` from the training
-    checkpoint. The evaluation stage handles its own checkpointing for
+    Creates fresh evaluation state, then optionally loads ``params``,
+    ``batched_data``, and ``sampler_state`` from a training checkpoint when
+    ``workflow.source_path`` is set. Wavefunctions with no trainable
+    parameters may omit ``source_path`` and start from freshly initialized
+    walkers. The evaluation stage handles its own checkpointing for
     resumability.
 
     Attributes:
-        eval_stage: The evaluation stage.
+        evaluation_stage: The evaluation stage.
         data_init: Function to initialize electron configurations.
     """
 
@@ -69,8 +78,13 @@ class EvaluationWorkflow(Workflow):
         """Execute the evaluation workflow.
 
         1. Create fresh eval state (data + estimator_state as template)
-        2. Load params, data, sampler_state from training checkpoint
+        2. Load params, data, sampler_state from training checkpoint when
+           ``workflow.source_path`` is set
         3. Run evaluation (the stage handles its own checkpoint for resumability)
+
+        Raises:
+            ValueError: If ``workflow.source_path`` is omitted for a
+                wavefunction with trainable parameters.
         """
         # We must use the same seed across all processes to ensure that replicated
         # parameters are initialized identically. Generation of different keys on
@@ -78,10 +92,6 @@ class EvaluationWorkflow(Workflow):
         seed = self.config.seed if self.config.seed is not None else int(time.time())
         rngs = multihost_utils.broadcast_one_to_all(jax.random.PRNGKey(seed))
         context = self.run_context
-
-        source_path = UPath(self.config.source_path)
-        if not source_path.is_absolute():
-            source_path = (UPath.cwd() / source_path).resolve()
 
         rngs, data_rngs = jax.random.split(rngs)
         batched_data = init_batched_data(
@@ -91,27 +101,44 @@ class EvaluationWorkflow(Workflow):
         rngs, sub_rngs = jax.random.split(rngs)
         state = self.evaluation_stage.create_state(sub_rngs, batched_data=batched_data)
 
-        # Load params, data, sampler_state from training checkpoint.
-        # The dict wrapper matches VMCState checkpoint key paths because
-        # DictKey("params") and GetAttrKey("params") both serialize to
-        # "params" in the checkpoint's key path format.
-        wrapper = {
-            "params": state.params,
-            "batched_data": state.batched_data,
-            "sampler_state": state.sampler_state,
-        }
-        # If source_path is a file, restore directly; otherwise glob for
-        # train_ckpt_*.npz in the directory.
-        prefix = "" if source_path.is_file() else "train"
-        restored = self.evaluation_stage.restore_checkpoint(
-            source_path, wrapper, prefix=prefix, strict=True
-        )
-        state = replace(
-            state,
-            params=restored["params"],
-            batched_data=restored["batched_data"],
-            sampler_state=restored["sampler_state"],
-        )
+        source_path_str = self.config.source_path
+        if source_path_str:
+            source_path = UPath(source_path_str)
+            if not source_path.is_absolute():
+                source_path = (UPath.cwd() / source_path).resolve()
+
+            # Load params, data, sampler_state from training checkpoint.
+            # The dict wrapper matches VMCState checkpoint key paths because
+            # DictKey("params") and GetAttrKey("params") both serialize to
+            # "params" in the checkpoint's key path format.
+            wrapper = {
+                "params": state.params,
+                "batched_data": state.batched_data,
+                "sampler_state": state.sampler_state,
+            }
+            # If source_path is a file, restore directly; otherwise glob for
+            # train_ckpt_*.npz in the directory.
+            prefix = "" if source_path.is_file() else "train"
+            restored = self.evaluation_stage.restore_checkpoint(
+                source_path, wrapper, prefix=prefix, strict=True
+            )
+            state = replace(
+                state,
+                params=restored["params"],
+                batched_data=restored["batched_data"],
+                sampler_state=restored["sampler_state"],
+            )
+        elif jax.tree.leaves(state.params):
+            raise ValueError(
+                "This wavefunction has trainable parameters, so "
+                "workflow.source_path is required. Set it to a training run "
+                "directory or train_ckpt_*.npz file."
+            )
+        else:
+            logger.info(
+                "No training checkpoint loaded; starting evaluation with "
+                "fresh walkers and sampler state."
+            )
 
         rngs, sub_rngs = jax.random.split(rngs)
         self.evaluation_stage.run(state, context, sub_rngs)

--- a/src/jaqmc/workflow/stage/vmc.py
+++ b/src/jaqmc/workflow/stage/vmc.py
@@ -193,6 +193,10 @@ class VMCWorkStage(SamplingWorkStage):
 
         Returns:
             Sharded VMC state.
+
+        Raises:
+            ValueError: If training is attempted for a wavefunction with no
+                trainable parameters.
         """
         base_rngs, opt_rngs = jax.random.split(rngs)
         base = super().create_state(
@@ -201,6 +205,12 @@ class VMCWorkStage(SamplingWorkStage):
             batched_data=batched_data,
             sampler_state=sampler_state,
         )
+
+        if not jax.tree.leaves(base.params):
+            raise ValueError(
+                "This wavefunction has no trainable parameters. Use "
+                "jaqmc <app> evaluate instead of train."
+            )
 
         local_data = jax.tree.map(parallel_jax.addressable_data, batched_data)
         # KFAC requires device-local parameters to construct graphs

--- a/tests/app/hall/analytic_wavefunction_workflow_test.py
+++ b/tests/app/hall/analytic_wavefunction_workflow_test.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import numpy as np
+import pytest
+
+from jaqmc.app.hall import HallEvalWorkflow, HallTrainWorkflow
+from jaqmc.utils.config import ConfigManager
+
+
+def _hall_config(tmp_path, *, wf_module: str, save_name: str):
+    return {
+        "workflow": {
+            "save_path": str(tmp_path / save_name),
+            "batch_size": 16,
+            "seed": 0,
+        },
+        "system": {
+            "flux": 6,
+            "nspins": (3, 0),
+        },
+        "wf": {"module": wf_module},
+    }
+
+
+def _evaluation_run_config():
+    """Return an evaluation run configuration compatible with supported JAX."""
+    return {
+        "iterations": 50,
+        "burn_in": 0,
+        # JAX 0.5.x and 0.6.x cannot validate this Hessian path inside shard_map.
+        "check_vma": jax.__version_info__[:2] not in {(0, 5), (0, 6)},
+    }
+
+
+@pytest.mark.parametrize("wf_module", ["laughlin", "free"])
+def test_hall_train_rejects_parameter_free_wavefunction(tmp_path, wf_module):
+    train_dir = tmp_path / "train"
+    config = _hall_config(tmp_path, wf_module=wf_module, save_name="train")
+    config["train"] = {"run": {"iterations": 1}}
+
+    with pytest.raises(ValueError, match="no trainable parameters"):
+        HallTrainWorkflow(ConfigManager(config))()
+
+    assert not list(train_dir.glob("train_ckpt_*.npz"))
+
+
+def test_laughlin_direct_eval_keeps_local_energy_variance_bounded(tmp_path):
+    config = _hall_config(tmp_path, wf_module="laughlin", save_name="eval")
+    config["run"] = _evaluation_run_config()
+    HallEvalWorkflow(ConfigManager(config))()
+
+    digest = np.load(tmp_path / "eval" / "evaluation_digest.npz")
+    assert digest["energy:potential"] > 0
+    assert digest["total_energy_real_var"] < 0.5
+
+
+def test_free_direct_eval_is_non_interacting(tmp_path):
+    config = _hall_config(tmp_path, wf_module="free", save_name="eval")
+    config["system"]["interaction_strength"] = 0.0
+    config["run"] = _evaluation_run_config()
+    HallEvalWorkflow(ConfigManager(config))()
+
+    digest = np.load(tmp_path / "eval" / "evaluation_digest.npz")
+    np.testing.assert_allclose(digest["energy:potential"], 0.0, atol=1e-6)
+    np.testing.assert_allclose(digest["energy:kinetic"], 1.5, atol=1e-2)
+    np.testing.assert_allclose(digest["total_energy_real"], 1.5, atol=1e-2)

--- a/tests/cli_dry_run_test.py
+++ b/tests/cli_dry_run_test.py
@@ -353,6 +353,16 @@ estimators:
         "estimators.enabled.pair_correlation=true "
         "estimators.enabled.one_rdm=true",
     ),
+    CliDryRunCase(
+        "hall_evaluate_laughlin_no_source",
+        "hall evaluate system.flux=6 system.nspins='[3,0]' "
+        "wf.module=laughlin workflow.batch_size=4 run.iterations=1",
+    ),
+    CliDryRunCase(
+        "hall_evaluate_free_no_source",
+        "hall evaluate system.flux=6 system.nspins='[3,0]' "
+        "wf.module=free workflow.batch_size=4 run.iterations=1",
+    ),
 ]
 
 

--- a/tests/hydrogen/atom_test.py
+++ b/tests/hydrogen/atom_test.py
@@ -91,6 +91,21 @@ def test_evaluation_writes_per_step_stats_and_digest(tmp_path):
     assert digest["energy:kinetic"].ndim == 0
 
 
+def test_evaluation_requires_source_path_for_trainable_wavefunction(tmp_path):
+    eval_dir = tmp_path / "eval-run"
+    eval_cfg = ConfigManager(
+        {
+            "workflow": {"save_path": str(eval_dir), "batch_size": 128},
+            "run": {"iterations": 1},
+        }
+    )
+
+    with pytest.raises(ValueError, match=r"workflow\.source_path is required"):
+        hydrogen_atom_eval_workflow(eval_cfg)()
+
+    assert not (eval_dir / "evaluation_digest.npz").exists()
+
+
 def test_evaluation_fails_when_source_path_is_missing(tmp_path):
     eval_dir = tmp_path / "eval-run"
     eval_cfg = ConfigManager(


### PR DESCRIPTION
Parameter-free wavefunctions, like the Laughlin wavefunction in fractional quantum Hall, can be evaluated from a fresh state without a training checkpoint. Rejecting them in VMC makes that workflow boundary explicit.