### PR TITLE
Fix Hall pair-correlation finalization and sharding

### DIFF
--- a/src/jaqmc/app/hall/estimator/pair_correlation.py
+++ b/src/jaqmc/app/hall/estimator/pair_correlation.py
@@ -7,14 +7,15 @@ Accumulates a histogram of geodesic pair angles :math:`\theta_{ij}`
 weighted by :math:`1/\sin\theta_{ij}` to obtain the pair correlation
 function :math:`g(\theta)`.
 
-The normalization factor per evaluation step is included, but the
-division by the total number of steps is **not** — divide the state
-by the step count to obtain the final :math:`g(\theta)`.
+The normalization factor per evaluation step is included.  The final
+:math:`g(\theta)` is averaged across devices and evaluation steps by
+:meth:`PairCorrelation.finalize_state`.
 """
 
 from collections.abc import Mapping
 from typing import Any
 
+import jax
 from jax import numpy as jnp
 
 from jaqmc.array_types import PRNGKey
@@ -42,7 +43,7 @@ class PairCorrelation(Estimator):
     data_field: str = runtime_dep(default="electrons")
 
     def init(self, data: Data, rngs: PRNGKey) -> jnp.ndarray:
-        return jnp.zeros(self.bins)
+        return jnp.zeros((jax.device_count(), self.bins))
 
     def evaluate_batch_walkers(
         self,
@@ -84,3 +85,12 @@ class PairCorrelation(Estimator):
         self, mean_stats: Mapping[str, Any], state: jnp.ndarray
     ) -> dict[str, Any]:
         return {}
+
+    def finalize_state(self, state: jnp.ndarray, *, n_steps: int) -> dict[str, Any]:
+        """Average the accumulated pair correlation across devices and steps.
+
+        Returns:
+            The normalized pair-correlation histogram.
+        """
+        pair_correlation = jnp.mean(state, axis=0) / n_steps
+        return {"pair_correlation": pair_correlation}

--- a/tests/app/hall/pair_correlation_test.py
+++ b/tests/app/hall/pair_correlation_test.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the pair-correlation estimator."""
+
+import jax
+import numpy as np
+import pytest
+from jax import numpy as jnp
+
+from jaqmc.app.hall.data import HallData
+from jaqmc.app.hall.estimator.pair_correlation import PairCorrelation
+from jaqmc.data import BatchedData
+from jaqmc.estimator.base import EstimatorPipeline
+from jaqmc.utils import parallel_jax
+
+
+def _make_batched(electrons: jnp.ndarray) -> BatchedData:
+    return BatchedData(
+        data=HallData(electrons=electrons),
+        fields_with_batch=["electrons"],
+    )
+
+
+def _sample_batch(batch_size: int) -> jnp.ndarray:
+    electrons = jnp.array([[0.5, 0.25], [1.5, 1.25]])
+    return jnp.broadcast_to(electrons, (batch_size, *electrons.shape))
+
+
+class TestPairCorrelation:
+    def test_digest_outputs_normalized_pair_correlation(self):
+        estimator = PairCorrelation(bins=4)
+        estimators = EstimatorPipeline({"pair_correlation": estimator})
+        batched_data = _make_batched(_sample_batch(2))
+        state = estimator.init(batched_data.unbatched_example(), jax.random.PRNGKey(0))
+
+        assert state.shape == (jax.device_count(), estimator.bins)
+
+        _, one_step_state = estimator.evaluate_batch_walkers(
+            {}, batched_data, {}, state, jax.random.PRNGKey(1)
+        )
+        _, two_step_state = estimator.evaluate_batch_walkers(
+            {}, batched_data, {}, one_step_state, jax.random.PRNGKey(2)
+        )
+
+        result = estimators.digest({}, {"pair_correlation": two_step_state}, n_steps=2)
+
+        assert result.keys() == {"pair_correlation"}
+        np.testing.assert_allclose(
+            result["pair_correlation"], one_step_state[0], rtol=1e-6
+        )
+
+    @pytest.mark.skipif(
+        jax.device_count() < 2,
+        reason="requires multiple devices",
+    )
+    def test_sharded_state_accumulates_on_multiple_devices(self):
+        estimator = PairCorrelation(bins=4)
+        batch_size = 2 * jax.device_count()
+        batched_data = _make_batched(_sample_batch(batch_size))
+        data_sharding = parallel_jax.make_sharding(parallel_jax.DATA_PARTITION)
+        batched_data = jax.device_put(batched_data, data_sharding)
+        state = jax.device_put(
+            estimator.init(batched_data.unbatched_example(), jax.random.PRNGKey(0)),
+            data_sharding,
+        )
+
+        evaluate = parallel_jax.jit_sharded(
+            lambda data, est_state: estimator.evaluate_batch_walkers(
+                {}, data, {}, est_state, jax.random.PRNGKey(1)
+            )[1],
+            in_specs=(parallel_jax.DATA_PARTITION, parallel_jax.DATA_PARTITION),
+            out_specs=parallel_jax.DATA_PARTITION,
+        )
+
+        state = evaluate(batched_data, state)
+        result = estimator.finalize_state(state, n_steps=1)
+
+        assert state.shape == (jax.device_count(), estimator.bins)
+        np.testing.assert_allclose(
+            result["pair_correlation"], np.asarray(state)[0], rtol=1e-6
+        )


### PR DESCRIPTION
## Summary

- give Hall pair-correlation state a device-leading axis so it follows the workflow's `DATA_PARTITION` sharding
- finalize the accumulated histogram by averaging across devices and evaluation steps
- add single-device digest and forced two-CPU-device sharding regressions

Fixes #91.

## Compatibility

The estimator is disabled by default. Its previously stored state used shape `(bins,)`; the corrected device-aware state uses `(device_count, bins)`, matching the existing histogram estimator pattern.

## Testing

- `pytest --n-cpu-devices=1 tests/app/hall/pair_correlation_test.py` (1 passed, 1 skipped)
- `pytest --n-cpu-devices=2 tests/app/hall/pair_correlation_test.py tests/estimator/estimator_test.py` (9 passed)
- `ruff check` on the changed files
- `ruff format --check .` (300 files already formatted)
- `git diff origin/main...HEAD --check`