### PR TITLE
speed up per-step hdf5 stats writes

### DIFF
--- a/src/jaqmc/utils/hdf5.py
+++ b/src/jaqmc/utils/hdf5.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Mapping
+from contextlib import contextmanager
+from typing import Any
+
+import h5py
+import jax
+import numpy as np
+from upath import UPath
+
+
+class CachedHDF5(h5py.File):
+    """HDF5 file that reuses dataset handles by name.
+
+    JaQMC writes statistics one step at a time, but each step usually appends
+    to the same small set of datasets. In h5py, ``file[name]`` and
+    ``name in file`` are not ordinary dictionary operations: both ask the HDF5
+    library to resolve ``name``, and ``file[name]`` also builds a new
+    ``Dataset`` wrapper for the opened object. For small per-step writes, that
+    repeated path lookup can dominate the cost of the actual append.
+
+    This class caches only opened or newly created ``Dataset`` handles. It does
+    not buffer rows or delay writes. Hot write paths should therefore check
+    :meth:`cached_dataset` first and fall back to HDF5 lookup only for names
+    that have not been seen before.
+    """
+
+    def __init__(self, name, mode="r", **kwds) -> None:
+        super().__init__(name, mode, **kwds)
+        self._cached_dataset_handlers: dict[str, h5py.Dataset] = {}
+
+    def __getitem__(self, name):
+        if name not in self._cached_dataset_handlers:
+            self._cached_dataset_handlers[name] = super().__getitem__(name)
+        return self._cached_dataset_handlers[name]
+
+    def cached_dataset(self, name: str) -> h5py.Dataset | None:
+        return self._cached_dataset_handlers.get(name)
+
+    def cache_dataset(self, name: str, dataset: h5py.Dataset) -> None:
+        self._cached_dataset_handlers[name] = dataset
+
+
+class HDF5ReadWrite:
+    """Statistics storage in an HDF5 file.
+
+    Args:
+        stats_path: Path of the HDF5 file.
+        truncate_to: If given, all datasets are truncated to at most this
+            many rows upon :meth:`open`, so resumed runs discard stale rows
+            left by a previous interrupted run. If None, rows are kept.
+    """
+
+    def __init__(self, stats_path: UPath, truncate_to: int | None = None) -> None:
+        self.stats_path = stats_path
+        self.truncate_to = truncate_to
+        self._h5_file: CachedHDF5 | None = None
+
+    @contextmanager
+    def open(self):
+        self.stats_path.parent.mkdir(exist_ok=True, parents=True)
+        open_mode = "r+b" if self.stats_path.exists() else "w+b"
+        with self.stats_path.open(open_mode) as raw, CachedHDF5(raw, "a") as h5:
+            self._h5_file = h5
+            self._truncate()
+            yield
+            self.close()
+
+    def _truncate(self) -> None:
+        """Truncate all datasets to ``truncate_to`` rows, if set."""
+        if self.truncate_to is None or not self._h5_file:
+            return
+        for name in list(self._h5_file):
+            dataset = self._h5_file[name]
+            if dataset.shape[0] > self.truncate_to:
+                dataset.resize(self.truncate_to, axis=0)
+
+    def read(self) -> dict[str, np.ndarray]:
+        """Read all accumulated stats from the open HDF5 file.
+
+        Returns:
+            Dictionary mapping stat names to numpy arrays with a leading
+            step dimension.
+
+        Raises:
+            ValueError: Writing on closed file.
+        """
+        if not self._h5_file:
+            raise ValueError("Writing on closed file.")
+        return {key: np.asarray(self._h5_file[key][:]) for key in self._h5_file}
+
+    def write(self, stats: Mapping[str, Any]) -> None:
+        if not self._h5_file:
+            raise ValueError("Writing on closed file.")
+
+        array_stats = jax.device_get(
+            {key: value for key, value in stats.items() if isinstance(value, jax.Array)}
+        )
+        for key, value in array_stats.items():
+            ds = self._h5_file.cached_dataset(key)
+            if ds is None and key not in self._h5_file:
+                ds = self._h5_file.create_dataset(
+                    key, data=value[None], maxshape=(None, *value.shape)
+                )
+                self._h5_file.cache_dataset(key, ds)
+            else:
+                ds = ds if ds is not None else self._h5_file[key]
+                ds.resize(ds.shape[0] + 1, axis=0)
+                ds[-1] = value
+
+    def close(self):
+        if not self._h5_file:
+            return
+        self._h5_file.close()
+        self._h5_file = None

--- a/src/jaqmc/workflow/stage/evaluation.py
+++ b/src/jaqmc/workflow/stage/evaluation.py
@@ -7,21 +7,18 @@ Accumulates per-step statistics in an HDF5 file owned by the stage and produces 
 ``digest.npz`` summary after all steps. Optionally logs preview digests.
 """
 
-from collections.abc import Mapping
-from contextlib import contextmanager
+from contextlib import nullcontext
 from dataclasses import dataclass, replace
 from typing import Any, ClassVar
 
-import h5py
 import jax
 import numpy as np
-from upath import UPath
 
 from jaqmc.array_types import PRNGKey
 from jaqmc.utils import parallel_jax
 from jaqmc.utils.config import configurable_dataclass
+from jaqmc.utils.hdf5 import HDF5ReadWrite
 from jaqmc.writer import Writers
-from jaqmc.writer.hdf5 import h5_append
 
 from .base import RunContext, WorkStageConfig
 from .sampling import SamplingStageBuilder, SamplingState, SamplingWorkStage
@@ -39,53 +36,6 @@ class EvaluationWorkStageConfig(WorkStageConfig):
     """
 
     digest_step_interval: int = 0
-
-
-class HDF5ReadWrite:
-    def __init__(self, working_dir: UPath, prefix: str, is_master: bool):
-        self._working_dir = working_dir
-        self._prefix = f"{prefix}_" if prefix else ""
-        self.is_master = is_master
-
-    @contextmanager
-    def open(self):
-        if self.is_master:
-            self._working_dir.mkdir(exist_ok=True, parents=True)
-            stats_path = self._working_dir / f"{self._prefix}stats.h5"
-            open_mode = "r+b" if stats_path.exists() else "w+b"
-            with stats_path.open(open_mode) as raw, h5py.File(raw, "a") as h5:
-                self._stats_file = h5
-                yield
-        else:
-            self._stats_file = None
-            yield
-
-    def read(self) -> dict[str, np.ndarray]:
-        """Read all accumulated stats from the open HDF5 file.
-
-        Returns:
-            Dictionary mapping stat names to numpy arrays with a leading
-            step dimension.
-
-        Raises:
-            ValueError: Writing on closed file.
-        """
-        if not self.is_master:
-            return {}
-        if not self._stats_file:
-            raise ValueError("Writing on closed file.")
-        return {key: np.asarray(self._stats_file[key][:]) for key in self._stats_file}
-
-    def write(self, step: int, stats: Mapping[str, Any]) -> None:
-        if not self.is_master:
-            return
-        if not self._stats_file:
-            raise ValueError("Writing on closed file.")
-
-        for key, value in stats.items():
-            if not isinstance(value, jax.Array):
-                continue
-            h5_append(self._stats_file, key, value[None])
 
 
 class EvalStageBuilder(SamplingStageBuilder):
@@ -158,7 +108,11 @@ class EvaluationWorkStage(SamplingWorkStage):
         is_master = jax.process_index() == 0
         self._save_dir = save_dir
         self._prefix = prefix
-        self.hdf5 = HDF5ReadWrite(save_dir, prefix, is_master)
+
+        prefix_str = f"{prefix}_" if prefix else ""
+        self.hdf5 = HDF5ReadWrite(
+            save_dir / f"{prefix_str}stats.h5", truncate_to=self.config.iterations
+        )
         if self.config.digest_step_interval == 0:
             self.logger.info(
                 "Evaluation digest will only be printed at the last step. Set "
@@ -170,7 +124,7 @@ class EvaluationWorkStage(SamplingWorkStage):
                 "Evaluation digest will be logged every %d steps.",
                 self.config.digest_step_interval,
             )
-        with self.hdf5.open():
+        with self.hdf5.open() if is_master else nullcontext():
             state = super().run(state, context, rngs)
             if is_master:
                 self.write_digest(state)
@@ -260,7 +214,7 @@ class EvaluationWorkStage(SamplingWorkStage):
             state, step_stats = compute(state, sub_rngs)
 
             if is_master:
-                self.hdf5.write(step, step_stats)
+                self.hdf5.write(step_stats)
                 self.writers.write(step, step_stats)
                 if digest_step_interval and (step + 1) % digest_step_interval == 0:
                     self.log_preview_digest(step, state)

--- a/src/jaqmc/writer/hdf5.py
+++ b/src/jaqmc/writer/hdf5.py
@@ -3,26 +3,16 @@
 
 from collections.abc import Mapping
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Any
 
-import h5py
-import jax
+from upath import UPath
 
 from jaqmc.utils.config import configurable_dataclass
+from jaqmc.utils.hdf5 import HDF5ReadWrite
 from jaqmc.writer.base import Writer
 
-__all__ = ["HDF5Writer", "h5_append"]
-
-
-def h5_append(h5file: h5py.File, key: str, values: Any) -> None:
-    """Append values along axis 0, creating the dataset if needed."""
-    if key in h5file:
-        ds = h5file[key]
-        n = ds.shape[0]
-        ds.resize(n + values.shape[0], axis=0)
-        ds[n:] = values
-    else:
-        h5file.create_dataset(key, data=values, maxshape=(None, *values.shape[1:]))
+__all__ = ["HDF5Writer"]
 
 
 @configurable_dataclass
@@ -30,7 +20,7 @@ class HDF5Writer(Writer):
     """Writes statistics to an HDF5 file.
 
     Existing files are truncated to ``initial_step`` data rows upon :meth:`open`
-    before new rows are appended, so resumed runs discard stale rows past the
+    before new rows are written, so resumed runs discard stale rows past the
     restored checkpoint.
 
     Args:
@@ -41,29 +31,15 @@ class HDF5Writer(Writer):
     path_template: str = "{stage}_stats.h5"
 
     @contextmanager
-    def open(self, working_dir, stage_name, initial_step: int = 0):
+    def open(self, working_dir: UPath | Path, stage_name: str, initial_step: int = 0):
         save_path = self.resolve_path_template(
             working_dir, self.path_template, stage_name
         )
-        open_mode = "r+b" if save_path.exists() else "w+b"
-        save_path.parent.mkdir(exist_ok=True, parents=True)
-        with save_path.open(open_mode) as f, h5py.File(f, "a") as self._h5_file:
-            self._truncate_to(initial_step)
+        self._h5_writer = HDF5ReadWrite(save_path, truncate_to=initial_step)
+        with self._h5_writer.open():
             yield
-        self._h5_file = None
-
-    def _truncate_to(self, initial_step: int) -> None:
-        """Truncate all datasets to ``initial_step`` entries."""
-        for name in list(self._h5_file):
-            dataset = self._h5_file[name]
-            if dataset.shape[0] > initial_step:
-                dataset.resize(initial_step, axis=0)
 
     def write(self, step: int, stats: Mapping[str, Any]) -> None:
-        if not self._h5_file:
+        if not self._h5_writer:
             raise ValueError("Writing on closed file.")
-
-        for key, value in stats.items():
-            if not isinstance(value, jax.Array):
-                continue
-            h5_append(self._h5_file, key, value[None])
+        self._h5_writer.write(stats)


### PR DESCRIPTION
Every iteration pays for synchronous h5py stats writes on the master process. The old path created a fresh `Dataset` proxy per key per row and transferred each JAX array to host memory individually, leaving the GPU idle during writes: in a molecule training run, the measured duty cycle was ~78%, versus ~88% with the HDF5 writer disabled entirely.

Cache dataset handles across rows and issues one batched `jax.device_get` per row instead. The measured GPU duty cycle rises to ~86%, closing most of the gap to the writer-disabled baseline.