### PR TITLE
skip calling W&B finish on abort

### DIFF
--- a/src/jaqmc/writer/wandb.py
+++ b/src/jaqmc/writer/wandb.py
@@ -11,6 +11,7 @@ from jax import numpy as jnp
 from upath import UPath
 
 from jaqmc.utils.config import configurable_dataclass
+from jaqmc.workflow.stage.base import StageAbort
 from jaqmc.writer.base import Writer
 
 __all__ = ["WandbWriter"]
@@ -63,10 +64,15 @@ class WandbWriter(Writer):
         else:
             init_kwargs = self._init_kwargs(working_dir, stage_name)
             self._run = wandb.init(**init_kwargs)
+            should_call_finish = True
             try:
                 yield
+            except StageAbort:
+                should_call_finish = False
+                raise  # Ensure the error propagates
             finally:
-                self._run.finish()
+                if should_call_finish:
+                    self._run.finish()
                 self._run = None
 
     @staticmethod


### PR DESCRIPTION
When receiving the abort signal, we should avoid calling `finish` so that W&B correctly treat the run as killed.