### PR TITLE
fix sampler configuration references

### DIFF
--- a/docs/systems/hall/eval.md
+++ b/docs/systems/hall/eval.md
@@ -3,11 +3,10 @@
 Configuration reference for `jaqmc hall evaluate`.
 This page shows the effective defaults for the evaluation workflow preset. Use
 `--dry-run` to see the resolved config for your run, or add
-`workflow.config.verbose=true` to include field descriptions. Evaluation has
-only one stage, so stage keys (`run.*`, `sampler.*`, `writers.*`) live at the
-config root rather than under a `train.*` prefix. Defaults are resolved in this
-order: schema defaults, workflow preset, YAML config, then CLI overrides. For
-training config, see <project:train.md>.
+`workflow.config.verbose=true` to include field descriptions. Evaluation keys
+for `run.*`, `sampler.*`, and `writers.*` live at the config root. Defaults are
+resolved in this order: schema defaults, workflow preset, YAML config, then CLI
+overrides. For training config, see <project:train.md>.
 
 Root-level runtime keys such as `logging.*`, `jax.*`, and `distributed.*` are
 shared by all commands. See <project:../../guide/runtime-configuration.md>.
@@ -51,7 +50,8 @@ adds `digest_step_interval` for previewing accumulated statistics.
 
 ## Sampler (`sampler.*`)
 
-- Default sampler module: `mcmc`, and its effective keys are listed below.
+Hall evaluation uses adaptive Metropolis-Hastings sampling with a spherical
+proposal.
 
 ```{eval-rst}
 .. config-defaults:: jaqmc.sampler.mcmc.MCMCSampler

--- a/docs/systems/hall/index.md
+++ b/docs/systems/hall/index.md
@@ -91,7 +91,7 @@ quick tests. See <project:../../guide/sampling.md> for walker count, mixing, and
 behavior.
 
 The sampler defaults are usually reasonable. Reach for
-{cfgkey}`train.sampler.steps <systems-hall-train-cfg-train-sampler-mcmc-steps>` or
+{cfgkey}`sampler.steps <systems-hall-train-cfg-sampler-steps>` or
 {cfgkey}`train.run.burn_in <systems-hall-train-cfg-train-run-burn-in>` only when the walkers are not
 mixing well or `pmove` looks unhealthy. For optimizer choice, the production default is
 [train.optim.module](#hall-train-optim); use the

--- a/docs/systems/hall/train.md
+++ b/docs/systems/hall/train.md
@@ -75,6 +75,17 @@ See <project:index.md> for background on each architecture.
    :scope: Free
 ```
 
+(hall-train-sampler)=
+## Sampler (`sampler.*`)
+
+The Hall workflow uses adaptive Metropolis-Hastings sampling with a spherical
+proposal.
+
+```{eval-rst}
+.. config-defaults:: jaqmc.sampler.mcmc.MCMCSampler
+   :prefix: sampler
+```
+
 (hall-train-stage)=
 ## Train Stage (`train.*`)
 
@@ -124,17 +135,6 @@ The VMC optimization loop. Samples electron configurations on the Haldane sphere
 .. config-defaults:: jaqmc.optimizer.optax.lamb
    :prefix: train.optim
    :scope: LAMB
-```
-
-(hall-train-sampler)=
-### Sampler (`train.sampler.*`)
-
-- Default sampler module: `mcmc`, and its effective keys are listed below.
-
-```{eval-rst}
-.. config-defaults:: jaqmc.sampler.mcmc.MCMCSampler
-   :prefix: train.sampler
-   :scope: MCMC
 ```
 
 (hall-train-writers)=

--- a/docs/systems/molecule/eval.md
+++ b/docs/systems/molecule/eval.md
@@ -3,11 +3,10 @@
 Configuration reference for `jaqmc molecule evaluate`.
 This page shows the effective defaults for the evaluation workflow preset. Use
 `--dry-run` to see the resolved config for your run, or add
-`workflow.config.verbose=true` to include field descriptions. Evaluation has
-only one stage, so stage keys (`run.*`, `sampler.*`, `writers.*`) live at the
-config root rather than under a `train.*` prefix. Defaults are resolved in this
-order: schema defaults, workflow preset, YAML config, then CLI overrides. For
-training config, see <project:train.md>.
+`workflow.config.verbose=true` to include field descriptions. Evaluation keys
+for `run.*`, `sampler.*`, and `writers.*` live at the config root. Defaults are
+resolved in this order: schema defaults, workflow preset, YAML config, then CLI
+overrides. For training config, see <project:train.md>.
 
 Root-level runtime keys such as `logging.*`, `jax.*`, and `distributed.*` are
 shared by all commands. See <project:../../guide/runtime-configuration.md>.
@@ -43,7 +42,8 @@ adds `digest_step_interval` for previewing accumulated statistics.
 
 ## Sampler (`sampler.*`)
 
-- Default sampler module: `mcmc`, and its effective keys are listed below.
+Molecule evaluation uses adaptive Metropolis-Hastings sampling with an
+all-electron Gaussian proposal.
 
 ```{eval-rst}
 .. config-defaults:: jaqmc.sampler.mcmc.MCMCSampler

--- a/docs/systems/molecule/train.md
+++ b/docs/systems/molecule/train.md
@@ -95,6 +95,17 @@ Selects and configures the neural-network ansatz.
    :scope: Psiformer
 ```
 
+(train-sampler)=
+## Sampler (`sampler.*`)
+
+The molecule workflow uses adaptive Metropolis-Hastings sampling with an
+all-electron Gaussian proposal. Pretraining and training share these settings.
+
+```{eval-rst}
+.. config-defaults:: jaqmc.sampler.mcmc.MCMCSampler
+   :prefix: sampler
+```
+
 ---
 
 (train-stage)=
@@ -149,17 +160,6 @@ updates wavefunction parameters.
    :scope: LAMB
 ```
 
-(train-sampler)=
-### Sampler (`train.sampler.*`)
-
-- Default sampler module: `mcmc`, and its effective keys are listed below.
-
-```{eval-rst}
-.. config-defaults:: jaqmc.sampler.mcmc.MCMCSampler
-   :prefix: train.sampler
-   :scope: MCMC
-```
-
 (train-writers)=
 ### Writers (`train.writers.*`)
 
@@ -201,8 +201,9 @@ Loss and gradient estimator. Computes the VMC loss and parameter gradients.
 ## Pretrain Stage (`pretrain.*`)
 
 Initializes the neural network to approximate Hartree-Fock orbitals before VMC
-training. It uses the same run, sampler, and writer schemas as the train stage,
-but with a different optimizer default and a workflow-wired supervised loss.
+training. Its run and writer settings follow the same schemas as the train
+stage, while the optimizer default and workflow-wired supervised loss are
+specific to pretraining.
 
 ### Reference (`pretrain.reference.*`)
 
@@ -232,16 +233,6 @@ target orbitals for pretraining. Most runs can keep the default settings.
 .. config-defaults:: jaqmc.optimizer.optax.adam
    :prefix: pretrain.optim
    :scope: Adam
-```
-
-### Sampler (`pretrain.sampler.*`)
-
-- Default sampler module: `mcmc`.
-
-```{eval-rst}
-.. config-defaults:: jaqmc.sampler.mcmc.MCMCSampler
-   :prefix: pretrain.sampler
-   :scope: MCMC
 ```
 
 ### Writers (`pretrain.writers.*`)

--- a/docs/systems/solid/eval.md
+++ b/docs/systems/solid/eval.md
@@ -3,11 +3,10 @@
 Configuration reference for `jaqmc solid evaluate`.
 This page shows the effective defaults for the evaluation workflow preset. Use
 `--dry-run` to see the resolved config for your run, or add
-`workflow.config.verbose=true` to include field descriptions. Evaluation has
-only one stage, so stage keys (`run.*`, `sampler.*`, `writers.*`) live at the
-config root rather than under a `train.*` prefix. Defaults are resolved in this
-order: schema defaults, workflow preset, YAML config, then CLI overrides. For
-training config, see <project:train.md>.
+`workflow.config.verbose=true` to include field descriptions. Evaluation keys
+for `run.*`, `sampler.*`, and `writers.*` live at the config root. Defaults are
+resolved in this order: schema defaults, workflow preset, YAML config, then CLI
+overrides. For training config, see <project:train.md>.
 
 Root-level runtime keys such as `logging.*`, `jax.*`, and `distributed.*` are
 shared by all commands. See <project:../../guide/runtime-configuration.md>.
@@ -54,7 +53,8 @@ adds `digest_step_interval` for previewing accumulated statistics.
 
 ## Sampler (`sampler.*`)
 
-- Default sampler module: `mcmc`, and its effective keys are listed below.
+Solid evaluation uses adaptive Metropolis-Hastings sampling with a periodic
+Gaussian proposal.
 
 ```{eval-rst}
 .. config-defaults:: jaqmc.sampler.mcmc.MCMCSampler

--- a/docs/systems/solid/train.md
+++ b/docs/systems/solid/train.md
@@ -73,6 +73,17 @@ Defines the periodic solid system to simulate. The implementation is selected by
    :scope: Solid
 ```
 
+(solid-train-sampler)=
+## Sampler (`sampler.*`)
+
+The solid workflow uses adaptive Metropolis-Hastings sampling with a periodic
+Gaussian proposal. Pretraining and training share these settings.
+
+```{eval-rst}
+.. config-defaults:: jaqmc.sampler.mcmc.MCMCSampler
+   :prefix: sampler
+```
+
 ---
 
 (solid-train-stage)=
@@ -126,17 +137,6 @@ The main VMC optimization loop. Samples electron configurations, computes energy
    :scope: LAMB
 ```
 
-(solid-train-sampler)=
-### Sampler (`train.sampler.*`)
-
-- Default sampler module: `mcmc`, and its effective keys are listed below.
-
-```{eval-rst}
-.. config-defaults:: jaqmc.sampler.mcmc.MCMCSampler
-   :prefix: train.sampler
-   :scope: MCMC
-```
-
 (solid-train-writers)=
 ### Writers (`train.writers.*`)
 
@@ -178,8 +178,9 @@ Loss and gradient estimator. Computes the VMC loss and parameter gradients. See 
 ## Pretrain Stage (`pretrain.*`)
 
 Initializes the neural network to approximate Hartree-Fock orbitals before VMC
-training. It uses the same run, sampler, and writer schemas as the train stage,
-but with a different optimizer default and a workflow-wired supervised loss.
+training. Its run and writer settings follow the same schemas as the train
+stage, while the optimizer default and workflow-wired supervised loss are
+specific to pretraining.
 
 ### Reference (`pretrain.reference.*`)
 
@@ -209,16 +210,6 @@ target orbitals for pretraining. Most runs can keep the default settings.
 .. config-defaults:: jaqmc.optimizer.optax.adam
    :prefix: pretrain.optim
    :scope: Adam
-```
-
-### Sampler (`pretrain.sampler.*`)
-
-- Default sampler module: `mcmc`.
-
-```{eval-rst}
-.. config-defaults:: jaqmc.sampler.mcmc.MCMCSampler
-   :prefix: pretrain.sampler
-   :scope: MCMC
 ```
 
 ### Writers (`pretrain.writers.*`)


### PR DESCRIPTION
Document sampler settings at their root-level location so the system references match resolved workflow configuration. Clarify shared stage usage and system-specific proposal geometry.