### PR TITLE
Fix all-singular determinant sums

### DIFF
--- a/src/jaqmc/wavefunction/output/logdet.py
+++ b/src/jaqmc/wavefunction/output/logdet.py
@@ -64,6 +64,10 @@ class LogDet(nn.Module):
         """
         signs, logdets = jnp.linalg.slogdet(xs)
         logmax = jnp.max(logdets)  # logsumexp trick
+        # When every determinant is singular, ``logmax`` is ``-inf``.
+        # Shifting by zero keeps all exponential weights at zero and avoids
+        # the undefined ``-inf - (-inf)`` operation.
+        logmax = jnp.where(jnp.isneginf(logmax), jnp.zeros_like(logmax), logmax)
         if jnp.iscomplexobj(xs):
             return ComplexLogDetOutput(
                 logpsi=jnp.log(jnp.sum(signs * jnp.exp(logdets - logmax))) + logmax,

--- a/tests/wavefunction/logdet_test.py
+++ b/tests/wavefunction/logdet_test.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Mapping
+from typing import cast
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from jaqmc.wavefunction.output.logdet import LogDet
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.complex64])
+def test_all_singular_determinants_return_log_zero(dtype):
+    matrices = jnp.zeros((2, 2, 2), dtype=dtype)
+
+    result = cast(Mapping[str, jax.Array], LogDet().apply({}, matrices))
+
+    assert jnp.isneginf(result["logpsi"].real)
+    assert result["logpsi"].imag == 0
+    assert jnp.all(result["sign_logdets"] == 0)
+    assert jnp.all(jnp.isneginf(result["abs_logdets"]))
+    if "sign_logpsi" in result:
+        assert result["sign_logpsi"] == 0
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.complex64])
+def test_singular_determinants_do_not_change_nonzero_sum(dtype):
+    matrices = jnp.stack([jnp.zeros((2, 2), dtype=dtype), jnp.eye(2, dtype=dtype)])
+
+    result = cast(Mapping[str, jax.Array], LogDet().apply({}, matrices))
+
+    assert result["logpsi"] == 0
+    if "sign_logpsi" in result:
+        assert result["sign_logpsi"] == 1


### PR DESCRIPTION
## Summary

- avoid the undefined `-inf - (-inf)` shift when every determinant is singular
- preserve zero determinant sums as sign 0 / log absolute value `-inf`
- cover real and complex all-singular inputs and mixed singular/non-singular inputs

Fixes #93.

## Testing

- `pytest -p no:cacheprovider tests/wavefunction/logdet_test.py -q` (4 passed)
- `ruff check src/jaqmc/wavefunction/output/logdet.py tests/wavefunction/logdet_test.py`
- `ruff format --check src/jaqmc/wavefunction/output/logdet.py tests/wavefunction/logdet_test.py`
- `mypy --config-file pyproject.toml --no-incremental src/jaqmc/wavefunction/output/logdet.py tests/wavefunction/logdet_test.py`
- `git diff --check`