### PR TITLE
work around CUDA donated-output corruption

### DIFF
--- a/src/jaqmc/workflow/stage/evaluation.py
+++ b/src/jaqmc/workflow/stage/evaluation.py
@@ -178,11 +178,11 @@ class EvaluationWorkStage(SamplingWorkStage):
 
     def compute_step(
         self, state: SamplingState, rngs: PRNGKey
-    ) -> tuple[dict[str, Any], SamplingState]:
+    ) -> tuple[SamplingState, dict[str, Any]]:
         """Sample and estimate observables (no parameter update).
 
         Returns:
-            Tuple of (per-walker local stats, updated state).
+            Tuple of (updated state, per-walker local stats).
         """
         sampler_rngs, est_rngs = jax.random.split(rngs, 2)
         data, _, sampler_state = self.sample_plan.step(
@@ -191,12 +191,13 @@ class EvaluationWorkStage(SamplingWorkStage):
         step_stats, estimator_state = self.estimators.evaluate(
             state.params, data, state.estimator_state, est_rngs
         )
-        return step_stats, replace(
+        new_state = replace(
             state,
             batched_data=data,
             sampler_state=sampler_state,
             estimator_state=estimator_state,
         )
+        return new_state, step_stats
 
     def write_digest(self, state: SamplingState) -> None:
         """Finalize accumulated stats and save digest."""
@@ -243,7 +244,7 @@ class EvaluationWorkStage(SamplingWorkStage):
         compute = parallel_jax.jit_sharded(
             self.compute_step,
             in_specs=(partition, parallel_jax.DATA_PARTITION),
-            out_specs=(parallel_jax.SHARE_PARTITION, partition),
+            out_specs=(partition, parallel_jax.SHARE_PARTITION),
             check_vma=self.config.check_vma,
             donate_argnums=0,
         )
@@ -256,7 +257,7 @@ class EvaluationWorkStage(SamplingWorkStage):
 
         for step in range(initial_step, self.config.iterations):
             rngs, sub_rngs = split_rngs(rngs)
-            step_stats, state = compute(state, sub_rngs)
+            state, step_stats = compute(state, sub_rngs)
 
             if is_master:
                 self.hdf5.write(step, step_stats)

--- a/src/jaqmc/workflow/stage/vmc.py
+++ b/src/jaqmc/workflow/stage/vmc.py
@@ -236,11 +236,11 @@ class VMCWorkStage(SamplingWorkStage):
 
     def compute_step(
         self, state: VMCState, rngs: PRNGKey
-    ) -> tuple[dict[str, Any], VMCState]:
+    ) -> tuple[VMCState, dict[str, Any]]:
         """Sample, estimate, compute gradients, and update parameters.
 
         Returns:
-            Tuple of (finalized stats, updated state with new params).
+            Tuple of (updated state with new params, finalized stats).
 
         Raises:
             ValueError: If no estimator provides ``grads``.
@@ -265,7 +265,7 @@ class VMCWorkStage(SamplingWorkStage):
             rngs=opt_rngs,
         )
         params = optax.apply_updates(state.params, updates)
-        return {**final_stats, **sampler_stats}, replace(
+        new_state = replace(
             state,
             params=params,
             batched_data=data,
@@ -273,6 +273,7 @@ class VMCWorkStage(SamplingWorkStage):
             estimator_state=estimator_state,
             opt_state=opt_state,
         )
+        return new_state, {**final_stats, **sampler_stats}
 
     def _has_nan(self, stats: dict[str, Any]) -> bool:
         if not self.config.stop_on_nan:
@@ -309,7 +310,7 @@ class VMCWorkStage(SamplingWorkStage):
         compute = parallel_jax.jit_sharded(
             self.compute_step,
             in_specs=(partition, parallel_jax.DATA_PARTITION),
-            out_specs=(parallel_jax.SHARE_PARTITION, partition),
+            out_specs=(partition, parallel_jax.SHARE_PARTITION),
             check_vma=check_vma,
             donate_argnums=0,
         )
@@ -320,7 +321,7 @@ class VMCWorkStage(SamplingWorkStage):
         # Main loop
         for step in range(initial_step, self.config.iterations):
             rngs, sub_rngs = split_rngs(rngs)
-            stats, state = compute(state, sub_rngs)
+            state, stats = compute(state, sub_rngs)
             self.writers.write(step, stats)
             if self._has_nan(stats):
                 raise StageAbort(step, state)


### PR DESCRIPTION
On CUDA with JAX 0.8 and new versions, work stage computations with `state` donated can return wrong `stats` if the `stats` is returned before `states`.

See also:
- https://github.com/jax-ml/jax/issues/39625