### PR TITLE
Truncate evaluation stats at the restored step

### DIFF
--- a/src/jaqmc/workflow/stage/base.py
+++ b/src/jaqmc/workflow/stage/base.py
@@ -7,6 +7,7 @@ import logging
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Self
@@ -142,52 +143,62 @@ class WorkStage[StateT: StageState](ABC):
 
         partition = state.partition()
         initial_step, restored = ckpt.restore(state)
-        state = jax.device_put(restored, parallel_jax.make_sharding(partition))
-        if self.config.iterations <= initial_step:
+        with self._open_stage_resources(initial_step):
+            state = jax.device_put(restored, parallel_jax.make_sharding(partition))
+            if self.config.iterations <= initial_step:
+                return state
+
+            rngs = jax.device_put(
+                jax.random.split(rngs, jax.device_count()).flatten(),
+                parallel_jax.make_sharding(parallel_jax.DATA_PARTITION),
+            )
+
+            def save(step: int, st: StateT) -> None:
+                gathered = st.process_allgather()
+                if is_master:
+                    ckpt.save(step, gathered)
+
+            remaining = self.config.iterations - initial_step
+            self.logger.info("Start %s %s steps.", remaining, self.name)
+
+            last_save_time = time.time()
+            tracker = TimeTracker(warmup_steps=self.config.timing_warmup_steps)
+
+            try:
+                with self.writers.open(
+                    save_dir, prefix, is_master=is_master, initial_step=initial_step
+                ):
+                    tracker.start()
+                    for step, state in self.loop(state, initial_step, rngs):
+                        tracker.tick()
+
+                        if context.signal_handler.exit_requested:
+                            raise StageAbort(step, state)
+
+                        now = time.time()
+                        is_last = step == self.config.iterations - 1
+                        time_ok = now - last_save_time > self.config.save_time_interval
+                        step_ok = (step + 1) % self.config.save_step_interval == 0
+                        if is_last or (time_ok and step_ok):
+                            save(step, state)
+                            last_save_time = now
+            except StageAbort as e:
+                save(e.step, e.state)
+                tracker.log_time_per_step(logger=self.logger)
+                raise SystemExit("=" * 30 + " ABORT " + "=" * 30) from None
+
+            self.logger.info("Done %s %s steps.", remaining, self.name)
+            tracker.log_time_per_step(logger=self.logger)
             return state
 
-        rngs = jax.device_put(
-            jax.random.split(rngs, jax.device_count()).flatten(),
-            parallel_jax.make_sharding(parallel_jax.DATA_PARTITION),
-        )
+    def _open_stage_resources(self, initial_step: int) -> AbstractContextManager[None]:
+        """Open stage-owned resources after checkpoint restoration.
 
-        def save(step: int, st: StateT) -> None:
-            gathered = st.process_allgather()
-            if is_master:
-                ckpt.save(step, gathered)
-
-        remaining = self.config.iterations - initial_step
-        self.logger.info("Start %s %s steps.", remaining, self.name)
-
-        last_save_time = time.time()
-        tracker = TimeTracker(warmup_steps=self.config.timing_warmup_steps)
-
-        try:
-            with self.writers.open(
-                save_dir, prefix, is_master=is_master, initial_step=initial_step
-            ):
-                tracker.start()
-                for step, state in self.loop(state, initial_step, rngs):
-                    tracker.tick()
-
-                    if context.signal_handler.exit_requested:
-                        raise StageAbort(step, state)
-
-                    now = time.time()
-                    is_last = step == self.config.iterations - 1
-                    time_ok = now - last_save_time > self.config.save_time_interval
-                    step_ok = (step + 1) % self.config.save_step_interval == 0
-                    if is_last or (time_ok and step_ok):
-                        save(step, state)
-                        last_save_time = now
-        except StageAbort as e:
-            save(e.step, e.state)
-            tracker.log_time_per_step(logger=self.logger)
-            raise SystemExit("=" * 30 + " ABORT " + "=" * 30) from None
-
-        self.logger.info("Done %s %s steps.", remaining, self.name)
-        tracker.log_time_per_step(logger=self.logger)
-        return state
+        Returns:
+            Context manager for resources needed during the stage run.
+        """
+        del initial_step
+        return nullcontext()
 
     @abstractmethod
     def loop(

--- a/src/jaqmc/workflow/stage/evaluation.py
+++ b/src/jaqmc/workflow/stage/evaluation.py
@@ -7,7 +7,7 @@ Accumulates per-step statistics in an HDF5 file owned by the stage and produces 
 ``digest.npz`` summary after all steps. Optionally logs preview digests.
 """
 
-from contextlib import nullcontext
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass, replace
 from typing import Any, ClassVar
 
@@ -110,9 +110,7 @@ class EvaluationWorkStage(SamplingWorkStage):
         self._prefix = prefix
 
         prefix_str = f"{prefix}_" if prefix else ""
-        self.hdf5 = HDF5ReadWrite(
-            save_dir / f"{prefix_str}stats.h5", truncate_to=self.config.iterations
-        )
+        self.hdf5 = HDF5ReadWrite(save_dir / f"{prefix_str}stats.h5")
         if self.config.digest_step_interval == 0:
             self.logger.info(
                 "Evaluation digest will only be printed at the last step. Set "
@@ -124,11 +122,16 @@ class EvaluationWorkStage(SamplingWorkStage):
                 "Evaluation digest will be logged every %d steps.",
                 self.config.digest_step_interval,
             )
-        with self.hdf5.open() if is_master else nullcontext():
-            state = super().run(state, context, rngs)
-            if is_master:
+        state = super().run(state, context, rngs)
+        if is_master:
+            self.hdf5.truncate_to = None
+            with self.hdf5.open():
                 self.write_digest(state)
         return state
+
+    def _open_stage_resources(self, initial_step: int) -> AbstractContextManager[None]:
+        self.hdf5.truncate_to = initial_step
+        return self.hdf5.open() if jax.process_index() == 0 else nullcontext()
 
     def compute_step(
         self, state: SamplingState, rngs: PRNGKey

--- a/tests/hydrogen/atom_test.py
+++ b/tests/hydrogen/atom_test.py
@@ -91,6 +91,46 @@ def test_evaluation_writes_per_step_stats_and_digest(tmp_path):
     assert digest["energy:kinetic"].ndim == 0
 
 
+def test_evaluation_stats_truncated_to_restored_checkpoint(tmp_path):
+    train_dir = tmp_path / "train-run"
+    eval_dir = tmp_path / "eval-run"
+
+    train_cfg = ConfigManager(
+        {
+            "workflow": {"save_path": str(train_dir), "batch_size": 128},
+            "train": {"run": {"iterations": 3}},
+        }
+    )
+    hydrogen_atom_train_workflow(train_cfg)()
+
+    def run_evaluation(iterations, save_step_interval=1000):
+        cfg = ConfigManager(
+            {
+                "workflow": {
+                    "save_path": str(eval_dir),
+                    "batch_size": 128,
+                    "source_path": str(train_dir),
+                },
+                "run": {
+                    "iterations": iterations,
+                    "save_step_interval": save_step_interval,
+                    "save_time_interval": 0,
+                },
+            }
+        )
+        hydrogen_atom_eval_workflow(cfg)()
+
+    run_evaluation(5, save_step_interval=3)
+    (eval_dir / "evaluation_ckpt_000004.npz").unlink()
+
+    # Restore checkpoint step 2 (initial_step=3), discard stale rows 3-4,
+    # then append steps 3-7 without duplicating statistics.
+    run_evaluation(8)
+
+    with h5py.File(eval_dir / "evaluation_stats.h5", "r") as f:
+        assert f["total_energy"].shape[0] == 8
+
+
 def test_evaluation_requires_source_path_for_trainable_wavefunction(tmp_path):
     eval_dir = tmp_path / "eval-run"
     eval_cfg = ConfigManager(


### PR DESCRIPTION
## Summary

- open stage-owned resources after checkpoint restoration exposes the restored `initial_step` without duplicating checkpoint logic
- truncate `evaluation_stats.h5` to that restored step before resumed evaluation appends rows
- add an end-to-end regression where statistics are ahead of the latest retained checkpoint

Fixes #90.

## Testing

- new resume regression: 1 passed
- new regression plus existing evaluation digest test: 2 passed
- `tests/integration/checkpoint_test.py`: 2 passed
- Ruff lint and format checks on the three changed files
- `mypy --no-incremental src/jaqmc/workflow/stage/base.py src/jaqmc/workflow/stage/evaluation.py tests/hydrogen/atom_test.py`
- `git diff --check`

The focused tests produced only the existing JAX `jax_pmap_shmap_merge` deprecation warning. The full frozen suite was not run locally because locked PySCF has no Windows wheel and requires an unavailable MSBuild toolchain; focused tests used the locked environment without installing PySCF.