### PR TITLE
fix console handling of unselected arrays

### DIFF
--- a/src/jaqmc/writer/console.py
+++ b/src/jaqmc/writer/console.py
@@ -104,22 +104,18 @@ class ConsoleWriter(Writer):
         if step % self.interval != 0:
             return
 
-        values = {"step": step}
-        for k, v in stats.items():
-            values[k] = self.to_scalar(v)
-
         final_parts = [f"step={step}"]
         missing_fields: set[str] = set()
 
         for spec in self.fields_specs:
-            if spec.key in values:
-                val = values[spec.key]
+            if spec.key in stats:
+                val = self.to_scalar(stats[spec.key])
                 final_parts.append(f"{spec.display_name}={val:{spec.fmt or '.4f'}}")
             elif spec.key not in self._warned_missing_fields:
                 missing_fields.add(spec.key)
 
         if missing_fields:
-            available = ", ".join(sorted(values))
+            available = ", ".join(sorted(stats))
             self.logger.warning(
                 "Console fields %s are not present in stats. Available fields: %s",
                 missing_fields,

--- a/tests/writer/console_writer_test.py
+++ b/tests/writer/console_writer_test.py
@@ -4,6 +4,7 @@
 import logging
 
 import pytest
+from jax import numpy as jnp
 
 from jaqmc.writer.console import ConsoleWriter
 
@@ -17,6 +18,15 @@ def test_console_writer_default(mocker):
 
         # Expect step and loss (default field)
         mock_logger.info.assert_called_with("step=1, loss=1.2346")
+
+
+def test_console_writer_ignores_unselected_array_stats(mocker):
+    writer = ConsoleWriter(interval=1)
+    with writer.open(None, "test"):
+        mock_logger = mocker.patch.object(writer, "logger")
+        writer.write(1, {"loss": 1.234567, "samples": jnp.ones(2)})
+
+        mock_logger.info.assert_called_once_with("step=1, loss=1.2346")
 
 
 def test_console_writer_custom_fields(mocker):
@@ -94,4 +104,4 @@ def test_console_writer_warns_once_for_missing_field(
         and "missing_var" in record.getMessage()
     ]
     assert len(warnings) == 1
-    assert "Available fields: loss, step" in warnings[0].getMessage()
+    assert "Available fields: loss" in warnings[0].getMessage()


### PR DESCRIPTION
Convert only configured console fields to scalars so unrelated array-valued stats do not break logging. Add regression coverage for this case.