### PR TITLE
scaffold contributed packages workspaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,94 @@ jobs:
       - name: Run prek
         run: uvx prek run --all-files --show-diff-on-failure
 
+  workspace-lock:
+    name: workspace lock
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          enable-cache: true
+
+      - name: Verify uv.lock is consistent
+        run: uv lock --locked
+
+  discover-contrib:
+    name: discover contributions
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Discover contribution packages
+        id: discover
+        run: |
+          import json
+          import os
+          import tomllib
+          from pathlib import Path
+
+          packages = []
+          for pyproject in sorted(Path("contrib").glob("*/pyproject.toml")):
+              project = tomllib.loads(pyproject.read_text())["project"]
+              packages.append(
+                  {"package": project["name"], "path": str(pyproject.parent)}
+              )
+
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+              print(
+                  "matrix=" + json.dumps({"include": packages}, separators=(",", ":")),
+                  file=output,
+              )
+        shell: python
+
+  contrib:
+    name: contrib ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    needs: discover-contrib
+    if: ${{ needs.discover-contrib.outputs.matrix != '{"include":[]}' }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.discover-contrib.outputs.matrix) }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          enable-cache: true
+
+      - name: Sync contribution package
+        run: uv sync --locked --group test --package ${{ matrix.package }}
+
+      - name: Build distribution
+        run: uv build --package ${{ matrix.package }}
+
+      - name: Run contribution tests
+        working-directory: ${{ matrix.path }}
+        run: uv run pytest
+
   test:
     name: test ${{ matrix.tox-env }}
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/docs.yml
+      - contrib/**
       - docs/**
       - src/**
       - pyproject.toml
@@ -13,6 +14,7 @@ on:
       - main
     paths:
       - .github/workflows/docs.yml
+      - contrib/**
       - docs/**
       - src/**
       - pyproject.toml

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ coverage.xml
 # Sphinx output
 docs/_build/
 docs/apidocs/
+docs/contrib/packages/
 
 # JaQMC run results
 /runs/

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,8 @@
+# Contrib Packages
+
+This directory holds contrib packages maintained separately from the core
+JaQMC project. Each package defines its own support status, release policy,
+and API stability unless its documentation states otherwise.
+
+For guidance on adding and maintaining a package, see the
+[documentation](https://jaqmc.readthedocs.io/latest/contrib/adding-contributions.html).

--- a/contrib/example/README.md
+++ b/contrib/example/README.md
@@ -1,0 +1,4 @@
+# jaqmc-contrib-example
+
+Experimental reference package for JaQMC workspace contributions. It is not a
+supported production workflow.

--- a/contrib/example/docs/index.md
+++ b/contrib/example/docs/index.md
@@ -1,0 +1,25 @@
+# Example contribution
+
+This package demonstrates how JaQMC contributions are structured in the
+monorepo workspace.
+
+## Commands
+
+After installing `jaqmc-contrib-example`:
+
+```bash
+jaqmc example-contrib info
+jaqmc example-contrib version
+```
+
+Both commands defer imports of JaQMC APIs until the callback runs.
+
+## Layout
+
+| Path | Purpose |
+|------|---------|
+| `src/jaqmc_contrib_example/cli.py` | Click group registered via `jaqmc.apps` |
+| `tests/` | Package-local pytest suite |
+| `docs/` | Package docs collected into the main site |
+
+See also the repository guide at <project:../../adding-contributions.md>.

--- a/contrib/example/pyproject.toml
+++ b/contrib/example/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "jaqmc-contrib-example"
+version = "0.1.0"
+description = "Reference JaQMC contribution demonstrating workspace packaging and lazy CLI discovery"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.12"
+maintainers = [
+    { name = "ByteDance Seed" }
+]
+dependencies = [
+    "click",
+    "jaqmc",
+]
+
+[project.entry-points."jaqmc.apps"]
+example-contrib = "jaqmc_contrib_example.cli:cli"
+
+[tool.uv.sources]
+jaqmc = { workspace = true }
+
+[dependency-groups]
+test = [
+    "pytest>=9.0.1",
+]
+
+[build-system]
+requires = ["uv_build>=0.11.0,<0.12.0"]
+build-backend = "uv_build"

--- a/contrib/example/src/jaqmc_contrib_example/__init__.py
+++ b/contrib/example/src/jaqmc_contrib_example/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reference JaQMC contribution package."""

--- a/contrib/example/src/jaqmc_contrib_example/cli.py
+++ b/contrib/example/src/jaqmc_contrib_example/cli.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI for the example JaQMC contribution."""
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
+
+import click
+
+
+@click.group(help="Example JaQMC contribution commands.")
+def cli() -> None:
+    pass
+
+
+def _show_jaqmc_version() -> None:
+    try:
+        jaqmc_version = package_version("jaqmc")
+    except PackageNotFoundError:
+        jaqmc_version = "not installed"
+    click.echo(f"jaqmc version: {jaqmc_version}")
+
+
+@cli.command(help="Show JaQMC version information via the core package API.")
+def version() -> None:
+    _show_jaqmc_version()
+
+
+@cli.command(help="Print a short description of this contribution.")
+def info() -> None:
+    from jaqmc.utils.config import ConfigManager
+
+    config = ConfigManager({"package_name": "jaqmc-contrib-example"})
+    click.echo("jaqmc-contrib-example: reference workspace contribution")
+    click.echo("CLI entry point: example-contrib")
+    click.echo(f"configured package: {config.get('package_name', '')}")
+    _show_jaqmc_version()

--- a/contrib/example/tests/test_cli.py
+++ b/contrib/example/tests/test_cli.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+from click.testing import CliRunner
+from jaqmc_contrib_example.cli import cli
+
+
+def test_example_contrib_info() -> None:
+    result = CliRunner().invoke(cli, ["info"])
+    assert result.exit_code == 0
+    assert "jaqmc-contrib-example" in result.output
+    assert "configured package: jaqmc-contrib-example" in result.output
+    assert "jaqmc version:" in result.output
+
+
+def test_example_contrib_version() -> None:
+    result = CliRunner().invoke(cli, ["version"])
+    assert result.exit_code == 0
+    assert "jaqmc version:" in result.output

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@ import os
 import sys
 import warnings
 from importlib.metadata import version as get_version
+from pathlib import Path
 
 from docutils import nodes
 from sphinx.application import Sphinx
@@ -46,6 +47,7 @@ extensions = [
     "sphinx_design",
     "sphinx_autodoc_typehints",
     "sphinx_copybutton",
+    "sphinx_collections",
 ]
 if os.environ.get("READTHEDOCS"):
     extensions.extend(
@@ -66,6 +68,18 @@ exclude_patterns = [
     ".jupyter_cache",
     "jupyter_execute",
 ]
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONTRIB_ROOT = REPO_ROOT / "contrib"
+collections_target = "contrib/packages"
+collections = {}
+for docs_dir in sorted(CONTRIB_ROOT.glob("*/docs")):
+    package_name = docs_dir.parent.name
+    collections[f"contrib_{package_name}"] = {
+        "driver": "copy_folder",
+        "source": str(docs_dir),
+        "target": package_name,
+    }
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -143,6 +157,29 @@ nb_execution_timeout = 360
 llms_txt_suffix_mode = "replace"
 
 
+def _remap_contrib_source_buttons(
+    app: Sphinx, pagename: str, templatename, context, doctree
+) -> None:
+    """Point collected-page source buttons to package-owned documentation."""
+    prefix = "contrib/packages/"
+    if not pagename.startswith(prefix):
+        return
+
+    package_name, _, relative_docname = pagename.removeprefix(prefix).partition("/")
+    source_suffix = context.get("page_source_suffix", "")
+    generated_path = f"/docs/{pagename}{source_suffix}"
+    source_path = f"/contrib/{package_name}/docs/{relative_docname}{source_suffix}"
+
+    def remap(button):
+        if button.get("label") in {"source-file-button", "source-edit-button"}:
+            button["url"] = button["url"].replace(generated_path, source_path)
+        for child in button.get("buttons", []):
+            remap(child)
+
+    for button in context["header_buttons"]:
+        remap(button)
+
+
 class GitHubSourceRole(SphinxRole):
     """Inline role that links a source path to its GitHub location.
 
@@ -169,3 +206,4 @@ def setup(app: Sphinx):
             app.config.nb_execution_mode = "off"
 
     app.connect("builder-inited", configure_for_builder)
+    app.connect("html-page-context", _remap_contrib_source_buttons, priority=502)

--- a/docs/contrib/adding-contributions.md
+++ b/docs/contrib/adding-contributions.md
@@ -1,0 +1,177 @@
+# Adding a contribution
+
+This guide explains how to add an independently maintained package under
+`contrib/`.
+
+## 1. Create the package layout
+
+```text
+contrib/<short-name>/
+  pyproject.toml
+  README.md
+  src/jaqmc_contrib_<short_name>/
+    __init__.py
+    cli.py  # when providing a CLI
+  tests/
+  docs/index.md
+```
+
+Use `<short-name>` for the package directory and distribution suffix, and use
+`<short_name>` for the corresponding Python import package. For example,
+`my-feature` becomes `contrib/my-feature/`, `jaqmc-contrib-my-feature`, and
+`jaqmc_contrib_my_feature`.
+
+## 2. Add the JaQMC dependency
+
+In `contrib/<short-name>/pyproject.toml`:
+
+```toml
+[project]
+name = "jaqmc-contrib-my-feature"
+version = "0.1.0"
+description = "My JaQMC contribution"
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "jaqmc",
+]
+
+[tool.uv.sources]
+jaqmc = { workspace = true }
+
+[build-system]
+requires = ["uv_build>=0.11.0,<0.12.0"]
+build-backend = "uv_build"
+
+[tool.uv.build-backend]
+module-name = "jaqmc_contrib_my_feature"
+```
+
+This makes the contribution depend on the workspace copy of JaQMC. Add other
+direct dependencies that the package uses.
+
+## 3. Add an optional CLI
+
+Add Click to the existing `[project].dependencies` in
+`contrib/<short-name>/pyproject.toml`:
+
+```toml
+dependencies = [
+    "click",
+    "jaqmc",
+]
+```
+
+Then create `src/jaqmc_contrib_<short_name>/cli.py`. A contribution CLI must
+expose a `click.Command` or `click.Group`; the following minimal group keeps
+JaQMC imports inside its command callback:
+
+```python
+import click
+
+
+@click.group(help="My contribution commands.")
+def cli() -> None:
+    pass
+
+
+@cli.command(help="Show contribution information.")
+def info() -> None:
+    from jaqmc.utils.config import ConfigManager
+
+    config = ConfigManager({"package_name": "jaqmc-contrib-my-feature"})
+    click.echo(f"configured package: {config.get('package_name', '')}")
+```
+
+This follows the core CLI pattern: once Click resolves a command, its callback
+imports the workflow, optional backend, or other heavyweight code it needs.
+Keep the entry-point module limited to Click and small standard-library imports.
+
+Then register the completed `cli` object with a unique `jaqmc.apps` name that
+does not collide with a built-in command:
+
+```toml
+[project.entry-points."jaqmc.apps"]
+my-feature = "jaqmc_contrib_my_feature.cli:cli"
+```
+
+JaQMC does not depend on contribution packages. It reads provider names from
+installed package metadata without importing them; when the user invokes a
+contributed command, Click imports that contribution's CLI module. The command
+callback then loads its heavyweight dependencies only when that subcommand runs.
+
+## 4. Install and run a contribution
+
+The root `uv sync` installs JaQMC and its dependencies, but not the
+contribution packages in the workspace. To develop or run one contribution,
+sync that package explicitly:
+
+```bash
+uv sync --package jaqmc-contrib-<short-name>
+source .venv/bin/activate
+```
+
+This installs the contribution and its regular `[project.dependencies]`. To
+install every contribution package, use `uv sync --all-packages`. Use the
+`jaqmc.apps` entry-point name as the `jaqmc` command name. For the
+`my-feature` example above:
+
+```bash
+jaqmc my-feature --help
+```
+
+More generally, run a contribution with
+`jaqmc <entry-point> ...`.
+
+## 5. Add package-local tests
+
+Place tests in `contrib/<short-name>/tests/`. When run from the contribution
+directory, pytest discovers this directory without additional configuration; add
+`pyproject.toml` settings only when the package needs them, such as warning
+filters.
+
+From the repository root, run:
+
+```bash
+uv sync --locked --group test --package jaqmc-contrib-<short-name>
+(cd contrib/<short-name> && uv run pytest)
+```
+
+CI discovers each workspace contribution and gives it a separate sync, build,
+and test matrix job.
+
+## 6. Write package documentation
+
+Add `contrib/<short-name>/docs/index.md` and additional pages as needed. Sphinx
+Collections publishes the tree under `contrib/packages/<short-name>/` in the
+main site.
+
+## 7. Configure quality gates
+
+Each contribution should include:
+
+- Apache-2.0 licensing in package metadata and headers on Python sources. A
+  separate `LICENSE` file in the package directory is not required; the
+  repository `LICENSE` covers contributions in this workspace.
+- README with support status and install instructions
+
+Repository pre-commit hooks still run license insertion and formatting on
+contrib Python files.
+
+## 8. Verify before opening a PR
+
+From the repository root:
+
+```bash
+uv lock
+uv sync --locked --group test --package jaqmc-contrib-<short-name>
+source .venv/bin/activate
+(cd contrib/<short-name> && uv run pytest)
+uv build --package jaqmc-contrib-<short-name>
+jaqmc <entry-point> --help
+uv run --group docs sphinx-build -W -b html docs docs/_build/html
+uv run pytest tests/contrib_cli_test.py
+```
+
+See `contrib/example` for a complete minimal reference implementation.

--- a/docs/contrib/index.md
+++ b/docs/contrib/index.md
@@ -1,0 +1,30 @@
+# Contributed packages
+
+JaQMC contributions live in `contrib/` as independent workspace packages. They
+can extend the CLI and reuse core APIs without shipping inside the main
+`jaqmc` wheel.
+
+```{important}
+Contributed packages are maintained separately from core JaQMC. Support status,
+release policy, and API stability are defined per package unless explicitly
+stated otherwise in that package's documentation.
+```
+
+## Package catalog
+
+```{toctree}
+:glob:
+:caption: Contributed packages
+
+packages/*/index
+```
+
+## Authoring
+
+```{toctree}
+:hidden:
+
+adding-contributions.md
+```
+
+- Step-by-step guide: <project:adding-contributions.md>

--- a/docs/extending/index.md
+++ b/docs/extending/index.md
@@ -12,6 +12,7 @@ Write custom workflows, wavefunctions, and configurable components. If you are c
 - Use {mod}`jaqmc.laplacian` directly in an estimator → <project:forward-laplacian/index.md>
 - Add custom Forward Laplacian rules, extend the transform itself, or debug primitive dispatch / sparse fallback → <project:forward-laplacian/index.md>
 - Contribute changes back to the project → <project:contributing.md>
+- Add or maintain a contributed workspace package → <project:../contrib/index.md>
 
 If you are starting from scratch, the usual reading order is
 <project:runtime-data-conventions.md> -> <project:writing-workflows.md> ->

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,6 +65,7 @@ getting-started/concepts.md
 systems/index.md
 guide/index.md
 extending/index.md
+contrib/index.md
 roadmap.md
 citing.md
 api-reference/index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ cuda12_local = ["jax[cuda12_local]>=0.4.36"]
 cuda13 = ["jax[cuda13]>=0.7.0"]
 cuda13_local = ["jax[cuda13_local]>=0.7.0"]
 
+[tool.uv.workspace]
+members = ["contrib/*"]
+
 [tool.uv]
 override-dependencies = ["setuptools==80.9.0"]
 conflicts = [
@@ -99,6 +102,7 @@ docs = [
     "sphinx-llm>=0.4.1",
     "sphinx-notfound-page>=1.1.0",
     "sphinx-reredirects>=1.1.0",
+    "sphinx-collections>=0.3.2",
     "types-docutils>=0.22.3.20251115",
 ]
 types = [
@@ -127,6 +131,7 @@ exclude = [
     "tests/legacy",
     "src/jaqmc_legacy",
     "legacy_examples",
+    "contrib",
 ]
 
 [[tool.mypy.overrides]]

--- a/src/jaqmc/app/cli.py
+++ b/src/jaqmc/app/cli.py
@@ -14,6 +14,10 @@ To add a new application to the CLI:
 2.  Add ``train`` and ``evaluate`` subcommands using ``@<group>.add_command``
     and ``@make_cli``. Import workflows lazily inside the command function.
 
+Contributed applications register a ``click.Command`` or ``click.Group`` through
+the ``jaqmc.apps`` entry-point group in a workspace package under ``contrib/``.
+See ``contrib/README.md`` and ``docs/contrib/adding-contributions.md``.
+
 Example::
 
     @cli.group(help="Demo workflows.")
@@ -28,13 +32,88 @@ Example::
         my_demo_train_workflow(cfg)(dry_run)
 """
 
+from functools import cached_property
+from importlib.metadata import EntryPoint, entry_points
+
 import click
 
 from jaqmc.utils.cli import make_cli
 from jaqmc.utils.config import ConfigManager
 
+ENTRY_POINT_GROUP = "jaqmc.apps"
 
-@click.group(help="JaQMC: JAX-accelerated Quantum Monte Carlo framework.")
+
+class ContribAppsGroup(click.Group):
+    """Click group that discovers contributed commands from entry points."""
+
+    @cached_property
+    def _contributed_entry_points(self) -> dict[str, EntryPoint]:
+        """Discover and validate contributed command providers.
+
+        Raises:
+            click.ClickException: If providers use duplicate names or collide with
+                built-in commands.
+        """
+        providers: dict[str, EntryPoint] = {}
+        duplicate_names: set[str] = set()
+        for entry_point in entry_points(group=ENTRY_POINT_GROUP):
+            if entry_point.name in providers:
+                duplicate_names.add(entry_point.name)
+            providers[entry_point.name] = entry_point
+
+        if duplicate_names:
+            names = ", ".join(sorted(duplicate_names))
+            raise click.ClickException(f"duplicate jaqmc.apps providers: {names}")
+
+        collision_names = sorted(set(self.commands) & set(providers))
+        if collision_names:
+            names = ", ".join(collision_names)
+            raise click.ClickException(
+                f"jaqmc.apps names collide with built-ins: {names}"
+            )
+
+        return providers
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        """List built-in and contributed command names.
+
+        Returns:
+            Sorted built-in and contributed command names.
+        """
+        builtin_names = super().list_commands(ctx)
+        return sorted(set(builtin_names) | set(self._contributed_entry_points))
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+        """Resolve a built-in or load the selected contributed command.
+
+        Returns:
+            The resolved command, or ``None`` when no command matches.
+
+        Raises:
+            click.ClickException: If the selected provider is duplicated,
+                collides with a built-in command, or does not return a Click
+                command.
+        """
+        builtin = super().get_command(ctx, cmd_name)
+        if builtin is not None:
+            return builtin
+        entry_point = self._contributed_entry_points.get(cmd_name)
+        if entry_point is None:
+            return None
+
+        loaded = entry_point.load()
+        if not isinstance(loaded, click.Command):
+            raise click.ClickException(
+                f"jaqmc.apps entry point '{cmd_name}' must return a "
+                f"click.Command, got {type(loaded).__name__}"
+            )
+        return loaded
+
+
+@click.group(
+    cls=ContribAppsGroup,
+    help="JaQMC: JAX-accelerated Quantum Monte Carlo framework.",
+)
 def cli():
     pass
 

--- a/tests/contrib_cli_test.py
+++ b/tests/contrib_cli_test.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for lazy discovery of jaqmc.apps CLI entry points."""
+
+from collections.abc import Generator
+from importlib.metadata import EntryPoint
+from types import ModuleType
+from unittest.mock import patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from jaqmc.app.cli import ENTRY_POINT_GROUP, cli
+
+
+def _entry_point(name: str, value: str) -> EntryPoint:
+    return EntryPoint(name=name, value=value, group=ENTRY_POINT_GROUP)
+
+
+def _patch_entry_points(entry_point_list: list[EntryPoint]) -> patch:
+    return patch(
+        "jaqmc.app.cli.entry_points",
+        return_value=entry_point_list,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_contrib_entry_point_cache() -> Generator[None, None, None]:
+    cli.__dict__.pop("_contributed_entry_points", None)
+    yield
+    cli.__dict__.pop("_contributed_entry_points", None)
+
+
+def test_builtin_commands_remain_available() -> None:
+    with _patch_entry_points([]) as mocked_entry_points:
+        result = CliRunner().invoke(cli, ["molecule", "--help"])
+
+    assert result.exit_code == 0
+    assert "Molecular system workflows." in result.output
+    mocked_entry_points.assert_not_called()
+
+
+def test_contrib_command_loads_on_demand() -> None:
+    plugin = ModuleType("test_contrib_cli_plugin")
+
+    @click.command()
+    def contrib_cli() -> None:
+        click.echo("loaded contributed command")
+
+    plugin.__dict__["contrib_cli"] = contrib_cli
+    with (
+        _patch_entry_points(
+            [_entry_point("demo-contrib", "test_contrib_cli_plugin:contrib_cli")]
+        ),
+        patch.dict("sys.modules", {plugin.__name__: plugin}),
+    ):
+        result = CliRunner().invoke(cli, ["demo-contrib"])
+
+    assert result.exit_code == 0
+    assert "loaded contributed command" in result.output
+
+
+def test_duplicate_entry_point_names_rejected() -> None:
+    with _patch_entry_points(
+        [
+            _entry_point("dup-contrib", "jaqmc_contrib_example.cli:cli"),
+            _entry_point("dup-contrib", "jaqmc_contrib_example.cli:cli"),
+        ]
+    ):
+        result = CliRunner().invoke(cli, ["--help"])
+
+    assert result.exit_code != 0
+    assert "duplicate jaqmc.apps providers" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,10 @@ conflicts = [[
 ]]
 
 [manifest]
+members = [
+    "jaqmc",
+    "jaqmc-contrib-example",
+]
 overrides = [{ name = "setuptools", specifier = "==80.9.0" }]
 
 [[package]]
@@ -724,6 +728,30 @@ wheels = [
 ]
 
 [[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.60"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/14/e6b1a48d831755a53c2029351fcef82e70db4a08f338daefe29d8d0cf31c/gitpython-3.1.60.tar.gz", hash = "sha256:e936431879fa85581b4311fa63492ea52251909e2d655b6529c704c904ddcc24", size = 230793, upload-time = "2026-08-25T18:33:46.102Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/63/ba28697918b7c190af9f3f21940d03e8814e25dd4ddd39d6929f3a553995/gitpython-3.1.60-py3-none-any.whl", hash = "sha256:39548bffb8fa0f3a548133348868bb4838e79d73283052207dc97781a569b6b4", size = 221893, upload-time = "2026-08-25T18:33:44.75Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -997,6 +1025,7 @@ docs = [
     { name = "sphinx-autobuild" },
     { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-book-theme" },
+    { name = "sphinx-collections" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
     { name = "sphinx-llm" },
@@ -1067,6 +1096,7 @@ docs = [
     { name = "sphinx-autobuild", specifier = ">=2025.8.25" },
     { name = "sphinx-autodoc-typehints", specifier = ">=3.6.1" },
     { name = "sphinx-book-theme", specifier = ">=1.4.0" },
+    { name = "sphinx-collections", specifier = ">=0.3.2" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-design", specifier = ">=0.6.1" },
     { name = "sphinx-llm", specifier = ">=0.4.1" },
@@ -1085,6 +1115,29 @@ test = [
     { name = "pytest-xdist", specifier = ">=3.6.1" },
 ]
 types = [{ name = "types-pyyaml", specifier = ">=6.0.12.20250915" }]
+
+[[package]]
+name = "jaqmc-contrib-example"
+version = "0.1.0"
+source = { editable = "contrib/example" }
+dependencies = [
+    { name = "click" },
+    { name = "jaqmc" },
+]
+
+[package.dev-dependencies]
+test = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "click" },
+    { name = "jaqmc", editable = "." },
+]
+
+[package.metadata.requires-dev]
+test = [{ name = "pytest", specifier = ">=9.0.1" }]
 
 [[package]]
 name = "jax"
@@ -3155,6 +3208,15 @@ wheels = [
 ]
 
 [[package]]
+name = "smmap"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
+]
+
+[[package]]
 name = "snowballstemmer"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3240,6 +3302,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/8a/cb008736682b3974cae6925c54939792fe56f5a167e37984cb45d8a85d8a/sphinx_book_theme-1.4.0.tar.gz", hash = "sha256:fee3cd70573d9a8cd4ab380a3cb1f11139c24dcaa2cf47d06d7f924f1b44eaff", size = 406113, upload-time = "2026-07-19T21:23:54.183Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/5e/6c41ee74f0a4caef53f224c3e6c3869b577dade1a283767bdc874f11e51c/sphinx_book_theme-1.4.0-py3-none-any.whl", hash = "sha256:10fd57d667ee0b565928c3ce95562e281c5d1b94bd5a2aafc5cd41a5d498dcd0", size = 458862, upload-time = "2026-07-19T21:23:52.852Z" },
+]
+
+[[package]]
+name = "sphinx-collections"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitpython" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/21/69cb9ca119f948a4433baf8d30d4f867b441b1f6210ff91c4c4ad082dd87/sphinx_collections-0.3.2.tar.gz", hash = "sha256:42506b0ec456b70a63be1641a84b33399503f3233bfdc1d181775c7475466b85", size = 13286, upload-time = "2026-06-22T17:45:40.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/70/f97f7d5f20db13afc1dc5a7d941e2f46cbdbda14e5ef603a6fbb3e0a5c5e/sphinx_collections-0.3.2-py3-none-any.whl", hash = "sha256:ab93ab151a045b9dd70a8ed6f8462f3f096c1a3a73bbe1ca8efbda093b5ac6da", size = 16703, upload-time = "2026-06-22T17:45:39.715Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Use uv workspaces to manage contributed packages. Provide a discoverable CLI and documentation path, plus CI coverage that keeps contributed packages buildable and compatible with the workspace.