### PR TITLE
Fix sum(local_charge) == total_charge

### DIFF
--- a/docs/systems/molecule/index.md
+++ b/docs/systems/molecule/index.md
@@ -33,8 +33,9 @@ For arbitrary molecules, the config describes the nuclei plus the electronic
 constraints rather than separate spin counts directly. JaQMC resolves each atom's
 effective charge from its element symbol and optional `system.pp`, then derives
 the spin-up and spin-down electron counts from the resolved total electron
-count plus `system.s_z`. Use `system.total_charge` when the simulated system is
-ionic.
+count plus `system.s_z`. For a charged system, set `system.total_charge`, then
+set `atoms[*].initialization.local_charge` on the relevant atoms so that the
+values sum to `system.total_charge`. Omitted `local_charge` values are zero.
 
 For example, to train a neural wavefunction for water from an angstrom-scale
 geometry, save the following as `water.yml`:
@@ -55,11 +56,29 @@ system:
 This water example is neutral and all-electron, so JaQMC resolves ten explicit
 electrons and assigns five spin-up and five spin-down electrons from `s_z: 0`.
 If you later enable an ECP or PH pseudopotential, JaQMC derives the
-valence-electron count automatically after pseudopotential resolution. For
-ions, add `system.total_charge`; for example, `total_charge: 1` removes one
-explicit electron from the simulated system.
+valence-electron count automatically after pseudopotential resolution.
 
-If you need finer control over charge resolution or electron initialization:
+For example, this configuration initializes an H2+ ion with one fewer electron
+near the first hydrogen:
+
+```yaml
+system:
+  atoms:
+    - symbol: H
+      coords: [0.0, 0.0, 0.0]
+      initialization:
+        local_charge: 1
+    - symbol: H
+      coords: [1.4, 0.0, 0.0]
+  total_charge: 1
+  s_z: 0.5
+```
+
+Positive `local_charge` values initialize fewer electrons near an atom;
+negative values initialize more. These values determine the initial electron
+placement. The charge distribution can change freely during optimization.
+
+Related per-atom settings are:
 
 - `atoms[*].charge` overrides the effective charge seen by the simulated electrons.
 - `atoms[*].initialization.local_s_z` biases the initial alpha/beta split near one atom.
@@ -182,8 +201,8 @@ Once an ECP is enabled, JaQMC derives the explicit electron count from the
 valence system rather than from the all-electron atoms. The `atom` and
 `diatomic` shortcuts use `system.pp` to choose the corresponding
 simulated-electron count automatically. If you define `atoms` directly, set
-`system.s_z` to the desired value for the explicit electrons, and add
-`system.total_charge` if the simulated valence system is charged.
+`system.s_z` to the desired value for the explicit electrons. For a charged
+system, follow the `total_charge` and `local_charge` rule above.
 
 For mixed systems, apply ECPs only to the elements that need them:
 

--- a/docs/systems/solid/index.md
+++ b/docs/systems/solid/index.md
@@ -40,8 +40,9 @@ For arbitrary solids, the config describes the primitive-cell nuclei plus the
 electronic constraints. JaQMC resolves each atom's effective charge from its
 element symbol and optional `system.pp`, then derives the primitive-cell
 spin-up and spin-down electron counts from the resolved explicit electron count
-plus `system.s_z`. Use `system.total_charge` when the simulated primitive cell
-is ionic.
+plus `system.s_z`. For a charged primitive cell, set `system.total_charge`, then
+set `atoms[*].initialization.local_charge` on the relevant atoms so that the
+values sum to `system.total_charge`. Omitted `local_charge` values are zero.
 
 For example, save the following LiH primitive cell in angstrom as
 `lih_solid.yml`:
@@ -178,8 +179,8 @@ system:
 
 The `rock_salt` and `two_atom_chain` shortcuts use `system.pp` to choose
 valence electron counts automatically. If you define `atoms` directly, set
-`system.s_z` to the desired value for the explicit electrons and add
-`system.total_charge` if the simulated primitive cell is charged.
+`system.s_z` to the desired value for the explicit electrons. For a charged
+primitive cell, follow the `total_charge` and `local_charge` rule above.
 
 Solid workflows currently support ECP and all-electron treatment only. The
 shared `pp` key accepts the same ECP names as molecules, but `pp: ph` is

--- a/src/jaqmc/utils/atomic/atomic_system.py
+++ b/src/jaqmc/utils/atomic/atomic_system.py
@@ -85,7 +85,7 @@ class AtomicSystemConfig:
             )
 
         for atom, init in zip(self.atoms, self.per_atom_init):
-            local_electron_count = atom.charge + init.local_charge
+            local_electron_count = atom.charge - init.local_charge
             if local_electron_count < 0:
                 raise ValueError(
                     f"Atom-local initialization would place {local_electron_count} "
@@ -120,6 +120,13 @@ class AtomicSystemConfig:
         ):
             raise ValueError(
                 f"Impossible s_z={self.s_z} for {total_electron_count} electrons."
+            )
+
+        local_charge_sum = sum(init.local_charge for init in self.per_atom_init)
+        if local_charge_sum != self.total_charge:
+            raise ValueError(
+                "Per-atom initialization local_charge values must sum to the "
+                f"system total_charge; got {local_charge_sum} and {self.total_charge}."
             )
 
     @property

--- a/src/jaqmc/utils/atomic/initialization.py
+++ b/src/jaqmc/utils/atomic/initialization.py
@@ -21,7 +21,7 @@ def _atom_initial_spin_config(atom: Atom, initialization: AtomInitialization):
     local_charge = initialization.local_charge
 
     if spin_imbalance is not None:
-        nelec = atom.charge + local_charge
+        nelec = atom.charge - local_charge
         spins = ((nelec + spin_imbalance) // 2, (nelec - spin_imbalance) // 2)
     elif local_charge > atom.spin_config[0]:
         spins = (0, sum(atom.spin_config) - local_charge)
@@ -42,13 +42,11 @@ def distribute_spins(
     per_atom_init: list[AtomInitialization],
     total_spins: tuple[int, int],
 ) -> list[tuple[int, int]]:
-    """Resolve a full per-atom initialization from partial user overrides.
+    """Resolve per-atom spin occupations for electron initialization.
 
-    Explicit atom initialization hints are first resolved into exact local
-    ``(n_alpha, n_beta)`` occupancies and then preserved exactly. Unspecified
-    atoms start from their chemical default ``atom.spin_config``, then absorb
-    any remaining channel-by-channel difference required to match
-    ``total_spins``.
+    ``local_charge`` sets how many electrons are initialized near each atom.
+    ``local_s_z`` also sets the initial alpha/beta split. For atoms without
+    ``local_s_z``, this split may change to match ``total_spins``.
 
     Args:
         rngs: Random number generator key.
@@ -60,14 +58,9 @@ def distribute_spins(
         Full per-atom initialization spins.
 
     Raises:
-        ValueError: If the explicit overrides over-constrain the target system
-            and the unspecified atoms cannot absorb the remaining difference.
+        ValueError: If the per-atom electron counts or local spin constraints
+            are incompatible with ``total_spins``.
     """
-    local_charge_sum = sum(init.local_charge for init in per_atom_init)
-    if not local_charge_sum == 0:
-        raise ValueError(
-            f"All per-atom charge offsets must sum to zero. Got {local_charge_sum}."
-        )
     spins_per_atom = list(map(_atom_initial_spin_config, atoms, per_atom_init))
     fixed_per_atom = [init.spin_imbalance is not None for init in per_atom_init]
     explicit_spins = [
@@ -81,7 +74,7 @@ def distribute_spins(
     total_electrons = sum(sum(spins) for spins in spins_per_atom)
     if sum(total_spins) != total_electrons:
         raise ValueError(
-            "After applying the explicit initialization hints, the system has "
+            "The per-atom initialization contains "
             f"{total_electrons} electrons but total_spins={total_spins} "
             f"requires {sum(total_spins)}."
         )

--- a/tests/utils/atomic/initialization_test.py
+++ b/tests/utils/atomic/initialization_test.py
@@ -7,6 +7,9 @@ import jax
 import pytest
 
 from jaqmc.app.molecule.config import AtomConfig, MoleculeConfig
+from jaqmc.app.molecule.data import data_init as molecule_data_init
+from jaqmc.app.solid.config import SolidAtomConfig, SolidConfig
+from jaqmc.app.solid.data import data_init as solid_data_init
 from jaqmc.utils.atomic import Atom, AtomInitialization, distribute_spins
 from jaqmc.utils.atomic.initialization import _atom_initial_spin_config
 
@@ -107,6 +110,21 @@ def test_distribute_spins_returns_all_explicit_overrides_when_consistent():
     assert spins_per_atom == [(1, 0), (0, 1)]
 
 
+def test_local_charge_keeps_its_sign_when_local_spin_is_set():
+    atoms, per_atom_init = _split_atoms_and_inits(
+        [
+            _resolved_atom_with_init("H", local_charge=1, local_s_z=0),
+            _resolved_atom_with_init("H", local_charge=-1, local_s_z=0),
+        ]
+    )
+
+    spins_per_atom = distribute_spins(
+        jax.random.PRNGKey(0), atoms, per_atom_init, (1, 1)
+    )
+
+    assert spins_per_atom == [(0, 0), (1, 1)]
+
+
 def test_distribute_spins_rejects_inconsistent_explicit_overrides():
     atoms, per_atom_init = _split_atoms_and_inits(
         [
@@ -124,7 +142,7 @@ def test_distribute_spins_rejects_total_electron_mismatch_without_overrides():
 
     with pytest.raises(
         ValueError,
-        match="After applying the explicit initialization hints",
+        match="The per-atom initialization contains",
     ):
         distribute_spins(jax.random.PRNGKey(0), atoms, per_atom_init, (0, 0))
 
@@ -139,9 +157,73 @@ def test_distribute_spins_rejects_override_electron_mismatch():
 
     with pytest.raises(
         ValueError,
-        match="per-atom charge offsets must sum to zero",
+        match="The per-atom initialization contains",
     ):
         distribute_spins(jax.random.PRNGKey(0), atoms, per_atom_init, (1, 1))
+
+
+@pytest.mark.parametrize(
+    ("symbol", "local_charge", "total_charge"),
+    [("Li", 1, 1), ("H", -1, -1)],
+)
+def test_charged_molecule_initialization_uses_local_charge(
+    symbol, local_charge, total_charge
+):
+    config = MoleculeConfig(
+        atom_configs=[_atom_config(symbol, local_charge=local_charge)],
+        total_charge=total_charge,
+        s_z=0,
+    )
+
+    electrons = molecule_data_init(
+        config, size=4, rngs=jax.random.PRNGKey(0)
+    ).data.electrons
+
+    assert config.electron_spins == (1, 1)
+    assert electrons.shape == (4, 2, 3)
+
+
+def test_charged_solid_initialization_uses_local_charge():
+    config = SolidConfig(
+        atom_configs=[
+            SolidAtomConfig(
+                symbol="H",
+                frac_coords=[0.0, 0.0, 0.0],
+                initialization=AtomInitialization(local_charge=1),
+            ),
+            SolidAtomConfig(symbol="H", frac_coords=[0.5, 0.0, 0.0]),
+        ],
+        total_charge=1,
+        s_z=0.5,
+    )
+
+    electrons = solid_data_init(
+        config, size=4, rngs=jax.random.PRNGKey(0)
+    ).data.electrons
+
+    assert config.electron_spins == (1, 0)
+    assert electrons.shape == (4, 1, 3)
+
+
+def test_atomic_system_rejects_unallocated_total_charge():
+    with pytest.raises(
+        ValueError,
+        match="local_charge values must sum to the system total_charge",
+    ):
+        MoleculeConfig(
+            atom_configs=[AtomConfig(symbol="H", coords=[0.0, 0.0, 0.0])],
+            total_charge=1,
+        )
+
+
+def test_atomic_system_accepts_zero_electron_state():
+    cfg = MoleculeConfig(
+        atom_configs=[_atom_config("H", local_charge=1)],
+        total_charge=1,
+        s_z=0,
+    )
+
+    assert cfg.electron_spins == (0, 0)
 
 
 def test_initial_spin_config_tracks_pp_resolved_charge():
@@ -177,7 +259,7 @@ def test_atom_with_initialization_rejects_spin_magnitude_mismatch():
 
 def test_atom_with_initialization_rejects_negative_local_electron_count():
     with pytest.raises(ValueError, match="local electron count must be non-negative"):
-        MoleculeConfig(atom_configs=[_atom_config("H", local_charge=-2)])
+        MoleculeConfig(atom_configs=[_atom_config("H", local_charge=2)])
 
 
 def test_atomic_system_rejects_spin_magnitude_mismatch():
@@ -203,16 +285,6 @@ def test_atomic_system_accepts_fully_polarized_one_electron_state():
     )
 
     assert cfg.electron_spins == (1, 0)
-
-
-def test_atomic_system_accepts_zero_electron_state():
-    cfg = MoleculeConfig(
-        atom_configs=[AtomConfig(symbol="H", coords=[0.0, 0.0, 0.0])],
-        total_charge=1,
-        s_z=0,
-    )
-
-    assert cfg.electron_spins == (0, 0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Better support walker initialization for charged systems. For a charged system, users are required to assign `atoms[*].initialization.local_charge` explicitly so that their sum equals system.total_charge.