### PR TITLE
exclude ignored and untracked files from mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,8 +40,8 @@ repos:
         name: mypy
         language: system
         # workaround for tools like VS Code which doesn't activate venv
-        entry: .venv/bin/mypy .
+        # wrapper excludes untracked files, which prek does not stash
+        entry: .venv/bin/python scripts/run_mypy.py
         types_or: [python, pyi]
-        args: ["--ignore-missing-imports"]
         pass_filenames: false
         exclude: "(docs|tests)/.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ build-backend = "uv_build"
 module-name = ["jaqmc", "jaqmc_legacy"]
 
 [tool.mypy]
+exclude_gitignore = true
 ignore_missing_imports = true
 warn_redundant_casts = true
 warn_unused_ignores = true

--- a/scripts/run_mypy.py
+++ b/scripts/run_mypy.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run mypy over the repository, excluding untracked files.
+
+prek only stashes unstaged changes to tracked files before running hooks,
+so a plain ``mypy .`` would also type-check untracked scratch files that
+are not part of the commit. This wrapper discovers untracked Python files
+via ``git ls-files --others`` and passes them to mypy as an explicit
+``--exclude`` pattern. Gitignored files are covered separately by mypy's
+``exclude_gitignore`` setting.
+"""
+
+import re
+import subprocess
+import sys
+
+
+def main() -> int:
+    """Run mypy with untracked files excluded.
+
+    Returns:
+        The mypy exit code.
+    """
+    result = subprocess.run(
+        [
+            "git",
+            "ls-files",
+            "--others",
+            "--exclude-standard",
+            "-z",
+            "--",
+            "*.py",
+            "*.pyi",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    untracked = [path for path in result.stdout.split("\0") if path]
+
+    cmd = [sys.executable, "-m", "mypy", "."]
+    if untracked:
+        pattern = "|".join(re.escape(path) for path in untracked)
+        cmd += ["--exclude", f"(^|/)({pattern})$"]
+
+    completed = subprocess.run(cmd, check=False)
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The prek mypy hook runs `mypy .` over the whole tree, but prek only stashes unstaged tracked changes, so gitignored and untracked scratch files such as local scripts were type-checked and could fail the commit hook despite never being meant for the repo. mypy now honors .gitignore via exclude_gitignore, and the hook wraps mypy to exclude untracked files, so whole-project checking still covers every tracked file.