### PR TITLE
Minor updates

### DIFF
--- a/docs/guide/running-workflows.md
+++ b/docs/guide/running-workflows.md
@@ -118,6 +118,17 @@ jaqmc <app> evaluate ... \
   run.iterations=1000
 ```
 
+Evaluation enables no configurable writer adapters by default. It does not emit per-step
+estimator statistics. Users who need per-step evaluation logging can enable writer
+adapters with `writers.*` command-line configuration overrides
+For example, with the energy estimator enabled:
+
+```bash
+jaqmc <app> evaluate ... \
+  writers.console.module=jaqmc.writer.console \
+  writers.console.fields="energy=total_energy"
+```
+
 If you want multiple evaluation variants, give each one its own `workflow.save_path` and
 reuse the same `workflow.source_path`.
 

--- a/docs/guide/writers.md
+++ b/docs/guide/writers.md
@@ -83,7 +83,7 @@ By default, their output paths come from the templates `{stage}_stats.csv` and `
 
 ```bash
 train.writers.csv.path_template=logs/{stage}_metrics.csv
-evaluation.writers.hdf5.path_template=artifacts/{stage}/stats.h5
+train.writers.hdf5.path_template=artifacts/{stage}/stats.h5
 ```
 
 See <project:training-stats.md> for how to work with these files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ cuda13 = ["jax[cuda13]>=0.7.0"]
 cuda13_local = ["jax[cuda13_local]>=0.7.0"]
 
 [tool.uv]
+override-dependencies = ["setuptools==80.9.0"]
 conflicts = [
     [
         { extra = "cuda12" },

--- a/requirements.txt
+++ b/requirements.txt
@@ -207,7 +207,7 @@ scipy==1.17.1
     #   jax
     #   jaxlib
     #   pyscf
-setuptools==82.0.1
+setuptools==80.9.0
     # via pyscf
 simplejson==3.20.2
     # via orbax-checkpoint

--- a/src/jaqmc/writer/base.py
+++ b/src/jaqmc/writer/base.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from contextlib import ExitStack, contextmanager
@@ -8,6 +9,8 @@ from pathlib import Path
 from typing import Any
 
 from upath import UPath
+
+logger = logging.getLogger(__name__)
 
 
 class Writer(ABC):
@@ -133,6 +136,12 @@ class Writers:
                     stack.enter_context(
                         writer.open(working_dir, stage_name, initial_step=initial_step)
                     )
+                active_writers = ", ".join(
+                    type(writer).__name__ for writer in self._writers
+                )
+                logging.LoggerAdapter(logger, extra={"category": stage_name}).info(
+                    "Active writers: %s.", active_writers or "none"
+                )
             yield
 
     def write(self, step: int, stats: Mapping[str, Any]) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -19,6 +19,9 @@ conflicts = [[
     { package = "jaqmc", extra = "cuda13-local" },
 ]]
 
+[manifest]
+overrides = [{ name = "setuptools", specifier = "==80.9.0" }]
+
 [[package]]
 name = "absl-py"
 version = "2.4.0"
@@ -3100,11 +3103,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "80.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
1. Mention explicitly that evaluation does not do console logging
2. Log the active writers
3. Enforce setuptools version