### PR TITLE
preserve stats across resume directories

### DIFF
--- a/docs/extending/custom-components/writers.md
+++ b/docs/extending/custom-components/writers.md
@@ -4,15 +4,17 @@ Write a custom writer when you need to record training statistics to a destinati
 
 ## The Write Lifecycle
 
-Writers follow a simple lifecycle managed by the training loop:
+The stage drives writers in this order on the master process:
 
-1. **`open()`** is called once when the stage starts. Set up resources here — open files, establish connections, create tables. In distributed runs, `open()` runs only on the master process, so you don't need to guard against multiple writers.
+1. **`sync_history(source_dir, working_dir, stage_name, steps)`** runs before the writer opens. `source_dir` is the restore directory (`workflow.restore_path`, or its parent if that path is a file) and `working_dir` is `workflow.save_path`. `steps` is the step the stage will resume from (`0` on a fresh run). If you persist a step log — a file, database, or other store — copy history from `source_dir` into `working_dir` when those directories differ, then keep only records for steps `0 .. steps-1`. Console and other writers that do not persist history can leave the default no-op.
 
-2. **`write(step, stats)`** is called every training step. `stats` is a flat dictionary containing the output of all estimators' `reduce()` — keys like `total_energy`, `pmove`, `energy:kinetic_var`, etc. Values are JAX/NumPy scalars; use `self.to_scalar(val)` to convert to Python floats if your destination requires it.
+2. **`open(working_dir, stage_name)`** is called once when the stage starts. Set up resources here — open files, establish connections, create tables. In distributed runs, `open()` runs only on the master process, so you don't need to guard against multiple writers.
 
-3. **`open()` cleanup** runs when the stage ends (after `yield`). Close file handles, flush buffers, disconnect.
+3. **`write(step, stats)`** is called every training step. `stats` is a flat dictionary of that step's recorded values — estimator outputs and, during training, sampler diagnostics such as `pmove`. Values may be JAX/NumPy scalars or arrays; use `self.to_scalar(val)` when your destination needs Python floats.
 
-4. **Resumption**: When training resumes from a checkpoint, `open()` receives `initial_step` — the step where training will restart. If your writer persists to a file, truncate any data at or beyond this point so stale entries from a previous (interrupted) run are discarded.
+4. **`open()` cleanup** runs when the stage ends (after `yield`). Close file handles, flush buffers, disconnect.
+
+The user-facing resume and branch recipes that produce a different `working_dir` are in <project:/guide/running-workflows.md#recipe-resume-evaluate>.
 
 ## Building a Writer
 
@@ -29,14 +31,28 @@ class MyWriter(Writer):
     log_dir: str = "/tmp/logs"  # config field — tunable via YAML
 ```
 
+**`sync_history`** prepares persisted history before `open()`. Skip this method only if the writer does not persist a step log.
+
+```python
+    def sync_history(self, source_dir, working_dir, stage_name, steps):
+        filename = f"{stage_name}_my_log.txt"
+        src = source_dir / filename
+        dest = working_dir / filename
+        if source_dir != working_dir and src.exists():
+            dest.write_text(src.read_text())
+        if not dest.exists():
+            return
+        lines = dest.read_text().splitlines()[:steps]
+        dest.write_text(("\n".join(lines) + "\n") if lines else "")
+```
+
 **`open`** manages the resource lifecycle. All I/O setup goes here — never in `__init__`. In distributed runs, multiple processes instantiate the writer during configuration, but only the master process enters `open()`. If you put file creation in `__init__`, every process would create (and fight over) the same files.
 
 ```python
     @contextmanager
-    def open(self, working_dir, stage_name, initial_step=0):
+    def open(self, working_dir, stage_name):
         path = working_dir / f"{stage_name}_my_log.txt"
         self._file = open(path, "a")
-        # If resuming, truncate stale entries
         try:
             yield
         finally:
@@ -52,11 +68,13 @@ class MyWriter(Writer):
         self._file.write(f"{step},{energy},{pmove}\n")
 ```
 
+{class}`~jaqmc.writer.csv.CSVWriter` and {class}`~jaqmc.writer.hdf5.HDF5Writer` apply the same copy-then-truncate pattern to `{stage}_stats.*`.
+
 ## Getting Started
 
 - {class}`~jaqmc.writer.console.ConsoleWriter` — simplest writer. Shows `to_scalar()` usage and selective field display.
-- {class}`~jaqmc.writer.csv.CSVWriter` — file-based writer. Shows `open()` with file handle management and header writing.
-- {class}`~jaqmc.writer.hdf5.HDF5Writer` — chunked array writes. Shows `initial_step` handling for checkpoint truncation.
+- {class}`~jaqmc.writer.csv.CSVWriter` — file-based writer. Shows `open()` with file handle management, header writing, and `sync_history` for resume.
+- {class}`~jaqmc.writer.hdf5.HDF5Writer` — chunked array writes. Shows `sync_history` for copy into a new directory and checkpoint truncation.
 - {class}`~jaqmc.writer.wandb.WandbWriter` — external service writer. Shows scalar filtering, W&B run lifecycle, and an optional dependency that must be installed separately.
 
 ## See Also

--- a/docs/extending/custom-components/writers.md
+++ b/docs/extending/custom-components/writers.md
@@ -14,7 +14,7 @@ The stage drives writers in this order on the master process:
 
 4. **`open()` cleanup** runs when the stage ends (after `yield`). Close file handles, flush buffers, disconnect.
 
-The user-facing resume and branch recipes that produce a different `working_dir` are in <project:/guide/running-workflows.md#recipe-resume-evaluate>.
+The user-facing resume and branch recipes that produce a different `working_dir` are in {ref}`recipe-resume-evaluate`.
 
 ## Building a Writer
 

--- a/docs/guide/analyzing-evaluations.md
+++ b/docs/guide/analyzing-evaluations.md
@@ -169,7 +169,7 @@ show_tree(WORKING_DIR / "eval")
 
 **Key files:**
 - **`evaluation_digest.npz`** — Final observables averaged over all evaluation steps. This is the main result.
-- **`evaluation_stats.h5`** — Per-step statistics written by the internal HDF5 writer. Used for digest computation and for the block analysis shown below.
+- **`evaluation_stats.h5`** — Per-step statistics written by the mandatory HDF5 writer. Used for digest computation and for the block analysis shown below.
 - **`evaluation_ckpt_*.npz`** — Checkpoint for resuming an interrupted evaluation.
 - **`config.yaml`** — The resolved configuration.
 

--- a/docs/guide/running-workflows.md
+++ b/docs/guide/running-workflows.md
@@ -98,8 +98,12 @@ jaqmc <app> train ... \
   train.run.iterations=<larger_value>
 ```
 
+JaQMC restores the latest checkpoint in that directory, drops any statistics written
+after that checkpoint, and appends new steps to the same `*_stats.*` files.
+
 Branch from an existing run into a new output directory by setting both save and restore
-paths:
+paths. JaQMC creates `workflow.save_path` if needed; that directory must not already
+contain files:
 
 ```bash
 jaqmc <app> train ... \
@@ -107,6 +111,11 @@ jaqmc <app> train ... \
   workflow.restore_path=./runs/<name>-prod \
   train.run.iterations=<larger_value>
 ```
+
+The new directory starts with the resumed stage's stats files (`train_stats.h5` and
+`train_stats.csv` by default), truncated to the restored checkpoint. New checkpoints and
+the resolved config are written as the run continues. Outputs from other stages, such as
+`pretrain_*`, stay in the original directory.
 
 For a trained wavefunction, run evaluation in a separate directory by pointing
 `workflow.source_path` at the training run you want to evaluate:
@@ -118,10 +127,10 @@ jaqmc <app> evaluate ... \
   run.iterations=1000
 ```
 
-Evaluation enables no configurable writer adapters by default. It does not emit per-step
-estimator statistics. Users who need per-step evaluation logging can enable writer
-adapters with `writers.*` command-line configuration overrides
-For example, with the energy estimator enabled:
+Evaluation always writes per-step statistics to `evaluation_stats.h5` in
+`workflow.save_path`. Use that file for uncertainty analysis. Console and CSV writers
+are disabled by default; see <project:writers.md> to enable them. For example, to print
+the total energy when the energy estimator is enabled:
 
 ```bash
 jaqmc <app> evaluate ... \
@@ -137,24 +146,22 @@ These three path settings do different jobs:
 
 - `workflow.save_path`: where the current command writes outputs
 - `workflow.restore_path`: where the current command looks for its own checkpoints; if
-  unset, it defaults to `workflow.save_path`
+  unset, it defaults to `workflow.save_path`. May be a directory or a specific checkpoint
+  file. When the checkpoint lives in a different directory, `workflow.save_path` must be
+  empty.
 - `workflow.source_path`: training run or checkpoint used by `evaluate` to load trained
   parameters, walkers, and sampler state. It is required when the wavefunction has
   trainable parameters. Analytic wavefunctions with no parameters can instead start
   evaluation from freshly initialized walkers; system pages document those workflows.
 ```
 
-When you rerun a command with the same `workflow.save_path`, JaQMC resumes from the
-latest checkpoint already in that directory. Use `workflow.restore_path` only when you
-want to start writing into a different output directory while restoring state from
-somewhere else.
-
 ### Reporting checklist
 
 Use this checklist before sharing final numbers:
 
 1. Prefer evaluation outputs over in-training values for final reported observables.
-2. Estimate uncertainty from per-step evaluation data, not from a single digest value.
+2. Estimate uncertainty from per-step evaluation data in `evaluation_stats.h5`, not from
+   a single digest value.
 3. Keep the resolved config and run provenance with the result.
 4. Record any non-default estimator, optimizer, or wavefunction settings.
 5. Make sure comparisons across runs use the same observable definitions and units.

--- a/docs/guide/writers.md
+++ b/docs/guide/writers.md
@@ -1,24 +1,37 @@
 # Writers
 
-Writers record statistics produced during training. The built-in writers are:
+Writers record per-step statistics. The built-in writers are:
 
 - **Console** — Prints selected fields to the terminal.
 - **CSV** — Appends scalar statistics to a CSV file (e.g., `train_stats.csv`) in the output directory.
 - **HDF5** — Appends all statistics (including array-valued fields) to an HDF5 file (e.g., `train_stats.h5`) in the output directory.
 - **W&B** — Sends scalar statistics to Weights & Biases.
 
-Which writers are active depends on the workflow. Use `--dry-run` to see the resolved config — the `writers` section shows what is enabled. To disable a writer, set it to `null`; to re-enable one that isn't active, set its module path:
+Which configurable writers are active depends on the workflow. Use `--dry-run`
+to see them in the resolved `writers` section. To disable a configurable writer,
+set it to `null`; to re-enable one that isn't active, set its module path.
+
+Evaluation writes `evaluation_stats.h5` as a required analysis file, not through
+the configurable HDF5 writer. Console and CSV stay off during evaluation unless
+you enable them at the config root (`writers.console.*`, `writers.csv.*`), not
+under `train.writers.*`.
 
 ```bash
-train.writers.hdf5=null                              # disable HDF5 for train
-train.writers.csv.module=jaqmc.writer.csv:CSVWriter   # enable CSV for train
-train.writers.wandb.module=jaqmc.writer.wandb:WandbWriter  # enable W&B for train
+train.writers.hdf5=null                               # disable HDF5 for train
+train.writers.csv.module=jaqmc.writer.csv             # enable CSV for train
+train.writers.wandb.module=jaqmc.writer.wandb         # enable W&B for train
 pretrain.writers.console.interval=10                  # configure pretrain's console writer
+writers.console.module=jaqmc.writer.console           # enable console during evaluate
+writers.csv.module=jaqmc.writer.csv                   # enable CSV during evaluate
 ```
 
 ## Console Output
 
-The console writer prints a configurable set of fields every `interval` steps (default: every step). The field spec format is `[alias=]key[:format]`, separated by commas:
+The console writer prints a configurable set of fields every `interval` steps
+(default: every step). The field spec format is `[alias=]key[:format]`,
+separated by commas. The examples below use the training prefix; for
+`jaqmc <app> evaluate`, use `writers.console.*` instead of
+`train.writers.console.*`.
 
 ```bash
 # Customize precision for energy and variance
@@ -77,16 +90,11 @@ already active before JaQMC starts the stage, the writer reuses that run.
 
 ## Output Files
 
-CSV and HDF5 writers produce files in the `workflow.save_path` directory. CSV captures scalar statistics; HDF5 captures all statistics including array-valued fields (e.g., histograms). When resuming from a checkpoint, both formats automatically truncate stale data from interrupted runs.
+CSV and HDF5 writers produce files in the `workflow.save_path` directory. CSV captures scalar statistics; HDF5 captures all statistics including array-valued fields. Their output files are named `{stage}_stats.csv` and `{stage}_stats.h5`.
 
-By default, their output paths come from the templates `{stage}_stats.csv` and `{stage}_stats.h5`. You can customize these with `path_template`; the only supported template field is `{stage}`:
-
-```bash
-train.writers.csv.path_template=logs/{stage}_metrics.csv
-train.writers.hdf5.path_template=artifacts/{stage}/stats.h5
-```
-
-See <project:training-stats.md> for how to work with these files.
+For resume and branch behavior, see
+<project:running-workflows.md#recipe-resume-evaluate>. For reading the files,
+see <project:training-stats.md>.
 
 ## See Also
 

--- a/docs/guide/writers.md
+++ b/docs/guide/writers.md
@@ -93,7 +93,7 @@ already active before JaQMC starts the stage, the writer reuses that run.
 CSV and HDF5 writers produce files in the `workflow.save_path` directory. CSV captures scalar statistics; HDF5 captures all statistics including array-valued fields. Their output files are named `{stage}_stats.csv` and `{stage}_stats.h5`.
 
 For resume and branch behavior, see
-<project:running-workflows.md#recipe-resume-evaluate>. For reading the files,
+{ref}`recipe-resume-evaluate`. For reading the files,
 see <project:training-stats.md>.
 
 ## See Also

--- a/docs/systems/hall/eval.md
+++ b/docs/systems/hall/eval.md
@@ -60,10 +60,9 @@ proposal.
 
 ## Writers (`writers.*`)
 
-No external writers are enabled by default. If you enable them manually, the
-root-level writer keys below control their configuration. The evaluation stage
-always writes per-step statistics to an internal HDF5 file for digest
-computation; this is independent of the writers configured here.
+The evaluation HDF5 writer is always enabled because its per-step statistics
+are required for digest computation. It writes to `evaluation_stats.h5`; other
+root-level writer keys enable additional outputs.
 
 ### Console writer (`writers.console.*`)
 
@@ -77,13 +76,6 @@ computation; this is independent of the writers configured here.
 ```{eval-rst}
 .. config-defaults:: jaqmc.writer.csv.CSVWriter
    :prefix: writers.csv
-```
-
-### HDF5 writer (`writers.hdf5.*`)
-
-```{eval-rst}
-.. config-defaults:: jaqmc.writer.hdf5.HDF5Writer
-   :prefix: writers.hdf5
 ```
 
 (hall-estimators)=

--- a/docs/systems/moire/eval.md
+++ b/docs/systems/moire/eval.md
@@ -54,10 +54,9 @@ adds `digest_step_interval` for previewing accumulated statistics.
 
 ## Writers (`writers.*`)
 
-No external writers are enabled by default. If you enable them manually, the
-root-level writer keys below control their configuration. The evaluation stage
-always writes per-step statistics to an internal HDF5 file for digest
-computation; this is independent of the writers configured here.
+The evaluation HDF5 writer is always enabled because its per-step statistics
+are required for digest computation. It writes to `evaluation_stats.h5`; other
+root-level writer keys enable additional outputs.
 
 ### Console writer (`writers.console.*`)
 
@@ -71,13 +70,6 @@ computation; this is independent of the writers configured here.
 ```{eval-rst}
 .. config-defaults:: jaqmc.writer.csv.CSVWriter
    :prefix: writers.csv
-```
-
-### HDF5 writer (`writers.hdf5.*`)
-
-```{eval-rst}
-.. config-defaults:: jaqmc.writer.hdf5.HDF5Writer
-   :prefix: writers.hdf5
 ```
 
 ## Estimators (`estimators.*`)

--- a/docs/systems/molecule/eval.md
+++ b/docs/systems/molecule/eval.md
@@ -52,10 +52,9 @@ all-electron Gaussian proposal.
 
 ## Writers (`writers.*`)
 
-No external writers are enabled by default. If you enable them manually, the
-root-level writer keys below control their configuration. The evaluation stage
-always writes per-step statistics to an internal HDF5 file for digest
-computation; this is independent of the writers configured here.
+The evaluation HDF5 writer is always enabled because its per-step statistics
+are required for digest computation. It writes to `evaluation_stats.h5`; other
+root-level writer keys enable additional outputs.
 
 ### Console writer (`writers.console.*`)
 
@@ -69,13 +68,6 @@ computation; this is independent of the writers configured here.
 ```{eval-rst}
 .. config-defaults:: jaqmc.writer.csv.CSVWriter
    :prefix: writers.csv
-```
-
-### HDF5 writer (`writers.hdf5.*`)
-
-```{eval-rst}
-.. config-defaults:: jaqmc.writer.hdf5.HDF5Writer
-   :prefix: writers.hdf5
 ```
 
 (molecule-estimators)=

--- a/docs/systems/solid/eval.md
+++ b/docs/systems/solid/eval.md
@@ -63,10 +63,9 @@ Gaussian proposal.
 
 ## Writers (`writers.*`)
 
-No external writers are enabled by default. If you enable them manually, the
-root-level writer keys below control their configuration. The evaluation stage
-always writes per-step statistics to an internal HDF5 file for digest
-computation; this is independent of the writers configured here.
+The evaluation HDF5 writer is always enabled because its per-step statistics
+are required for digest computation. It writes to `evaluation_stats.h5`; other
+root-level writer keys enable additional outputs.
 
 ### Console writer (`writers.console.*`)
 
@@ -80,13 +79,6 @@ computation; this is independent of the writers configured here.
 ```{eval-rst}
 .. config-defaults:: jaqmc.writer.csv.CSVWriter
    :prefix: writers.csv
-```
-
-### HDF5 writer (`writers.hdf5.*`)
-
-```{eval-rst}
-.. config-defaults:: jaqmc.writer.hdf5.HDF5Writer
-   :prefix: writers.hdf5
 ```
 
 (solid-estimators)=

--- a/src/jaqmc/utils/hdf5.py
+++ b/src/jaqmc/utils/hdf5.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Mapping
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from typing import Any
 
 import h5py
@@ -53,9 +53,8 @@ class HDF5ReadWrite:
             left by a previous interrupted run. If None, rows are kept.
     """
 
-    def __init__(self, stats_path: UPath, truncate_to: int | None = None) -> None:
+    def __init__(self, stats_path: UPath) -> None:
         self.stats_path = stats_path
-        self.truncate_to = truncate_to
         self._h5_file: CachedHDF5 | None = None
 
     @contextmanager
@@ -64,18 +63,23 @@ class HDF5ReadWrite:
         open_mode = "r+b" if self.stats_path.exists() else "w+b"
         with self.stats_path.open(open_mode) as raw, CachedHDF5(raw, "a") as h5:
             self._h5_file = h5
-            self._truncate()
-            yield
-            self.close()
+            try:
+                yield h5
+            finally:
+                self.close()
 
-    def _truncate(self) -> None:
+    def truncate(self, steps: int) -> None:
         """Truncate all datasets to ``truncate_to`` rows, if set."""
-        if self.truncate_to is None or not self._h5_file:
-            return
-        for name in list(self._h5_file):
-            dataset = self._h5_file[name]
-            if dataset.shape[0] > self.truncate_to:
-                dataset.resize(self.truncate_to, axis=0)
+        with ExitStack() as stack:
+            h5_file = (
+                self._h5_file
+                if self._h5_file is not None
+                else stack.enter_context(self.open())
+            )
+            for name in list(h5_file):
+                dataset = h5_file[name]
+                if dataset.shape[0] > steps:
+                    dataset.resize(steps, axis=0)
 
     def read(self) -> dict[str, np.ndarray]:
         """Read all accumulated stats from the open HDF5 file.

--- a/src/jaqmc/workflow/base.py
+++ b/src/jaqmc/workflow/base.py
@@ -47,10 +47,11 @@ class WorkflowConfig:
         seed: Fixed random seed. If not provided, current time will be used.
         batch_size: Number of walkers (samples) to use in each iteration.
         save_path: Path to save checkpoints and logs. Can be any path
-            supported by fsspec/universal_pathlib.
-        restore_path: Path to restore checkpoints from. When set, checkpoints
-            are restored from this path instead of ``save_path``. Can be a
-            directory or a specific checkpoint file.
+            supported by fsspec/universal_pathlib. If empty, defaults to a
+            timestamped directory under ``runs/``.
+        restore_path: Path to restore checkpoints from. If ``None``,
+            ``save_path`` is used. Can be a directory or a specific checkpoint
+            file.
         config: Controls config validation behavior (extra-key warnings,
             verbose output).
     """
@@ -58,7 +59,7 @@ class WorkflowConfig:
     seed: int | None = None
     batch_size: int = 4096
     save_path: str = ""
-    restore_path: str = ""
+    restore_path: str | None = None
     config: ConfigCheck = field(default_factory=ConfigCheck)
 
     def __post_init__(self):
@@ -70,8 +71,6 @@ class WorkflowConfig:
                 self.save_path = str(project_root / "runs" / dirname)
             else:
                 self.save_path = str(Path("runs") / dirname)
-        if not self.restore_path:
-            self.restore_path = self.save_path
 
 
 class Workflow:
@@ -105,9 +104,9 @@ class Workflow:
         cfg.use_preset(type(self).default_preset())
         self.cfg = cfg
         self.config = cfg.get("workflow", self.config_class)
-        self.save_path = UPath(self.config.save_path)
+        self.save_path = UPath(self.config.save_path).resolve()
         self.restore_path = (
-            UPath(self.config.restore_path)
+            UPath(self.config.restore_path).resolve()
             if self.config.restore_path is not None
             else self.save_path
         )
@@ -136,7 +135,7 @@ class Workflow:
         filename = "config.yaml"
         if self.config_namespace:
             filename = f"{self.config_namespace}_config.yaml"
-        return UPath(self.config.save_path) / filename
+        return self.save_path / filename
 
     def config_backup_path(self) -> UPath:
         """Return an unused backup path for the current config snapshot."""
@@ -159,6 +158,7 @@ class Workflow:
         """
         # Only write config and compare on the master process
         if jax.process_index() == 0:
+            self._validate_paths()
             config_path = self.config_path()
             previous_yaml = config_path.read_text() if config_path.exists() else None
             self.cfg.finalize(
@@ -184,6 +184,31 @@ class Workflow:
             jax.local_device_count(),
             jax.process_count(),
         )
+
+    def _validate_paths(self) -> None:
+        """Reject a restore path that does not exist or an unusable ``save_path``.
+
+        ``restore_path`` must exists unless it's the same as ``save_path`` (the case of
+        fresh runs). If ``save_path`` differs from the restore directory, it should be
+        empty, otherwise the files there can be overwritten and cause data loss.
+
+        Raises:
+            FileNotFoundError: Restore path does not exist.
+            ValueError: Save path is not a directory, or is not empty
+                during cross-directory resume.
+        """
+        save_path = self.save_path
+        restore_path = self.restore_path
+        if restore_path != save_path and not restore_path.exists():
+            raise FileNotFoundError(f"Restore path {restore_path} does not exist")
+        if save_path.exists() and not save_path.is_dir():
+            raise ValueError(f"Save path is not a directory: {save_path}")
+
+        restore_dir = restore_path.parent if restore_path.is_file() else restore_path
+        if save_path != restore_dir and save_path.exists() and any(save_path.iterdir()):
+            raise ValueError(
+                f"Save path is not empty during cross-directory resume: {save_path}"
+            )
 
 
 def init_batched_data(

--- a/src/jaqmc/workflow/stage/base.py
+++ b/src/jaqmc/workflow/stage/base.py
@@ -164,7 +164,13 @@ class WorkStage[StateT: StageState](ABC):
 
         try:
             with self.writers.open(
-                save_dir, prefix, is_master=is_master, initial_step=initial_step
+                save_dir,
+                prefix,
+                is_master=is_master,
+                initial_step=initial_step,
+                restore_dir=ckpt.restore_path.parent
+                if ckpt.restore_path.is_file()
+                else ckpt.restore_path,
             ):
                 tracker.start()
                 for step, state in self.loop(state, initial_step, rngs):

--- a/src/jaqmc/workflow/stage/evaluation.py
+++ b/src/jaqmc/workflow/stage/evaluation.py
@@ -7,7 +7,6 @@ Accumulates per-step statistics in an HDF5 file owned by the stage and produces 
 ``digest.npz`` summary after all steps. Optionally logs preview digests.
 """
 
-from contextlib import nullcontext
 from dataclasses import dataclass, replace
 from typing import Any, ClassVar
 
@@ -17,8 +16,8 @@ import numpy as np
 from jaqmc.array_types import PRNGKey
 from jaqmc.utils import parallel_jax
 from jaqmc.utils.config import configurable_dataclass
-from jaqmc.utils.hdf5 import HDF5ReadWrite
 from jaqmc.writer import Writers
+from jaqmc.writer.hdf5 import HDF5Writer
 
 from .base import RunContext, WorkStageConfig
 from .sampling import SamplingStageBuilder, SamplingState, SamplingWorkStage
@@ -48,20 +47,22 @@ class EvalStageBuilder(SamplingStageBuilder):
     config: EvaluationWorkStageConfig
 
     def configure_writers(self, writers: Writers | None = None) -> None:
-        """Configure writers. If no argument, loads defaults from config.
+        """Configure optional writers and add evaluation statistics storage.
 
         Args:
             writers: Pre-built writers, or None to load from config.
         """
-        if writers is not None:
-            self.writers = writers
-        else:
+        if writers is None:
             writers_map = self.cfg.get_collection(
                 "writers",
                 defaults={},
                 context={"config": self.config, "name": self.name},
             )
-            self.writers = Writers(list(writers_map.values()))
+            optional_writers = list(writers_map.values())
+        else:
+            optional_writers = list(writers)
+        self.stats_writer = HDF5Writer()
+        self.writers = Writers([self.stats_writer, *optional_writers])
 
     def build(self) -> "EvaluationWorkStage":
         """Build a fully-configured :class:`EvaluationWorkStage`.
@@ -77,6 +78,7 @@ class EvalStageBuilder(SamplingStageBuilder):
             sample_plan=self.sample_plan,
             estimators=self.estimators,
             writers=self.writers,
+            stats_writer=self.stats_writer,
         )
 
 
@@ -100,19 +102,15 @@ class EvaluationWorkStage(SamplingWorkStage):
     config: EvaluationWorkStageConfig
     name: str
     writers: Writers
+    stats_writer: HDF5Writer
 
     builder: ClassVar[type[EvalStageBuilder]] = EvalStageBuilder
 
     def run(self, state: Any, context: RunContext, rngs: PRNGKey) -> Any:
         save_dir, prefix, _ = self._resolve_paths(context)
-        is_master = jax.process_index() == 0
         self._save_dir = save_dir
         self._prefix = prefix
 
-        prefix_str = f"{prefix}_" if prefix else ""
-        self.hdf5 = HDF5ReadWrite(
-            save_dir / f"{prefix_str}stats.h5", truncate_to=self.config.iterations
-        )
         if self.config.digest_step_interval == 0:
             self.logger.info(
                 "Evaluation digest will only be printed at the last step. Set "
@@ -124,11 +122,7 @@ class EvaluationWorkStage(SamplingWorkStage):
                 "Evaluation digest will be logged every %d steps.",
                 self.config.digest_step_interval,
             )
-        with self.hdf5.open() if is_master else nullcontext():
-            state = super().run(state, context, rngs)
-            if is_master:
-                self.write_digest(state)
-        return state
+        return super().run(state, context, rngs)
 
     def compute_step(
         self, state: SamplingState, rngs: PRNGKey
@@ -158,7 +152,7 @@ class EvaluationWorkStage(SamplingWorkStage):
         if not self.estimators._reduce_keys:
             return
 
-        stacked = self.hdf5.read()
+        stacked = self.stats_writer.read()
         digest = self.estimators.digest(
             stacked, state.estimator_state, n_steps=self.config.iterations
         )
@@ -172,7 +166,7 @@ class EvaluationWorkStage(SamplingWorkStage):
 
     def log_preview_digest(self, step: int, state: SamplingState) -> None:
         """Log a preview digest from the stats accumulated so far."""
-        stacked = self.hdf5.read()
+        stacked = self.stats_writer.read()
         if not stacked:
             return
         preview = self.estimators.finalize_stats(stacked, state.estimator_state)
@@ -184,10 +178,7 @@ class EvaluationWorkStage(SamplingWorkStage):
                     self.logger.info("Digest step %d for %s:\n%s", step, k, v)
 
     def loop(self, state: SamplingState, initial_step: int, rngs):
-        """Yield ``(step, state)`` for each evaluation iteration.
-
-        Accumulates per-step statistics in the stage-owned HDF5 file.
-        """
+        """Yield ``(step, state)`` for each evaluation iteration."""
         is_master = jax.process_index() == 0
         partition = state.partition()
         split_rngs = parallel_jax.jit_sharded(
@@ -214,7 +205,6 @@ class EvaluationWorkStage(SamplingWorkStage):
             state, step_stats = compute(state, sub_rngs)
 
             if is_master:
-                self.hdf5.write(step_stats)
                 self.writers.write(step, step_stats)
                 if digest_step_interval and (step + 1) % digest_step_interval == 0:
                     self.log_preview_digest(step, state)
@@ -225,3 +215,5 @@ class EvaluationWorkStage(SamplingWorkStage):
             digest_step_interval == 0 or (step + 1) % digest_step_interval != 0
         ):
             self.log_preview_digest(step, state)
+        if is_master:
+            self.write_digest(state)

--- a/src/jaqmc/writer/base.py
+++ b/src/jaqmc/writer/base.py
@@ -3,7 +3,7 @@
 
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from typing import Any
@@ -30,42 +30,6 @@ class Writer(ABC):
             return val.item()
         return val
 
-    @staticmethod
-    def resolve_path_template(
-        working_dir: UPath | Path, path_template: str, stage_name: str
-    ) -> UPath:
-        """Resolve a writer path template against the working directory.
-
-        The template may contain ``{stage}``, which is replaced with the
-        current stage name before the path is resolved.
-
-        Args:
-            working_dir: Base directory for relative paths.
-            path_template: Absolute path or path relative to ``working_dir``.
-            stage_name: Name of the current stage.
-
-        Returns:
-            The resolved output path.
-
-        Raises:
-            ValueError: If ``stage_name`` is empty or the template uses
-                unsupported fields.
-        """
-        if not stage_name:
-            raise ValueError("File-backed writers require a non-empty stage name.")
-        try:
-            rendered = path_template.format(stage=stage_name)
-        except KeyError as e:
-            raise ValueError(
-                f"Unsupported path template field '{e.args[0]}'. "
-                "Only '{stage}' is supported."
-            ) from None
-
-        save_path = UPath(rendered)
-        if save_path.is_absolute():
-            return save_path
-        return UPath(working_dir) / save_path
-
     @abstractmethod
     def write(self, step: int, stats: Mapping[str, Any]) -> None:
         """Write statistics for the current step.
@@ -75,38 +39,59 @@ class Writer(ABC):
             stats: Dictionary of statistics to write.
         """
 
+    def sync_history(
+        self, source_dir: UPath, working_dir: UPath, stage_name: str, steps: int
+    ) -> None:
+        """Inherit persisted history before opening the writer.
+
+        Called on the master process before :meth:`open`. File-based writers
+        should copy their artifacts from ``source_dir`` into ``working_dir``
+        when those directories differ, then discard records for step
+        ``steps`` and later so a resume does not keep stale rows from an
+        interrupted run. Writers that do not persist files can leave the
+        default no-op.
+
+        Args:
+            source_dir: Directory that contains the checkpoint being restored.
+                Same as ``working_dir`` for in-place resume.
+            working_dir: Directory where this run writes outputs.
+            stage_name: Name of the current stage, used to locate
+                stage-specific files.
+            steps: Step at which the stage will resume. Keep history for
+                steps ``0 .. steps-1``.
+        """
+        del source_dir, working_dir, stage_name, steps
+
     @contextmanager
-    def open(self, working_dir: UPath | Path, stage_name: str, initial_step: int = 0):
+    def open(self, working_dir: UPath, stage_name: str):
         """Context manager for resource handling.
 
         This method manages resource lifecycle and side effects, such as
-        initializing files or other I/O operations.
-
-        When restoring from a checkpoint, ``initial_step`` indicates where
-        training will resume. Writers that persist to files should truncate
-        any data beyond this point so that stale entries from a previous
-        (interrupted) run are discarded.
+        initializing files or other I/O operations. Do file creation and
+        handle opening here, not in ``__init__``.
 
         Args:
             working_dir: The directory where artifacts should be stored.
-            stage_name: Name of the current training stage. File-backed
-                writers may use it when resolving their output path template.
-            initial_step: The step from which training will resume. Data
-                written for steps >= ``initial_step`` should be discarded.
+            stage_name: Name of the current training stage.
         """
+        del working_dir, stage_name
         yield
 
 
 class Writers:
     """A collection of writers with master-process guarding.
 
-    Wraps multiple :class:`Writer` instances and ensures that ``open`` and ``write``
-    only execute on the master process in distributed settings.
+    Wraps multiple :class:`Writer` instances and ensures that
+    ``sync_history``, ``open``, and ``write`` only execute on the master
+    process in distributed settings.
     """
 
     def __init__(self, writers: Sequence[Writer] = ()):
         self._writers = list(writers)
         self._is_master = False
+
+    def __iter__(self) -> Iterator[Writer]:
+        return iter(self._writers)
 
     @contextmanager
     def open(
@@ -114,6 +99,7 @@ class Writers:
         working_dir: UPath | Path,
         stage_name: str,
         *,
+        restore_dir: UPath | Path,
         is_master: bool = True,
         initial_step: int = 0,
     ):
@@ -122,6 +108,8 @@ class Writers:
         Args:
             working_dir: Directory where artifacts should be stored.
             stage_name: Name of the current training stage.
+            restore_dir: Directory containing history to inherit before
+                opening writers. Same as ``working_dir`` for in-place resume.
             is_master: Whether this is the master process.
             initial_step: The step from which training will resume. Data
                 written for steps >= ``initial_step`` should be discarded.
@@ -130,12 +118,16 @@ class Writers:
             None.
         """
         self._is_master = is_master
+        working_dir = UPath(working_dir)
+        restore_dir = UPath(restore_dir)
         with ExitStack() as stack:
             if self._is_master:
                 for writer in self._writers:
-                    stack.enter_context(
-                        writer.open(working_dir, stage_name, initial_step=initial_step)
+                    writer.sync_history(
+                        restore_dir, working_dir, stage_name, initial_step
                     )
+                for writer in self._writers:
+                    stack.enter_context(writer.open(working_dir, stage_name))
                 active_writers = ", ".join(
                     type(writer).__name__ for writer in self._writers
                 )

--- a/src/jaqmc/writer/console.py
+++ b/src/jaqmc/writer/console.py
@@ -96,7 +96,8 @@ class ConsoleWriter(Writer):
         self._warned_missing_fields: set[str] = set()
 
     @contextmanager
-    def open(self, working_dir, stage_name, initial_step: int = 0):
+    def open(self, working_dir, stage_name):
+        del working_dir
         self.logger = logging.LoggerAdapter(logger, extra={"category": stage_name})
         yield
 

--- a/src/jaqmc/writer/csv.py
+++ b/src/jaqmc/writer/csv.py
@@ -4,13 +4,13 @@
 import csv
 from collections.abc import Mapping
 from contextlib import contextmanager
-from typing import IO, TYPE_CHECKING, Any
+from typing import IO, TYPE_CHECKING, Any, ClassVar
 
 from jax import numpy as jnp
 from upath import UPath
 
 from jaqmc.utils.config import configurable_dataclass
-from jaqmc.writer.base import Writer
+from jaqmc.writer import Writer
 
 if TYPE_CHECKING:
     import _csv
@@ -20,27 +20,26 @@ __all__ = ["CSVWriter"]
 
 @configurable_dataclass
 class CSVWriter(Writer):
-    """Writes statistics to a CSV file.
+    """Appends scalar statistics to a CSV file.
 
-    Existing files are truncated to ``initial_step`` data rows upon :meth:`open`
-    before new rows are appended, so resumed runs discard stale rows past the
-    restored checkpoint.
+    Writes ``{stage}_stats.csv`` in the working directory. Each
+    :meth:`write` call adds one row: ``step`` first, then the scalar
+    entries of ``stats`` in sorted key order. Python scalars and 0-d
+    arrays are written; non-scalar values are skipped.
 
-    Args:
-        path_template: Output path template. Relative paths are resolved
-            under the working directory. The template may contain ``{stage}``.
+    If the file already exists and is non-empty, rows are appended and
+    the header is left unchanged. On resume, :meth:`sync_history` copies
+    the file from ``source_dir`` into ``working_dir`` when those
+    directories differ, then keeps only the header and the first
+    ``steps`` data rows.
     """
 
-    path_template: str = "{stage}_stats.csv"
+    path_template: ClassVar[str] = "{stage}_stats.csv"
 
     @contextmanager
-    def open(self, working_dir, stage_name, initial_step: int = 0):
-        save_path = self.resolve_path_template(
-            working_dir, self.path_template, stage_name
-        )
+    def open(self, working_dir: UPath, stage_name: str):
+        save_path = working_dir / self.path_template.format(stage=stage_name)
         save_path.parent.mkdir(exist_ok=True, parents=True)
-
-        self._truncate_to(save_path, initial_step)
 
         file_exists = False
         try:
@@ -58,18 +57,26 @@ class CSVWriter(Writer):
         self._file = None
         self._writer = None
 
-    @staticmethod
-    def _truncate_to(save_path: UPath, initial_step: int) -> None:
-        """Keep only the header and the first ``initial_step`` data rows."""
-        if not save_path.exists() or save_path.stat().st_size == 0:
+    def sync_history(
+        self, source_dir: UPath, working_dir: UPath, stage_name: str, steps: int
+    ) -> None:
+        filename = self.path_template.format(stage=stage_name)
+        csv_path = source_dir / filename
+        if source_dir != working_dir:
+            csv_path = (
+                csv_path.copy_into(working_dir)
+                if csv_path.exists()
+                else working_dir / filename
+            )
+        if not csv_path.exists() or csv_path.stat().st_size == 0:
             return
-        with save_path.open("r", newline="") as f:
+        with csv_path.open("r", newline="") as f:
             lines = f.readlines()
         # lines[0] is the header, lines[1:] are data rows
-        if len(lines) - 1 <= initial_step:
+        if len(lines) - 1 <= steps:
             return
-        keep = lines[: 1 + initial_step]
-        with save_path.open("w", newline="") as f:
+        keep = lines[: 1 + steps]
+        with csv_path.open("w", newline="") as f:
             f.writelines(keep)
 
     def write(self, step: int, stats: Mapping[str, Any]) -> None:

--- a/src/jaqmc/writer/hdf5.py
+++ b/src/jaqmc/writer/hdf5.py
@@ -3,43 +3,88 @@
 
 from collections.abc import Mapping
 from contextlib import contextmanager
-from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
+import numpy as np
 from upath import UPath
 
 from jaqmc.utils.config import configurable_dataclass
 from jaqmc.utils.hdf5 import HDF5ReadWrite
-from jaqmc.writer.base import Writer
+from jaqmc.writer import Writer
 
 __all__ = ["HDF5Writer"]
 
 
 @configurable_dataclass
 class HDF5Writer(Writer):
-    """Writes statistics to an HDF5 file.
+    """Appends statistics, including array-valued fields, to an HDF5 file.
 
-    Existing files are truncated to ``initial_step`` data rows upon :meth:`open`
-    before new rows are written, so resumed runs discard stale rows past the
-    restored checkpoint.
+    Writes ``{stage}_stats.h5`` in the working directory. Each
+    :meth:`write` call appends one entry per JAX array in ``stats``
+    (scalars and higher-rank arrays); other value types are skipped.
+    Each key is stored as a resizable dataset whose first axis grows by
+    one row per call.
 
-    Args:
-        path_template: Output path template. Relative paths are resolved
-            under the working directory. The template may contain ``{stage}``.
+    On resume, :meth:`sync_history` copies the file from ``source_dir``
+    into ``working_dir`` when those directories differ, then truncates
+    every dataset to ``steps`` rows. While the writer is open,
+    :meth:`read` returns the accumulated datasets as NumPy arrays.
     """
 
-    path_template: str = "{stage}_stats.h5"
+    path_template: ClassVar[str] = "{stage}_stats.h5"
+
+    def __post_init__(self) -> None:
+        self._h5_writer: HDF5ReadWrite | None = None
 
     @contextmanager
-    def open(self, working_dir: UPath | Path, stage_name: str, initial_step: int = 0):
-        save_path = self.resolve_path_template(
-            working_dir, self.path_template, stage_name
-        )
-        self._h5_writer = HDF5ReadWrite(save_path, truncate_to=initial_step)
-        with self._h5_writer.open():
-            yield
+    def open(self, working_dir: UPath, stage_name: str):
+        save_path = working_dir / self.path_template.format(stage=stage_name)
+        h5_writer = HDF5ReadWrite(save_path)
+        self._h5_writer = h5_writer
+        try:
+            with h5_writer.open():
+                yield
+        finally:
+            self._h5_writer = None
+
+    def sync_history(
+        self, source_dir: UPath, working_dir: UPath, stage_name: str, steps: int
+    ) -> None:
+        filename = self.path_template.format(stage=stage_name)
+        h5_path = source_dir / filename
+        if source_dir != working_dir:
+            h5_path = (
+                h5_path.copy_into(working_dir)
+                if h5_path.exists()
+                else working_dir / filename
+            )
+        if h5_path.exists():
+            HDF5ReadWrite(h5_path).truncate(steps)
 
     def write(self, step: int, stats: Mapping[str, Any]) -> None:
+        """Append one step of ``jax.Array`` statistics to the HDF5 file.
+
+        Args:
+            step: Current iteration step. Not stored; rows append in order.
+            stats: Statistics dictionary. ``jax.Array`` values are written;
+                other types are skipped.
+
+        Raises:
+            ValueError: If called outside the :meth:`open` context manager.
+        """
         if not self._h5_writer:
             raise ValueError("Writing on closed file.")
         self._h5_writer.write(stats)
+
+    def read(self) -> dict[str, np.ndarray]:
+        """Return all accumulated datasets as NumPy arrays.
+
+        Returns:
+            Mapping from stat name to an array with a leading step dimension.
+
+        Raises:
+            ValueError: If called outside the :meth:`open` context manager.
+        """
+        if not self._h5_writer:
+            raise ValueError("Reading from closed file.")
+        return self._h5_writer.read()

--- a/src/jaqmc/writer/wandb.py
+++ b/src/jaqmc/writer/wandb.py
@@ -45,13 +45,7 @@ class WandbWriter(Writer):
         self._run: Any | None = None
 
     @contextmanager
-    def open(
-        self,
-        working_dir: UPath | Path,
-        stage_name: str,
-        initial_step: int = 0,
-    ):
-        del initial_step
+    def open(self, working_dir: UPath, stage_name: str):
         wandb = self._import_wandb()
         active_run = getattr(wandb, "run", None)
 

--- a/tests/hydrogen/atom_test.py
+++ b/tests/hydrogen/atom_test.py
@@ -72,6 +72,9 @@ def test_evaluation_writes_per_step_stats_and_digest(tmp_path):
                 "source_path": str(train_dir),
             },
             "run": {"iterations": 5},
+            "writers": {
+                "csv": {"module": "jaqmc.writer.csv:CSVWriter"},
+            },
         }
     )
     hydrogen_atom_eval_workflow(eval_cfg)()
@@ -80,6 +83,10 @@ def test_evaluation_writes_per_step_stats_and_digest(tmp_path):
     with h5py.File(eval_dir / "evaluation_stats.h5", "r") as f:
         assert "total_energy" in f
         assert f["total_energy"].shape[0] == 5
+        expected_energy = np.nanmean(f["total_energy"], axis=0)
+
+    with (eval_dir / "evaluation_stats.csv").open(encoding="utf8") as f:
+        assert len(f.readlines()) == 6
 
     # Digest produced after evaluation — values should be scalars
     digest_path = eval_dir / "evaluation_digest.npz"
@@ -87,6 +94,7 @@ def test_evaluation_writes_per_step_stats_and_digest(tmp_path):
     digest = np.load(digest_path)
     assert "total_energy" in digest
     assert digest["total_energy"].ndim == 0
+    assert np.isclose(digest["total_energy"], expected_energy)
     assert "energy:kinetic" in digest
     assert digest["energy:kinetic"].ndim == 0
 

--- a/tests/integration/checkpoint_test.py
+++ b/tests/integration/checkpoint_test.py
@@ -4,20 +4,65 @@
 from pathlib import Path
 
 import h5py
+import numpy as np
 import pytest
 
-from jaqmc.app.hydrogen_atom import hydrogen_atom_train_workflow
+from jaqmc.app.hydrogen_atom import (
+    hydrogen_atom_eval_workflow,
+    hydrogen_atom_train_workflow,
+)
 from jaqmc.utils.config import ConfigManager
+
+
+def _train_hydrogen(save_path: Path) -> None:
+    cfg = ConfigManager(
+        {
+            "workflow": {"save_path": str(save_path), "batch_size": 128},
+            "train": {"run": {"iterations": 5}},
+        }
+    )
+    hydrogen_atom_train_workflow(cfg)()
+
+
+def _evaluation_config(
+    save_path: Path,
+    restore_path: Path,
+    train_path: Path,
+    *,
+    iterations: int,
+    seed: int,
+    save_step_interval: int = 1000,
+    save_time_interval: int = 600,
+) -> ConfigManager:
+    return ConfigManager(
+        {
+            "workflow": {
+                "seed": seed,
+                "save_path": str(save_path),
+                "restore_path": str(restore_path),
+                "source_path": str(train_path),
+                "batch_size": 128,
+            },
+            "run": {
+                "iterations": iterations,
+                "save_step_interval": save_step_interval,
+                "save_time_interval": save_time_interval,
+            },
+        }
+    )
 
 
 @pytest.mark.integration
 def test_stats_truncated_on_restore(tmp_path: Path):
     """Stats beyond the restored checkpoint step are discarded."""
+    resume_step = 3
 
-    def create_config(iterations, save_step_interval=1000, save_time_interval=600):
+    def create_config(
+        iterations, *, seed, save_step_interval=1000, save_time_interval=600
+    ):
         return ConfigManager(
             {
-                "workflow": {"seed": 42, "save_path": str(tmp_path)},
+                "workflow": {"seed": seed, "save_path": str(tmp_path)},
                 "train": {
                     "run": {
                         "iterations": iterations,
@@ -30,7 +75,9 @@ def test_stats_truncated_on_restore(tmp_path: Path):
 
     # Run 5 iterations with frequent checkpointing to get a mid-run checkpoint.
     # save_step_interval=3 → checkpoint at step 2 ((2+1)%3==0) and step 4 (final).
-    cfg = create_config(iterations=5, save_step_interval=3, save_time_interval=0)
+    cfg = create_config(
+        iterations=5, seed=1, save_step_interval=3, save_time_interval=0
+    )
     hydrogen_atom_train_workflow(cfg)()
 
     ckpts = sorted((tmp_path).glob("train_ckpt_*.npz"))
@@ -41,8 +88,11 @@ def test_stats_truncated_on_restore(tmp_path: Path):
     # Stats have 5 entries (steps 0-4).
     with h5py.File(tmp_path / "train_stats.h5", "r") as f:
         assert len(f["loss"]) == 5
-    with open(tmp_path / "train_stats.csv", encoding="utf8") as f:
-        assert len(f.readlines()) == 1 + 5
+        expected_hdf5_prefix = f["loss"][:resume_step].copy()
+    with (tmp_path / "train_stats.csv").open(encoding="utf8") as f:
+        initial_csv_lines = f.readlines()
+    assert len(initial_csv_lines) == 1 + 5
+    expected_csv_prefix = initial_csv_lines[: 1 + resume_step]
 
     # Delete the final checkpoint so restore falls back to step 2.
     (tmp_path / "train_ckpt_000004.npz").unlink()
@@ -50,87 +100,126 @@ def test_stats_truncated_on_restore(tmp_path: Path):
     # Restore and continue to 8 iterations.  initial_step = 3 (checkpoint
     # step 2 + 1), so stats for steps 3-4 from the first run must be
     # discarded before appending steps 3-7.
-    cfg = create_config(iterations=8)
+    cfg = create_config(iterations=8, seed=2)
     hydrogen_atom_train_workflow(cfg)()
 
     with h5py.File(tmp_path / "train_stats.h5", "r") as f:
+        np.testing.assert_array_equal(f["loss"][:resume_step], expected_hdf5_prefix)
         assert len(f["loss"]) == 8
-    with open(tmp_path / "train_stats.csv", encoding="utf8") as f:
+    with (tmp_path / "train_stats.csv").open(encoding="utf8") as f:
         lines = f.readlines()
-        assert len(lines) == 1 + 8
-        # Verify step column is monotonically increasing (no duplicates)
-        steps = [int(line.split(",")[0]) for line in lines[1:]]
-        assert steps == list(range(8))
+    assert lines[: 1 + resume_step] == expected_csv_prefix
+    assert len(lines) == 1 + 8
+    # Verify step column is monotonically increasing (no duplicates)
+    steps = [int(line.split(",")[0]) for line in lines[1:]]
+    assert steps == list(range(8))
 
 
 @pytest.mark.integration
-def test_checkpoint_restoration(tmp_path: Path):
-    def create_config(iterations: int, stats_file: str):
+def test_cross_directory_resume_inherits_stats(tmp_path: Path):
+    source_dir = tmp_path / "source"
+    target_dir = tmp_path / "target"
+
+    def create_config(save_path: Path, iterations: int):
         return ConfigManager(
             {
-                "workflow": {"seed": 42, "save_path": str(tmp_path)},
+                "workflow": {
+                    "seed": 42,
+                    "save_path": str(save_path),
+                    "restore_path": str(source_dir)
+                    if save_path == target_dir
+                    else str(save_path),
+                },
                 "train": {
-                    "run": {"iterations": iterations},
-                    "writers": {"hdf5": {"path_template": "{stage}_" + stats_file}},
+                    "run": {
+                        "iterations": iterations,
+                        "save_step_interval": 3,
+                        "save_time_interval": 0,
+                    },
                 },
             }
         )
 
-    # First training run: 5 iterations
-    cfg = create_config(iterations=5, stats_file="stats1.h5")
-    hydrogen_atom_train_workflow(cfg)()
+    hydrogen_atom_train_workflow(create_config(source_dir, 5))()
+    hydrogen_atom_train_workflow(create_config(target_dir, 8))()
 
-    # Verify only final checkpoint (iteration 4) exists
-    ckpts = list((tmp_path).glob("train_ckpt_*.npz"))
-    assert ckpts, "Expected checkpoints to be created"
+    with h5py.File(target_dir / "train_stats.h5", "r") as f:
+        assert len(f["loss"]) == 8
+    with (target_dir / "train_stats.csv").open(encoding="utf8") as f:
+        steps = [int(line.split(",")[0]) for line in f.readlines()[1:]]
+    assert steps == list(range(8))
 
-    assert (tmp_path / "train_config.yaml").exists()
-    assert "iterations: 5" in (tmp_path / "train_config.yaml").read_text()
 
-    ckpt_iterations = sorted(int(ckpt.stem.split("_")[-1]) for ckpt in ckpts)
-    assert ckpt_iterations == [4], (
-        f"Expected only checkpoint at 4, got {ckpt_iterations}"
+@pytest.mark.integration
+def test_evaluation_stats_truncated_on_restore(tmp_path: Path):
+    """Regression test for https://github.com/bytedance/jaqmc/issues/90."""
+    train_dir = tmp_path / "train"
+    eval_dir = tmp_path / "evaluation"
+    resume_step = 3
+    _train_hydrogen(train_dir)
+
+    cfg = _evaluation_config(
+        eval_dir,
+        eval_dir,
+        train_dir,
+        iterations=5,
+        seed=1,
+        save_step_interval=3,
+        save_time_interval=0,
     )
+    hydrogen_atom_eval_workflow(cfg)()
+    with h5py.File(eval_dir / "evaluation_stats.h5", "r") as f:
+        expected_prefix = f["total_energy"][:resume_step].copy()
 
-    # Verify stats have 50 iterations
-    assert (tmp_path / "train_stats1.h5").exists()
-    with h5py.File(tmp_path / "train_stats1.h5", "r") as f:
-        assert len(f["loss"]) == 5
-
-    assert (tmp_path / "train_stats.csv").exists()
-    with open(tmp_path / "train_stats.csv", encoding="utf8") as f:
-        assert len(f.readlines()) == 1 + 5
-
-    # Second training run: restore and train 3 more iterations (total 8)
-    cfg = create_config(iterations=8, stats_file="stats2.h5")
-    hydrogen_atom_train_workflow(cfg)()
-
-    # Verify only expected checkpoints exist (no extra ones)
-    ckpts_after = list((tmp_path).glob("train_ckpt_*.npz"))
-    ckpt_iterations_after = sorted(
-        int(ckpt.stem.split("_")[-1]) for ckpt in ckpts_after
+    (eval_dir / "evaluation_ckpt_000004.npz").unlink()
+    cfg = _evaluation_config(
+        eval_dir,
+        eval_dir,
+        train_dir,
+        iterations=8,
+        seed=2,
     )
-    assert ckpt_iterations_after == [4, 7], (
-        f"Expected checkpoints at 4 and 7, got {ckpt_iterations_after}"
+    hydrogen_atom_eval_workflow(cfg)()
+
+    with h5py.File(eval_dir / "evaluation_stats.h5", "r") as f:
+        np.testing.assert_array_equal(f["total_energy"][:resume_step], expected_prefix)
+        assert f["total_energy"].shape[0] == 8
+        expected_energy = np.nanmean(f["total_energy"], axis=0)
+    with np.load(eval_dir / "evaluation_digest.npz") as digest:
+        assert np.isclose(digest["total_energy"], expected_energy)
+
+
+@pytest.mark.integration
+def test_evaluation_cross_directory_resume_inherits_stats(tmp_path: Path):
+    train_dir = tmp_path / "train"
+    source_dir = tmp_path / "evaluation-source"
+    target_dir = tmp_path / "evaluation-target"
+    resume_step = 5
+    _train_hydrogen(train_dir)
+
+    cfg = _evaluation_config(
+        source_dir,
+        source_dir,
+        train_dir,
+        iterations=resume_step,
+        seed=1,
     )
+    hydrogen_atom_eval_workflow(cfg)()
+    with h5py.File(source_dir / "evaluation_stats.h5", "r") as f:
+        expected_prefix = f["total_energy"][:].copy()
 
-    assert (tmp_path / "train_config.yaml").exists()
-    assert "iterations: 8" in (tmp_path / "train_config.yaml").read_text()
-    backups = sorted((tmp_path / "config_history").glob("train_config.backup_*.yaml"))
-    assert len(backups) == 1
-    assert "iterations: 5" in backups[0].read_text()
+    cfg = _evaluation_config(
+        target_dir,
+        source_dir,
+        train_dir,
+        iterations=8,
+        seed=2,
+    )
+    hydrogen_atom_eval_workflow(cfg)()
 
-    # Verify restored run has 3 iterations (steps 5-7 inclusive)
-    with h5py.File(tmp_path / "train_stats2.h5", "r") as f:
-        assert len(f["loss"]) == 3
-    with open(tmp_path / "train_stats.csv", encoding="utf8") as f:
-        assert len(f.readlines()) == 1 + 8
-
-    # Third training run: 2 more iterations, writing to the same stats file
-    cfg = create_config(iterations=10, stats_file="stats2.h5")
-    hydrogen_atom_train_workflow(cfg)()
-    # Verify restored run has 5 iterations (steps 5-9 inclusive)
-    with h5py.File(tmp_path / "train_stats2.h5", "r") as f:
-        assert len(f["loss"]) == 5
-    with open(tmp_path / "train_stats.csv", encoding="utf8") as f:
-        assert len(f.readlines()) == 1 + 10
+    with h5py.File(target_dir / "evaluation_stats.h5", "r") as f:
+        np.testing.assert_array_equal(f["total_energy"][:resume_step], expected_prefix)
+        assert f["total_energy"].shape[0] == 8
+        expected_energy = np.nanmean(f["total_energy"], axis=0)
+    with np.load(target_dir / "evaluation_digest.npz") as digest:
+        assert np.isclose(digest["total_energy"], expected_energy)

--- a/tests/workflow/workflow_config_test.py
+++ b/tests/workflow/workflow_config_test.py
@@ -59,7 +59,7 @@ def _make_workflow(
 def test_workflow_config_path_uses_namespace():
     cfg = ConfigManager({"workflow": {"save_path": "/tmp/run"}})
     workflow = NamespacedWorkflow(cfg)
-    assert str(workflow.config_path()) == "/tmp/run/custom_config.yaml"
+    assert workflow.config_path() == workflow.save_path / "custom_config.yaml"
 
 
 def test_prepare_skips_identical_backup_and_suffixes_same_second_collisions(
@@ -136,3 +136,45 @@ def test_prepare_tracks_evaluation_config_and_consumed_run_section(
     backup_yaml = backup_path.read_text()
     assert "source_path: train-source" in backup_yaml
     assert "iterations: 2" in backup_yaml
+
+
+def test_prepare_validates_save_path_only_on_master(tmp_path, monkeypatch):
+    import jaqmc.workflow.base as workflow_base
+
+    save_path = tmp_path / "save"
+    save_path.touch()
+    workflow = NamespacedWorkflow(
+        ConfigManager({"workflow": {"save_path": str(save_path)}})
+    )
+    monkeypatch.setattr(workflow_base.jax, "process_index", lambda: 1)
+
+    workflow.prepare()
+    monkeypatch.setattr(workflow_base.jax, "process_index", lambda: 0)
+
+    with pytest.raises(ValueError, match="Save path is not a directory"):
+        workflow.prepare()
+
+
+def test_prepare_rejects_non_empty_cross_directory_resume_destination(tmp_path):
+    source_path = tmp_path / "source"
+    save_path = tmp_path / "save"
+    source_path.mkdir()
+    save_path.mkdir()
+    (save_path / "existing.txt").touch()
+
+    workflow = NamespacedWorkflow(
+        ConfigManager(
+            {
+                "workflow": {
+                    "save_path": str(save_path),
+                    "restore_path": str(source_path),
+                }
+            }
+        )
+    )
+
+    with pytest.raises(
+        ValueError, match="Save path is not empty during cross-directory resume"
+    ):
+        workflow.prepare()
+    assert not (save_path / "custom_config.yaml").exists()

--- a/tests/writer/csv_writer_test.py
+++ b/tests/writer/csv_writer_test.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+from upath import UPath
+
+from jaqmc.writer.csv import CSVWriter
+
+
+def _write_rows(directory: UPath, n: int) -> None:
+    writer = CSVWriter()
+    with writer.open(directory, "train"):
+        for step in range(n):
+            writer.write(step, {"loss": float(step)})
+
+
+def _data_rows(directory: UPath) -> list[str]:
+    return (directory / "train_stats.csv").read_text(encoding="utf8").splitlines()[1:]
+
+
+def test_same_dir_truncates_then_appends(tmp_path: Path) -> None:
+    working_dir = UPath(tmp_path)
+    _write_rows(working_dir, 5)
+    prefix = _data_rows(working_dir)[:3]
+
+    writer = CSVWriter()
+    writer.sync_history(working_dir, working_dir, "train", 3)
+    with writer.open(working_dir, "train"):
+        writer.write(3, {"loss": 3.0})
+
+    rows = _data_rows(working_dir)
+    assert rows[:3] == prefix
+    assert [int(row.split(",")[0]) for row in rows] == [0, 1, 2, 3]
+
+
+def test_cross_dir_copies_without_mutating_source(tmp_path: Path) -> None:
+    source = UPath(tmp_path) / "source"
+    dest = UPath(tmp_path) / "dest"
+    dest.mkdir()
+    _write_rows(source, 5)
+    source_rows = _data_rows(source)
+
+    writer = CSVWriter()
+    writer.sync_history(source, dest, "train", 3)
+    with writer.open(dest, "train"):
+        writer.write(3, {"loss": 3.0})
+
+    assert _data_rows(source) == source_rows
+    dest_rows = _data_rows(dest)
+    assert dest_rows[:3] == source_rows[:3]
+    assert [int(row.split(",")[0]) for row in dest_rows] == [0, 1, 2, 3]

--- a/tests/writer/wandb_writer_test.py
+++ b/tests/writer/wandb_writer_test.py
@@ -5,12 +5,9 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
-import h5py
-import pytest
 from jax import numpy as jnp
+from upath import UPath
 
-from jaqmc.writer.csv import CSVWriter
-from jaqmc.writer.hdf5 import HDF5Writer
 from jaqmc.writer.wandb import WandbWriter
 
 
@@ -38,42 +35,13 @@ class FakeWandb(ModuleType):
         return self.run
 
 
-def test_csv_writer_path_template(tmp_path: Path):
-    writer = CSVWriter(path_template="metrics/{stage}_stats.csv")
-
-    with writer.open(tmp_path, "train"):
-        writer.write(0, {"loss": 1.0})
-
-    assert (tmp_path / "metrics" / "train_stats.csv").exists()
-
-
-def test_hdf5_writer_path_template(tmp_path: Path):
-    writer = HDF5Writer(path_template="{stage}/stats.h5")
-
-    with writer.open(tmp_path, "evaluation"):
-        writer.write(0, {})
-
-    with h5py.File(tmp_path / "evaluation" / "stats.h5", "r"):
-        pass
-
-
-def test_csv_writer_rejects_unknown_template_field(tmp_path: Path):
-    writer = CSVWriter(path_template="{name}_stats.csv")
-
-    with (
-        pytest.raises(ValueError, match="Only '\\{stage\\}' is supported"),
-        writer.open(tmp_path, "train"),
-    ):
-        pass
-
-
 def test_wandb_writer_logs_only_scalars(tmp_path: Path, monkeypatch):
     fake_wandb = FakeWandb()
     monkeypatch.setitem(sys.modules, "wandb", fake_wandb)
 
     writer = WandbWriter(project="project", run_name="run")
 
-    with writer.open(tmp_path, "train"):
+    with writer.open(UPath(tmp_path), "train"):
         writer.write(3, {"loss": 1.5, "vector": jnp.ones(2), "acceptance": 0.25})
 
     assert fake_wandb.init_kwargs == {
@@ -94,7 +62,7 @@ def test_wandb_writer_reuses_active_run(tmp_path: Path, monkeypatch):
 
     writer = WandbWriter(project="unused")
 
-    with writer.open(tmp_path, "train"):
+    with writer.open(UPath(tmp_path), "train"):
         writer.write(2, {"loss": 1.0})
 
     assert fake_wandb.init_kwargs is None


### PR DESCRIPTION
Resuming into a new save directory previously split one logical run's statistics across locations, leaving downstream analysis without the full history. Evaluation statistics also bypassed the shared writer lifecycle, so restoring an older checkpoint could retain stale samples.

Inherit stage statistics from the checkpoint directory before truncating them at the restored step, and manage evaluation HDF5 output through the same lifecycle. Use fixed stage-based filenames so history can be located unambiguously across directories.

Closes #90, closes #98