### PR TITLE
improve error messages for common config mistakes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "jax>=0.4.36,<=0.9.1",
     "kfac-jax==0.0.8",
     "numpy>=2.3.5",
-    "pyserde>=0.31.1",
+    "pyserde>=0.31.7",
     "optax>=0.2.5",
     "pygments>=2.19.2",
     "pyscf>=2.11.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -181,7 +181,7 @@ pygments==2.20.0
     #   rich
 pyscf==2.12.1
     # via jaqmc
-pyserde==0.31.2
+pyserde==0.31.7
     # via jaqmc
 pytest==9.0.3
     # via

--- a/src/jaqmc/utils/cli.py
+++ b/src/jaqmc/utils/cli.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 import click
 import yaml
 
-from jaqmc.utils.config import ConfigManager
+from jaqmc.utils.config import ConfigError, ConfigManager
 from jaqmc.utils.runtime import configure_runtime
 
 
@@ -34,9 +34,12 @@ def make_cli(workflow=None, **kwargs):
     def command(
         dotlist: tuple[str, ...], yml: Sequence[str], dry_run: bool = False
     ) -> None:
-        cfg = ConfigManager([load_yaml(f) for f in yml], list(dotlist))
-        configure_runtime(cfg, dry_run=dry_run)
-        workflow(cfg, dry_run=dry_run)
+        try:
+            cfg = ConfigManager([load_yaml(f) for f in yml], list(dotlist))
+            configure_runtime(cfg, dry_run=dry_run)
+            workflow(cfg, dry_run=dry_run)
+        except ConfigError as e:
+            raise click.ClickException(str(e)) from None
 
     return command
 
@@ -51,11 +54,14 @@ def load_yaml(f):
         Plain dictionary config.
 
     Raises:
-        ValueError: YAML contains list config.
+        ConfigError: YAML root is not a mapping.
     """
+    source = getattr(f, "name", "<stream>")
     config = yaml.safe_load(f)
     if not isinstance(config, dict):
-        raise ValueError(
-            f"JaQMC expects a dictionary config from {f.read()}. Got {type(config)}."
+        got = "empty document" if config is None else type(config).__name__
+        raise ConfigError(
+            f"Invalid YAML config in '{source}': expected a mapping at the "
+            f"document root, got {got}."
         )
     return config

--- a/src/jaqmc/utils/config.py
+++ b/src/jaqmc/utils/config.py
@@ -17,7 +17,7 @@ from pygments.formatters import TerminalFormatter
 from pygments.lexers import DiffLexer, YamlLexer
 from serde.core import field as serde_field
 
-from jaqmc.utils.module_resolver import resolve_object
+from jaqmc.utils.module_resolver import ModuleResolutionError, resolve_object
 from jaqmc.utils.wiring import wire
 from jaqmc.utils.yaml_format import annotate_yaml_with_sources, dump_yaml
 
@@ -26,6 +26,11 @@ _PRIMITIVE_TYPES = (int, float, str)
 logger = logging.LoggerAdapter(
     logging.getLogger(__name__), extra={"category": "config"}
 )
+
+
+class ConfigError(ValueError):
+    """Raised when JaQMC configuration is invalid."""
+
 
 # =============================================================================
 # Public API: Decorators and field helpers
@@ -412,14 +417,14 @@ class ConfigManager(ConfigManagerLike):
         any unused configuration keys.
 
         Args:
-            raise_on_unused: If True, raises `SystemExit` if there are any
+            raise_on_unused: If True, raises :class:`ConfigError` if there are any
                 unused configuration keys in the input.
             verbose: If True, includes docstrings and source information in
                 the logged YAML output.
             compare_yaml: YAML from previous from to log the difference.
 
         Raises:
-            SystemExit: If `raise_on_unused` is True and unused keys are found.
+            ConfigError: If `raise_on_unused` is True and unused keys are found.
         """
         yaml_content = self.to_yaml(verbose=verbose)
         logger.info(
@@ -430,21 +435,27 @@ class ConfigManager(ConfigManagerLike):
         )
         unused_yaml = _find_unused_yaml_path(self._visited_paths, self._user_config)
         unused_cli = _find_unused_yaml_path(self._visited_paths, self._cli_config)
-        if unused_yaml:
+        if (unused_yaml or unused_cli) and raise_on_unused:
+            lines = ["Unused config keys detected:"]
+            if unused_yaml:
+                lines.append(f"- from YAML/API: {unused_yaml}")
+            if unused_cli:
+                lines.append(f"- from CLI: {unused_cli}")
+            lines.append(
+                "\nRemove these keys, or set `workflow.config.ignore_extra=true` to "
+                "ignore extra config. If you call `cfg.finalize()` manually, use "
+                "`raise_on_unused=False`."
+            )
+            raise ConfigError("\n".join(lines))
+        elif unused_yaml:
             logger.warning(
                 "The following configs are specified via YAML/API but not used: %s",
                 sorted(unused_yaml),
             )
-        if unused_cli:
+        elif unused_cli:
             logger.warning(
                 "The following configs are specified via CLI but not used: %s",
                 sorted(unused_cli),
-            )
-        if (unused_yaml or unused_cli) and raise_on_unused:
-            raise SystemExit(
-                "Stopping due to invalid configs specified. Please consider using "
-                "`raise_on_unused=False` if you are calling `cfg.finalize` manually, "
-                "or pass workflow.config.ignore_extra=True if you are using CLI."
             )
         if compare_yaml is not None:
             diff = "\n".join(
@@ -492,7 +503,9 @@ class ConfigManager(ConfigManagerLike):
                 else default_module[: default_module.rfind(".")]
             )
             module_name = self._get_primitive(f"{name}.module", default_module)
-            make_module = resolve_object(module_name, package=module_base)
+            make_module = self._resolve_config_module(
+                f"{name}.module", module_name, package=module_base
+            )
         else:
             default_module_name = (
                 f"{default_module.__module__}:{default_module.__name__}"
@@ -504,7 +517,9 @@ class ConfigManager(ConfigManagerLike):
             )
             module_name = self._get_primitive(f"{name}.module", default_module_name)
             if module_name != default_module_name:
-                make_module = resolve_object(module_name, package=module_base)
+                make_module = self._resolve_config_module(
+                    f"{name}.module", module_name, package=module_base
+                )
             else:
                 make_module = default_module
         if is_dataclass(make_module):
@@ -530,8 +545,15 @@ class ConfigManager(ConfigManagerLike):
         for k, v in module_configs.items():
             if v is None:
                 continue
+            if not isinstance(v, dict):
+                raise ConfigError(
+                    f"Invalid config at '{name}.{k}': expected a mapping, "
+                    f"got {type(v).__name__}."
+                )
+            if "module" not in v:
+                raise ConfigError(f"Missing required config key '{name}.{k}.module'.")
             module_path = v["module"]
-            make_module = resolve_object(module_path)
+            make_module = self._resolve_config_module(f"{name}.{k}.module", module_path)
             if is_dataclass(make_module):
                 default_item = default_dict.get(k, {})
                 default_config = {
@@ -635,6 +657,11 @@ class ConfigManager(ConfigManagerLike):
         base_config = serde.to_dict(default) if not inspect.isclass(default) else {}
 
         config_data = user_config if user_config is not _MISSING else {}
+        if user_config is not _MISSING and not isinstance(config_data, dict):
+            raise ConfigError(
+                f"Invalid config at '{name}': expected a mapping, "
+                f"got {type(config_data).__name__}."
+            )
         if isinstance(config_data, dict):
             config_data = {k: v for k, v in config_data.items() if k != "module"}
         else:
@@ -644,7 +671,7 @@ class ConfigManager(ConfigManagerLike):
         try:
             result = serde.from_dict(cls, merged)
         except serde.SerdeError as e:
-            raise serde.SerdeError(f"Invalid config at '{name}': {e}") from None
+            raise ConfigError(f"Invalid config at '{name}': {e}") from None
 
         if not inspect.isclass(default):
             _copy_runtime_fields(default, result)
@@ -655,6 +682,18 @@ class ConfigManager(ConfigManagerLike):
         _set_path(self.resolved_config, name, resolved)
 
         return cast(DataclassT, result)
+
+    def _resolve_config_module(
+        self,
+        path: str,
+        module_name: str,
+        *,
+        package: str | None = None,
+    ) -> Any:
+        try:
+            return resolve_object(module_name, package=package)
+        except ModuleResolutionError as e:
+            raise ConfigError(f"Invalid config at '{path}': {e}") from None
 
     def _get_callable[CallableT: Callable](
         self,
@@ -717,7 +756,13 @@ def _get_path(data: dict[str, Any], path: list[str], default: Any = None) -> Any
 def _dotlist_to_dict(dotlist: list[str]) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for entry in dotlist:
+        if "=" not in entry:
+            raise ConfigError(
+                f"Invalid CLI override '{entry}': expected the form key=value."
+            )
         key, _, raw_value = entry.partition("=")
+        if not key:
+            raise ConfigError(f"Invalid CLI override '{entry}': key must not be empty.")
         _set_path(result, key, yaml.safe_load(raw_value))
     return result
 

--- a/src/jaqmc/utils/module_resolver.py
+++ b/src/jaqmc/utils/module_resolver.py
@@ -8,6 +8,49 @@ from importlib import import_module
 from typing import Any
 
 
+class ModuleResolutionError(ValueError):
+    """Raised when a module reference cannot be resolved."""
+
+
+def split_module_and_object(name: str) -> tuple[str, str | None]:
+    """Parse ``module[:object]`` notation.
+
+    Args:
+        name: The module reference to parse.
+
+    Returns:
+        The module name and optional explicit object name.
+
+    Raises:
+        ModuleResolutionError: If the reference has empty segments or
+            more than one colon.
+    """
+    if not name:
+        raise ModuleResolutionError(
+            "invalid module reference '': the module segment is empty. Expected "
+            "`module` or `module:object`; `module` may also be a path to a .py file."
+        )
+
+    colon_count = name.count(":")
+    if colon_count == 0:
+        return name, None
+    if colon_count > 1:
+        reason = "a module reference can contain one colon"
+    else:
+        module, obj_name = name.split(":")
+        if not module:
+            reason = "the module segment before ':' is empty"
+        elif not obj_name:
+            reason = "the object segment after ':' is empty"
+        else:
+            return module, obj_name
+
+    raise ModuleResolutionError(
+        f"invalid module reference '{name}': {reason}. Expected `module` or "
+        "`module:object`; `module` may also be a path to a .py file."
+    )
+
+
 def import_module_or_file(module_name: str, package: str | None = None) -> Any:
     """Import a python module or a python file.
 
@@ -21,6 +64,8 @@ def import_module_or_file(module_name: str, package: str | None = None) -> Any:
 
     Raises:
         OSError: Python file not found.
+        ModuleNotFoundError: Requested Python module or one of its dependencies
+            cannot be imported.
     """
     if module_name.endswith(".py"):
         # generate unique module name
@@ -31,26 +76,40 @@ def import_module_or_file(module_name: str, package: str | None = None) -> Any:
             raise OSError(f"Failed to load {module_name}")
         module = importlib.util.module_from_spec(spec)
         sys.modules[module_id] = module
-        spec.loader.exec_module(module)
+        try:
+            spec.loader.exec_module(module)
+        except BaseException:
+            # Clean staled temporary entries
+            if sys.modules.get(module_id) is module:
+                del sys.modules[module_id]
+            raise
         return module
     if package:
         try:
             return import_module("." + module_name, package=package)
-        except ModuleNotFoundError:
+        except ModuleNotFoundError as e:
+            relative_module = f"{package}.{module_name}"
+            if (
+                e.name != package
+                and e.name != relative_module
+                and not relative_module.startswith(f"{e.name}.")
+            ):
+                # Import error within target module
+                raise
             return import_module(module_name)
     return import_module(module_name)
 
 
 def resolve_object(name: str, package: str | None = None) -> Any:
-    """Resolve object from ``module:name`` notation with default export support.
+    """Resolve object from ``module:object`` notation with default export support.
 
     The default object (without explicitly specified object name) is
     the primary object via ``__all__[0]`` in the target module.
 
     Args:
-        name: The ``module:name`` notation. Supported forms:
+        name: The ``module:object`` notation. Supported forms:
 
-            - ``"module:name"``: Explicitly resolve ``module.name``
+            - ``"module:object"``: Explicitly resolve ``module.object``
               (e.g., ``"optax:adam"`` resolves to ``optax.adam``).
             - ``"module"``: Resolve default object from ``module.__all__[0]``
               (e.g., ``"jaqmc.optimizer.kfac"`` resolves to ``kfac``).
@@ -62,12 +121,11 @@ def resolve_object(name: str, package: str | None = None) -> Any:
         The resolved callable, class, or other object.
 
     Raises:
-        ValueError: If the object cannot be resolved, including when using
-            shorthand notation ("module") but the module has no `__all__`
-            attribute defined.
+        ModuleResolutionError: The reference is malformed, cannot be imported,
+            or cannot select an object from its imported module.
 
     Examples:
-        Explicit ``module:name`` form:
+        Explicit ``module:object`` form:
 
         >>> resolve_object("optax:adam")
         <function adam at ...>
@@ -77,20 +135,49 @@ def resolve_object(name: str, package: str | None = None) -> Any:
         >>> resolve_object("schedule:Standard", package="jaqmc.optimizer")
         <class 'jaqmc.optimizer.schedule.Standard'>
     """
-    colon_count = name.count(":")
-    if colon_count == 0:
-        module, obj_name = name, ""
-    elif colon_count == 1:
-        module, obj_name = name.split(":")
-    else:
-        raise ValueError(f"Invalid module '{name}': too many colons.")
+    module, obj_name = split_module_and_object(name)
+    try:
+        module_obj = import_module_or_file(module, package)
+    except ModuleNotFoundError as e:
+        missing_module = e.name or str(e)
+        if module == missing_module or module.startswith(f"{missing_module}."):
+            detail = (
+                f"could not import module '{module}': {e}. Check its spelling, "
+                "whether it is installed in this environment, and the import path."
+            )
+        else:
+            detail = (
+                f"could not import module '{module}' because its dependency "
+                f"'{missing_module}' is unavailable: {e}. Install that dependency "
+                "in this environment."
+            )
+        raise ModuleResolutionError(
+            f"module reference '{name}' is well-formed but {detail}"
+        ) from e
+    except OSError as e:
+        raise ModuleResolutionError(
+            f"could not load Python file '{module}': {e}. Check that the path exists "
+            "and is readable."
+        ) from e
 
-    module_obj = import_module_or_file(module, package)
-    if not obj_name:
+    if obj_name is None:
         if not getattr(module_obj, "__all__", []):
-            raise ValueError(f"Failed to find default object in {module}.")
+            raise ModuleResolutionError(
+                f"shorthand module reference '{name}' imported, but module '{module}' "
+                "does not define a default object in __all__. Use an explicit "
+                f"`{module}:object` reference instead."
+            )
         obj_name = module_obj.__all__[0]
-    obj = getattr(module_obj, obj_name)
+    try:
+        obj = getattr(module_obj, obj_name)
+    except AttributeError as e:
+        raise ModuleResolutionError(
+            f"module '{module}' imported, but does not export the requested object "
+            f"'{obj_name}'. Check the object name in `{module}:object`."
+        ) from e
     if obj is None:
-        raise ValueError(f"Fail to resolve '{name}'.")
+        raise ModuleResolutionError(
+            f"module reference '{name}' resolved to None: module '{module}' exports "
+            f"object '{obj_name}' as None."
+        )
     return obj

--- a/tests/app/system_unit_test.py
+++ b/tests/app/system_unit_test.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 import pytest
-import serde
 
 from jaqmc.app.molecule.config.base import MoleculePretrainReferenceConfig
 from jaqmc.app.molecule.wavefunction.ferminet import FermiNetWavefunction
@@ -12,7 +11,7 @@ from jaqmc.app.molecule.workflow import make_scf as make_molecule_scf
 from jaqmc.app.solid.config.base import SolidAtomConfig, SolidPretrainReferenceConfig
 from jaqmc.app.solid.workflow import configure_system as configure_solid_system
 from jaqmc.app.solid.workflow import make_scf as make_solid_scf
-from jaqmc.utils.config import ConfigManager
+from jaqmc.utils.config import ConfigError, ConfigManager
 from jaqmc.utils.units import ONE_ANGSTROM_IN_BOHR, LengthUnit
 
 
@@ -116,7 +115,7 @@ def test_solid_configure_system_normalizes_angstrom_before_scf():
 def test_system_config_rejects_unknown_length_unit():
     cfg = ConfigManager({"system": {"unit": "non-existing"}})
 
-    with pytest.raises(serde.SerdeError, match="not a valid LengthUnit"):
+    with pytest.raises(ConfigError, match="not a valid LengthUnit"):
         configure_molecule_system(cfg)
 
 
@@ -160,7 +159,7 @@ def test_solid_configure_system_rejects_cartesian_atom_coords():
         }
     )
 
-    with pytest.raises(serde.SerdeError, match="coords"):
+    with pytest.raises(ConfigError, match="coords"):
         configure_solid_system(cfg)
 
 

--- a/tests/cli_dry_run_test.py
+++ b/tests/cli_dry_run_test.py
@@ -388,3 +388,83 @@ def test_cli_verbose_config_dotlist(caplog: pytest.LogCaptureFixture) -> None:
     assert result.exit_code == 0, result.output
     assert "verbose: true" in caplog.text
     assert "Base configuration for workflows." in caplog.text
+
+
+def test_cli_invalid_dotlist_shows_click_error() -> None:
+    result = CliRunner().invoke(
+        cli,
+        [
+            "hall",
+            "train",
+            "--dry-run",
+            "workflow.batch_size",
+            "train.run.iterations=1",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Invalid CLI override 'workflow.batch_size'" in result.output
+
+
+def test_cli_unused_key_lists_exact_path() -> None:
+    result = CliRunner().invoke(
+        cli,
+        [
+            "hall",
+            "train",
+            "--dry-run",
+            "definitely_not_exist.batch_size=4",
+            "train.run.iterations=1",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Unused config keys detected" in result.output
+    assert "definitely_not_exist.batch_size" in result.output
+
+
+def test_cli_yaml_root_type_error(tmp_path: Path) -> None:
+    config_path = tmp_path / "bad.yml"
+    config_path.write_text("- not\n- a\n- mapping\n", encoding="utf8")
+
+    result = CliRunner().invoke(
+        cli,
+        ["hall", "train", "--yml", str(config_path), "--dry-run"],
+    )
+
+    assert result.exit_code == 1
+    assert f"Invalid YAML config in '{config_path}'" in result.output
+
+
+def test_cli_missing_required_field_uses_wrapped_pyserde_message() -> None:
+    result = CliRunner().invoke(
+        cli,
+        [
+            "hall",
+            "evaluate",
+            "--dry-run",
+            "workflow.batch_size=4",
+            "run.iterations=1",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Invalid config at 'workflow': missing required field" in result.output
+
+
+def test_cli_unknown_field_uses_wrapped_pyserde_message() -> None:
+    result = CliRunner().invoke(
+        cli,
+        [
+            "hall",
+            "evaluate",
+            "--dry-run",
+            "workflow.batch_size=4",
+            "workflow.source_path=source",
+            "workflow.source_pat=source",
+            "run.iterations=1",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Invalid config at 'workflow': unknown fields:" in result.output

--- a/tests/estimator/ph/ph_workflow_test.py
+++ b/tests/estimator/ph/ph_workflow_test.py
@@ -12,7 +12,7 @@ from jaqmc.app.molecule.config import AtomConfig, MoleculeConfig
 from jaqmc.app.molecule.workflow import make_estimators as make_molecule_estimators
 from jaqmc.estimator.ecp import ECPEnergy
 from jaqmc.estimator.ph import PHEnergy
-from jaqmc.utils.config import ConfigManager
+from jaqmc.utils.config import ConfigError, ConfigManager
 
 
 class _DummyWavefunction:
@@ -81,5 +81,5 @@ def test_ph_workflow_rejects_kinetic_mode_override_via_cfg_finalize():
 
     make_molecule_estimators(cfg, wf, system_config, always_enable_energy=True)
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(ConfigError, match="Unused config keys detected"):
         cfg.finalize(raise_on_unused=True)

--- a/tests/utils/config_test.py
+++ b/tests/utils/config_test.py
@@ -7,9 +7,15 @@ from typing import Any
 
 import pytest
 import yaml
-from serde.compat import SerdeError
 
-from jaqmc.utils.config import ConfigManager, configurable_dataclass, module_config
+from jaqmc.utils.config import (
+    ConfigError,
+    ConfigManager,
+    configurable_dataclass,
+    module_config,
+)
+from jaqmc.utils.module_resolver import ModuleResolutionError
+from jaqmc.workflow.evaluation import EvaluationWorkflowConfig
 
 
 @dataclass
@@ -266,7 +272,9 @@ def test_get_collection_dataclass_defaults(mocker):
 def test_get_collection_dataclass_module_override_ignores_old_defaults(mocker):
     mocker.patch(
         "jaqmc.utils.config.resolve_object",
-        side_effect=lambda path: {"path1": SimpleConfig, "path2": OtherConfig}[path],
+        side_effect=lambda path, package: {"path1": SimpleConfig, "path2": OtherConfig}[
+            path
+        ],
     )
 
     cfg = ConfigManager({"collection": {"item1": {"module": "path2"}}})
@@ -292,11 +300,72 @@ def test_finalize_unused():
     cfg.get("used", 0)
 
     # Should exit if unused keys exist and raise_on_unused is True (default)
-    with pytest.raises(SystemExit):
+    with pytest.raises(ConfigError, match=r"YAML.*unused"):
         cfg.finalize()
 
     # Should not raise if we ignore it
     cfg.finalize(raise_on_unused=False)
+
+
+def test_dotlist_missing_equals_raises_config_error():
+    with pytest.raises(
+        ConfigError,
+        match=(
+            r"Invalid CLI override 'workflow.batch_size': "
+            r"expected the form key=value"
+        ),
+    ):
+        ConfigManager({}, dotlist=["workflow.batch_size"])
+
+
+def test_get_dataclass_missing_required_field_message():
+    cfg = ConfigManager({})
+
+    with pytest.raises(
+        ConfigError,
+        match=(
+            r"Invalid config at 'workflow': missing required field "
+            r"'source_path' while deserializing EvaluationWorkflowConfig"
+        ),
+    ):
+        cfg.get("workflow", EvaluationWorkflowConfig)
+
+
+def test_get_dataclass_unknown_field_uses_pyserde_message():
+    cfg = ConfigManager({"workflow": {"source_pat": "runs/train"}})
+
+    with pytest.raises(
+        ConfigError,
+        match=(
+            r"Invalid config at 'workflow': unknown fields: \{'source_pat'\}, "
+            r"expected one of"
+        ),
+    ):
+        cfg.get("workflow", EvaluationWorkflowConfig)
+
+
+def test_get_dataclass_rejects_non_mapping():
+    cfg = ConfigManager({"workflow": 123})
+
+    with pytest.raises(
+        ConfigError,
+        match=r"Invalid config at 'workflow': expected a mapping, got int",
+    ):
+        cfg.get("workflow", EvaluationWorkflowConfig)
+
+
+def test_get_module_adds_config_path_to_resolution_error(mocker):
+    cfg = ConfigManager({"wf": {"module": "module:object"}})
+    mocker.patch(
+        "jaqmc.utils.config.resolve_object",
+        side_effect=ModuleResolutionError("resolver diagnostic"),
+    )
+
+    with pytest.raises(
+        ConfigError,
+        match=r"Invalid config at 'wf.module': resolver diagnostic",
+    ):
+        cfg.get_module("wf", "jaqmc.app.hall.wavefunction.mhpo")
 
 
 def test_to_yaml_with_comments():
@@ -535,7 +604,7 @@ def test_module_config_direct_value_union_keeps_dict_input_as_module_config():
 def test_module_config_direct_value_union_rejects_string_input():
     cfg = ConfigManager({"section": {"value": "4.5"}})
 
-    with pytest.raises(SerdeError, match=r"Union\[int, float\]"):
+    with pytest.raises(ConfigError, match=r"Union\[int, float\]"):
         cfg.get("section", default=DirectValueUnionConfig())
 
 
@@ -545,7 +614,7 @@ def test_get_module_rejects_unknown_fields_for_wavefunction_configs():
     cfg = ConfigManager({"wf": {"unknown": 1}})
 
     with pytest.raises(
-        SerdeError,
+        ConfigError,
         match=r"Invalid config at 'wf': unknown fields: \{'unknown'\}",
     ):
         cfg.get_module("wf", default_module=HydrogenAtom)

--- a/tests/utils/module_resolver_test.py
+++ b/tests/utils/module_resolver_test.py
@@ -1,18 +1,24 @@
 # Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
 # SPDX-License-Identifier: Apache-2.0
 
+import importlib
 import sys
 import tempfile
+import uuid
 from pathlib import Path
 from types import ModuleType
 
 import pytest
 
-from jaqmc.utils.module_resolver import import_module_or_file, resolve_object
+from jaqmc.utils.module_resolver import (
+    ModuleResolutionError,
+    import_module_or_file,
+    resolve_object,
+)
 
 
 # Test fixtures: create mock modules dynamically
-def make_module_with_all(name: str, exports: list[str]) -> ModuleType:
+def make_module_with_all(monkeypatch, name: str, exports: list[str]) -> ModuleType:
     """Create a module with __all__ defined.
 
     Returns:
@@ -23,11 +29,11 @@ def make_module_with_all(name: str, exports: list[str]) -> ModuleType:
     # Add some dummy objects
     for export in exports:
         setattr(module, export, f"object_{export}")
-    sys.modules[name] = module
+    monkeypatch.setitem(sys.modules, name, module)
     return module
 
 
-def make_module_without_all(name: str) -> ModuleType:
+def make_module_without_all(monkeypatch, name: str) -> ModuleType:
     """Create a module without __all__.
 
     Returns:
@@ -36,65 +42,95 @@ def make_module_without_all(name: str) -> ModuleType:
     module = ModuleType(name)
     module.some_function = "some_function_obj"  # type: ignore[attr-defined]
     module.another_object = "another_object_obj"  # type: ignore[attr-defined]
-    sys.modules[name] = module
+    monkeypatch.setitem(sys.modules, name, module)
     return module
 
 
 class TestResolveObject:
     """Tests for resolve_object function."""
 
-    def test_explicit_notation_with_colon(self):
+    def test_explicit_notation_with_colon(self, monkeypatch):
         """Test explicit 'module:name' notation."""
         # Setup: create a test module
-        make_module_with_all("test_module_explicit", ["target_func", "other"])
+        make_module_with_all(
+            monkeypatch, "test_module_explicit", ["target_func", "other"]
+        )
 
         # Test: resolve with explicit notation
         result = resolve_object("test_module_explicit:target_func")
 
         assert result == "object_target_func"
 
-    def test_shorthand_notation_uses_all_first_item(self):
+    def test_shorthand_notation_uses_all_first_item(self, monkeypatch):
         """Test shorthand 'module' notation uses __all__[0]."""
         # Setup: create module with __all__ = ["first", "second"]
-        make_module_with_all("test_module_shorthand", ["first", "second"])
+        make_module_with_all(monkeypatch, "test_module_shorthand", ["first", "second"])
 
         # Test: resolve without colon should get first item from __all__
         result = resolve_object("test_module_shorthand")
 
         assert result == "object_first"  # Should get __all__[0]
 
-    def test_shorthand_without_all_raises_error(self):
+    def test_shorthand_without_all_raises_error(self, monkeypatch):
         """Test shorthand notation fails when module has no __all__."""
         # Setup: create module without __all__
-        make_module_without_all("test_module_no_all")
+        make_module_without_all(monkeypatch, "test_module_no_all")
 
-        # Test: should raise ValueError
-        with pytest.raises(ValueError, match="Failed to find default object"):
+        # Test: shorthand has no default export
+        with pytest.raises(
+            ModuleResolutionError, match="does not define a default object"
+        ):
             resolve_object("test_module_no_all")
 
-    def test_shorthand_with_empty_all_raises_error(self):
+    def test_shorthand_with_empty_all_raises_error(self, monkeypatch):
         """Test shorthand notation fails when __all__ is empty."""
         # Setup: create module with empty __all__
         module = ModuleType("test_module_empty_all")
         module.__all__ = []  # type: ignore[attr-defined]
-        sys.modules["test_module_empty_all"] = module
+        monkeypatch.setitem(sys.modules, "test_module_empty_all", module)
 
-        # Test: should raise ValueError
-        with pytest.raises(ValueError, match="Failed to find default object"):
+        # Test: shorthand has no default export
+        with pytest.raises(
+            ModuleResolutionError, match="does not define a default object"
+        ):
             resolve_object("test_module_empty_all")
 
-    def test_too_many_colons_raises_error(self):
-        """Test that multiple colons in notation raises error."""
-        with pytest.raises(ValueError, match="too many colons"):
-            resolve_object("module:name:extra")
+    @pytest.mark.parametrize(
+        ("reference", "reason"),
+        [
+            ("", "module segment is empty"),
+            (":object", "module segment before ':' is empty"),
+            ("module:", "object segment after ':' is empty"),
+            ("module:name:extra", "can contain one colon"),
+        ],
+    )
+    def test_invalid_reference_raises_clear_error(self, reference, reason):
+        """Test malformed module references identify the invalid segment."""
+        with pytest.raises(ModuleResolutionError, match=reason):
+            resolve_object(reference)
 
-    def test_nonexistent_object_raises_error(self):
+    def test_missing_module_reports_import_guidance(self):
+        """Test missing modules report environment and spelling guidance."""
+        module_name = f"jaqmc_test_missing_{uuid.uuid4().hex}"
+
+        with pytest.raises(
+            ModuleResolutionError,
+            match=(
+                rf"module reference '{module_name}' is well-formed but could not "
+                rf"import module '{module_name}': .*Check its spelling"
+            ),
+        ):
+            resolve_object(module_name)
+
+    def test_nonexistent_object_raises_error(self, monkeypatch):
         """Test accessing non-existent object name raises AttributeError."""
         # Setup: create module
-        make_module_with_all("test_module_missing", ["exists"])
+        make_module_with_all(monkeypatch, "test_module_missing", ["exists"])
 
-        # Test: accessing non-existent attribute raises AttributeError
-        with pytest.raises(AttributeError):
+        # Test: accessing a missing object reports its module and object name
+        with pytest.raises(
+            ModuleResolutionError, match="does not export the requested object"
+        ):
             resolve_object("test_module_missing:nonexistent")
 
     def test_real_module_optax_adam(self):
@@ -109,31 +145,64 @@ class TestResolveObject:
         except ImportError:
             pytest.skip("optax not available")
 
-    def test_package_relative_import(self):
+    def test_package_relative_import(self, monkeypatch):
         """Test package parameter for relative imports."""
         # Setup: create a parent module and submodule
         parent = ModuleType("test_parent")
-        sys.modules["test_parent"] = parent
+        monkeypatch.setitem(sys.modules, "test_parent", parent)
 
         submodule = ModuleType("test_parent.submodule")
         submodule.target = "target_object"  # type: ignore[attr-defined]
-        sys.modules["test_parent.submodule"] = submodule
+        monkeypatch.setitem(sys.modules, "test_parent.submodule", submodule)
 
         # Test: resolve with package parameter (relative import)
         result = resolve_object("submodule:target", package="test_parent")
 
         assert result == "target_object"
 
+    def test_missing_python_file_reports_path_guidance(self, tmp_path):
+        """Test missing Python files report path guidance."""
+        module_path = tmp_path / "missing_plugin.py"
+
+        with pytest.raises(
+            ModuleResolutionError,
+            match=(
+                rf"could not load Python file '{module_path}': .*Check that the path "
+                r"exists"
+            ),
+        ):
+            resolve_object(f"{module_path}:Factory")
+
+    def test_missing_plugin_dependency_is_distinguished(self, tmp_path):
+        """Test plugin dependencies are distinguished from the configured module."""
+        module_path = tmp_path / "plugin.py"
+        missing_dependency = f"jaqmc_test_missing_{uuid.uuid4().hex}"
+        module_path.write_text(f"import {missing_dependency}\n", encoding="utf-8")
+        loaded_modules = {name for name in sys.modules if name.startswith("jaqmc_")}
+
+        with pytest.raises(
+            ModuleResolutionError,
+            match=(
+                rf"could not import module '{module_path}' because its dependency "
+                rf"'{missing_dependency}' is unavailable"
+            ),
+        ):
+            resolve_object(f"{module_path}:Factory")
+
+        assert {name for name in sys.modules if name.startswith("jaqmc_")} == (
+            loaded_modules
+        )
+
 
 class TestImportModuleOrFile:
     """Tests for import_module_or_file function."""
 
-    def test_import_regular_module(self):
+    def test_import_regular_module(self, monkeypatch):
         """Test importing a regular Python module."""
         # Setup: create a test module
         module = ModuleType("test_regular_module")
         module.value = 42  # type: ignore[attr-defined]
-        sys.modules["test_regular_module"] = module
+        monkeypatch.setitem(sys.modules, "test_regular_module", module)
 
         # Test: import should work
         result = import_module_or_file("test_regular_module")
@@ -166,14 +235,33 @@ class TestImportModuleOrFile:
         with pytest.raises(FileNotFoundError):
             import_module_or_file("/nonexistent/path/file.py")
 
-    def test_import_with_package_fallback(self):
+    def test_import_with_package_fallback(self, monkeypatch):
         """Test package parameter with fallback to absolute import."""
         # Setup: create a module only in absolute namespace
         module = ModuleType("absolute_module")
         module.value = "absolute"  # type: ignore[attr-defined]
-        sys.modules["absolute_module"] = module
+        monkeypatch.setitem(sys.modules, "absolute_module", module)
 
         # Test: even with package specified, should fallback to absolute import
         result = import_module_or_file("absolute_module", package="nonexistent_package")
 
         assert result.value == "absolute"
+
+    def test_relative_import_preserves_missing_dependency(self, tmp_path, monkeypatch):
+        """Test fallback does not hide a dependency missing inside a package."""
+        package_name = f"jaqmc_test_package_{uuid.uuid4().hex}"
+        missing_dependency = f"jaqmc_test_missing_{uuid.uuid4().hex}"
+        package_path = tmp_path / package_name
+        package_path.mkdir()
+        (package_path / "__init__.py").write_text("", encoding="utf-8")
+        (package_path / "plugin.py").write_text(
+            f"import {missing_dependency}\n",
+            encoding="utf-8",
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+        importlib.invalidate_caches()
+
+        with pytest.raises(ModuleNotFoundError, match=missing_dependency):
+            import_module_or_file("plugin", package=package_name)
+
+        monkeypatch.delitem(sys.modules, package_name, raising=False)

--- a/uv.lock
+++ b/uv.lock
@@ -1032,7 +1032,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=3.0.1" },
     { name = "pygments", specifier = ">=2.19.2" },
     { name = "pyscf", specifier = ">=2.11.0" },
-    { name = "pyserde", specifier = ">=0.31.1" },
+    { name = "pyserde", specifier = ">=0.31.7" },
     { name = "universal-pathlib", specifier = ">=0.3.6" },
 ]
 provides-extras = ["cuda12", "cuda12-local", "cuda13", "cuda13-local"]
@@ -2709,7 +2709,7 @@ wheels = [
 
 [[package]]
 name = "pyserde"
-version = "0.31.2"
+version = "0.31.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -2719,9 +2719,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspect" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/cb/0a6f40a74003cb13845733300f9debdc19fe3d25e5e73e9aaf69ee4e1480/pyserde-0.31.2.tar.gz", hash = "sha256:3ec19498cbd7df40f187565482a40f97bcbd382eba9f7cf2cb29d9b39f6e8ac6", size = 518265, upload-time = "2026-04-01T08:07:16.446Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/0b/4f92e27cb1ff15a820edc7b06b51bba4ef0d95bbf09522a72730cc7ffd51/pyserde-0.31.7.tar.gz", hash = "sha256:a9ec2a5a61930b6fee4498adda20067eab516798e5a0348da7797778d8b02fb6", size = 525805, upload-time = "2026-07-05T12:30:23.961Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/11/7b3d9495a977fbf56cba768b6c0239a6f84c37e3409607ac3572a78f7bb3/pyserde-0.31.2-py3-none-any.whl", hash = "sha256:97c0d3af585c6c664ecabd421290a822dc3910d8d7b842c64fb1f01e6e93a00e", size = 49097, upload-time = "2026-04-01T08:07:17.745Z" },
+    { url = "https://files.pythonhosted.org/packages/27/9c/055c3fb933119186541240e062973b44932fc10295965edac08c57bc5946/pyserde-0.31.7-py3-none-any.whl", hash = "sha256:5e72d5c2054d681b4aad712a40322fa2236ca5c181377daed4dbb4ec51a22ebb", size = 52340, upload-time = "2026-07-05T12:30:22.687Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This covers the main confusing cases: missing required key, bad module paths, and malformed CLI overrides like `key` without `=`.

Unused config keys now produce direct JaQMC errors instead of a generic stop or mixed raw exceptions.