### PR TITLE
fix sparse concat with plain owner segments

### DIFF
--- a/src/jaqmc/laplacian/primitives/shape.py
+++ b/src/jaqmc/laplacian/primitives/shape.py
@@ -489,11 +489,10 @@ def _concatenate_sparse_jacobians(
     owners = []
     for jacobian, shape in zip(jacobians, shapes, strict=True):
         if jacobian is None:
-            # Plain-array segments contribute zero derivatives, but can still
-            # participate in a sparse concatenation if the owner metadata of the
-            # sparse segments remains consistent after inserting zeros. This is
-            # concatenate-specific shape construction, not broadcast: the plain
-            # segment can be smaller or larger only along the concatenation axis.
+            # Plain-array segments contribute zero derivatives. Build zero
+            # blocks at the plain shape and collapse concat-axis owner roles to
+            # a constant dummy so they fill to that segment length. Off-axis
+            # roles stay as in the sparse template.
             blocks.append(
                 jnp.zeros_like(
                     template.blocks,
@@ -501,7 +500,13 @@ def _concatenate_sparse_jacobians(
                     dtype=template.blocks.dtype,
                 )
             )
-            owners.append(template.owners)
+            plain_owners = OwnerRoles(
+                *(
+                    OwnerRole(None, owner.values[:1]) if owner.axis == axis else owner
+                    for owner in template.owners
+                )
+            )
+            owners.append(plain_owners)
             continue
         if type(jacobian) is not type(template):
             raise ValueError("Incompatible sparse Jacobian families for concatenation.")

--- a/tests/laplacian/sparse/shape_test.py
+++ b/tests/laplacian/sparse/shape_test.py
@@ -60,6 +60,20 @@ def _varying_owner_local1(owner: OwnerRole) -> LapTuple:
             id="sparse_leading_broadcast",
         ),
         pytest.param(lambda value: jnp.reshape(value, (1, 2, 3)), id="reshape"),
+        pytest.param(
+            lambda value: jnp.concatenate(
+                [jnp.zeros((2, 1, 2), dtype=value.dtype), value],
+                axis=2,
+            ),
+            id="concatenate_plain_segment",
+        ),
+        pytest.param(
+            lambda value: jnp.concatenate(
+                [jnp.zeros((3, 1, 3), dtype=value.dtype), value],
+                axis=0,
+            ),
+            id="concatenate_plain_leading_axis",
+        ),
     ),
 )
 def test_constant_owner_local1_shape_operations(fn):
@@ -93,6 +107,20 @@ def test_constant_owner_local1_shape_operations(fn):
                 axis=2,
             ),
             id="concatenate_plain_segment",
+        ),
+        pytest.param(
+            lambda value: jnp.concatenate(
+                [jnp.zeros((2, 4, 3), dtype=value.dtype), value],
+                axis=0,
+            ),
+            id="concatenate_plain_owner_axis",
+        ),
+        pytest.param(
+            lambda value: jnp.concatenate(
+                [value, jnp.zeros((4, 2, 3), dtype=value.dtype)],
+                axis=1,
+            ),
+            id="concatenate_plain_second_owner_axis",
         ),
     ),
 )
@@ -207,6 +235,21 @@ def test_broadcast_filled_local1_shape_operations(fn):
         broadcast_blocks=True,
     )
     check_sparse_jacobian(fn, seed, expected_jacobian=Local1Jacobian)
+
+
+def test_concatenate_sliced_local1_with_plain_segment():
+    seed = make_laplacian_input(
+        jnp.ones((4, 2), dtype=jnp.float32),
+        sparse_axis=0,
+    )
+
+    def fn(value):
+        reduced = jnp.sum(value * value, axis=1)
+        return jnp.concatenate([reduced[:3], jnp.zeros((2,), dtype=value.dtype)])
+
+    actual = forward_laplacian(fn)(seed)
+    assert isinstance(actual.jacobian, Local1Jacobian)
+    check_with_brute_force(fn, seed, actual_result=actual)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Previously, concatenating a plain array with a sparse array would have problems because of the wrong `Owner` assigned to the plain array. Specifically:

```python
import jax
from jax import numpy as jnp
from jaqmc.laplacian import forward_laplacian, make_laplacian_input

def f(x):
    # x: (4, 2) seeded sparse along axis 0
    a = jnp.sum(x * x, axis=1)       # (4,) sparse
    b = jnp.zeros((2,))              # (2,) plain
    return jnp.sum(jnp.concatenate([a[:3], b]))  # sparse (3,) + plain (2,)

forward_laplacian(f)(make_laplacian_input(jnp.ones((4, 2)), sparse_axis=0))
```

This change fixes this by correcting the `Owner` assignment for the plain array