### PR TITLE
update tests for optional evaluation source path

### DIFF
--- a/tests/cli_dry_run_test.py
+++ b/tests/cli_dry_run_test.py
@@ -446,22 +446,6 @@ def test_cli_yaml_root_type_error(tmp_path: Path) -> None:
     assert f"Invalid YAML config in '{config_path}'" in result.output
 
 
-def test_cli_missing_required_field_uses_wrapped_pyserde_message() -> None:
-    result = CliRunner().invoke(
-        cli,
-        [
-            "hall",
-            "evaluate",
-            "--dry-run",
-            "workflow.batch_size=4",
-            "run.iterations=1",
-        ],
-    )
-
-    assert result.exit_code == 1
-    assert "Invalid config at 'workflow': missing required field" in result.output
-
-
 def test_cli_unknown_field_uses_wrapped_pyserde_message() -> None:
     result = CliRunner().invoke(
         cli,

--- a/tests/utils/config_test.py
+++ b/tests/utils/config_test.py
@@ -318,17 +318,12 @@ def test_dotlist_missing_equals_raises_config_error():
         ConfigManager({}, dotlist=["workflow.batch_size"])
 
 
-def test_get_dataclass_missing_required_field_message():
+def test_get_dataclass_allows_missing_optional_source_path():
     cfg = ConfigManager({})
 
-    with pytest.raises(
-        ConfigError,
-        match=(
-            r"Invalid config at 'workflow': missing required field "
-            r"'source_path' while deserializing EvaluationWorkflowConfig"
-        ),
-    ):
-        cfg.get("workflow", EvaluationWorkflowConfig)
+    workflow = cfg.get("workflow", EvaluationWorkflowConfig)
+
+    assert workflow.source_path is None
 
 
 def test_get_dataclass_unknown_field_uses_pyserde_message():


### PR DESCRIPTION
Follow up to #74 and #75: checkpoint-free analytic evaluation makes `workflow.source_path` optional, superseding the required-field assertions. Remove the stale CLI check and verify omitted values resolve to `None.`