### PR TITLE
Subspace clean

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto
+
+*.py   text eol=lf
+*.md   text eol=lf
+*.yml  text eol=lf
+*.yaml text eol=lf
+*.toml text eol=lf
+*.sh   text eol=lf
+*.sbatch text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ docs/apidocs/
 jupyter_execute/
 # Synced notebooks
 notebooks/
+/scripts/

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@ docs/apidocs/
 jupyter_execute/
 # Synced notebooks
 notebooks/
-/scripts/
+/scripts/*
+!/scripts/run_mypy.py

--- a/configs/hardware/multi_v100_2gpu.yml
+++ b/configs/hardware/multi_v100_2gpu.yml
@@ -1,0 +1,20 @@
+# Two V100s, four local determinant walkers per device.
+jax:
+  enable_x64: true
+
+workflow:
+  batch_size: 8
+
+subspace:
+  evaluation:
+    vmap_chunk_size: 1
+    pair_chunk_size: 1
+
+train:
+  grads:
+    vmap_chunk_size: 1
+
+estimators:
+  energy:
+    kinetic:
+      vmap_chunk_size: 1

--- a/configs/hardware/multi_v100_4gpu.yml
+++ b/configs/hardware/multi_v100_4gpu.yml
@@ -1,0 +1,20 @@
+# Four V100s, four local determinant walkers per device.
+jax:
+  enable_x64: true
+
+workflow:
+  batch_size: 16
+
+subspace:
+  evaluation:
+    vmap_chunk_size: 1
+    pair_chunk_size: 1
+
+train:
+  grads:
+    vmap_chunk_size: 1
+
+estimators:
+  energy:
+    kinetic:
+      vmap_chunk_size: 1

--- a/configs/hardware/single_v100.yml
+++ b/configs/hardware/single_v100.yml
@@ -1,0 +1,20 @@
+# One V100, four local determinant walkers.
+jax:
+  enable_x64: true
+
+workflow:
+  batch_size: 4
+
+subspace:
+  evaluation:
+    vmap_chunk_size: 1
+    pair_chunk_size: 1
+
+train:
+  grads:
+    vmap_chunk_size: 1
+
+estimators:
+  energy:
+    kinetic:
+      vmap_chunk_size: 1

--- a/configs/run_subspace_smoke.sbatch
+++ b/configs/run_subspace_smoke.sbatch
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# One launcher for 1/2/4-GPU correctness smoke runs. Select GPU resources in
+# the sbatch command and select memory sizing through CONFIG_HW.
+set -euo pipefail
+
+CONFIG_SYSTEM="${CONFIG_SYSTEM:-configs/systems/h24_base.yml}"
+CONFIG_WORKFLOW="${CONFIG_WORKFLOW:-configs/workflows/subspace_smoke.yml}"
+CONFIG_HW="${CONFIG_HW:-configs/hardware/single_v100.yml}"
+PYTHON_BIN="${PYTHON_BIN:-python}"
+JAQMC_BIN="${JAQMC_BIN:-jaqmc}"
+
+git branch --show-current
+git rev-parse HEAD
+git status --short
+"${PYTHON_BIN}" --version
+"${PYTHON_BIN}" -c 'import jax, jaxlib; print("jax", jax.__version__); print("jaxlib", jaxlib.__version__); print("devices", jax.devices()); print("process_count", jax.process_count()); print("local_device_count", jax.local_device_count())'
+printenv CUDA_VISIBLE_DEVICES || true
+nvidia-smi || true
+
+"${JAQMC_BIN}" solid subspace-train \
+  --yml "${CONFIG_SYSTEM}" \
+  --yml "${CONFIG_WORKFLOW}" \
+  --yml "${CONFIG_HW}"

--- a/configs/systems/h24_base.yml
+++ b/configs/systems/h24_base.yml
@@ -1,0 +1,24 @@
+# Physical H24 definition shared by ground- and excited-state workflows.
+system:
+  module: two_atom_chain
+  symbol: H
+  bond_length: 2.0
+  unit: bohr
+  supercell: 12
+  vacuum_separation: 20.0
+  s_z: 0
+  electron_init_width: 0.8
+
+wf:
+  hidden_dims_single: [256, 256, 256, 256]
+  hidden_dims_double: [32, 32, 32, 32]
+  ndets: 1
+  distance_type: nu
+  envelope_type: abs_isotropic
+  full_det: true
+
+reference:
+  basis: sto-3g
+  sample_fraction: 1.0
+  verbose: 0
+  method: KUHF

--- a/configs/workflows/subspace_grassmann_sr.yml
+++ b/configs/workflows/subspace_grassmann_sr.yml
@@ -1,0 +1,19 @@
+# Production Grassmann natural-gradient preset.
+# The determinant-state logpsi score is the Grassmann score; use JaQMC's
+# distributed/chunked SR implementation rather than a second QGT backend.
+train:
+  optim:
+    module: jaqmc.optimizer.sr:SROptimizer
+    learning_rate: 0.05
+    damping: 1.0e-3
+    spring_mu: 0.9
+    march_beta: null
+    max_cond_num: null
+    max_norm: null
+    robust_gamma: null
+    mixed_precision: true
+    score_chunk_size: 64
+    gram_num_chunks: 4
+  grads:
+    clip_method: none
+

--- a/configs/workflows/subspace_grassmann_sr.yml
+++ b/configs/workflows/subspace_grassmann_sr.yml
@@ -1,6 +1,8 @@
 # Production Grassmann natural-gradient preset.
 # The determinant-state logpsi score is the Grassmann score; use JaQMC's
 # distributed/chunked SR implementation rather than a second QGT backend.
+# For controlled plain-SR A/B tests, JaQMC's native factor-2 gradient means
+# lr_native is approximately lr_gvmc / 2. Robust features break exact scaling.
 train:
   optim:
     module: jaqmc.optimizer.sr:SROptimizer
@@ -16,4 +18,3 @@ train:
     gram_num_chunks: 4
   grads:
     clip_method: none
-

--- a/configs/workflows/subspace_gvmc_reference_sr.yml
+++ b/configs/workflows/subspace_gvmc_reference_sr.yml
@@ -1,0 +1,14 @@
+# Small-system single-device oracle matching the GVMC minSR/Kacz equations.
+# Do not use this backend for H24 or multi-device production runs.
+train:
+  optim:
+    module: jaqmc.optimizer.gvmc_reference_sr:GVMCReferenceSROptimizer
+    learning_rate: 0.10
+    lam0: 1.0e-3
+    lam1: 1.0
+    mu: 0.9
+    scale_lr_by_sqrt_n_states: true
+    score_chunk_size: null
+  grads:
+    clip_method: none
+

--- a/configs/workflows/subspace_gvmc_reference_sr.yml
+++ b/configs/workflows/subspace_gvmc_reference_sr.yml
@@ -1,4 +1,7 @@
 # Small-system single-device oracle matching the GVMC minSR/Kacz equations.
+# This backend converts JaQMC's factor-2 native gradient at its adapter and
+# applies the configured learning rate directly, as cqsl/GVMC does.
+# For controlled plain-SR comparisons, use lr_native ~= lr_gvmc / 2.
 # Do not use this backend for H24 or multi-device production runs.
 train:
   optim:
@@ -7,8 +10,6 @@ train:
     lam0: 1.0e-3
     lam1: 1.0
     mu: 0.9
-    scale_lr_by_sqrt_n_states: true
     score_chunk_size: null
   grads:
     clip_method: none
-

--- a/configs/workflows/subspace_smoke.yml
+++ b/configs/workflows/subspace_smoke.yml
@@ -1,0 +1,49 @@
+# Correctness-only subspace workflow. Memory sizing belongs to hardware overlays.
+logging:
+  level: info
+  stream: stdout
+
+workflow:
+  seed: 20260820
+  save_path: runs/h24_subspace_smoke
+
+subspace:
+  n_states: 2
+  initialization:
+    mode: random
+  sampling:
+    steps: 2
+    initial_width: 0.02
+    adapt_frequency: 100
+    pmove_range: [0.5, 0.55]
+  evaluation:
+    matrix_dtype: complex128
+  diagnostics:
+    condition_warning: 1.0e10
+    solve_residual_warning: 1.0e-8
+    max_imag_eigenvalue_warning: 1.0e-6
+
+train:
+  run:
+    iterations: 3
+    burn_in: 2
+    save_time_interval: 0
+    save_step_interval: 1
+    timing_warmup_steps: 1
+    stop_on_nan: loss
+  optim:
+    module: jaqmc.optimizer.optax:adam
+    learning_rate: 1.0e-4
+  grads:
+    module: jaqmc.estimator.streaming_loss_grad:StreamingLossAndGrad
+    clip_method: mad
+    clip_scale: 5.0
+
+estimators:
+  energy:
+    kinetic:
+      mode: forward_laplacian
+      sparse: true
+  enabled:
+    spin: false
+    density: false

--- a/configs/workflows/subspace_tda_pretrain_smoke.yml
+++ b/configs/workflows/subspace_tda_pretrain_smoke.yml
@@ -1,0 +1,70 @@
+# H24 correctness workflow with PySCF KUHF-TDA orbital pretraining.
+logging:
+  level: info
+  stream: stdout
+
+workflow:
+  seed: 20260820
+  save_path: runs/h24_subspace_tda_pretrain_smoke
+
+subspace:
+  n_states: 2
+  initialization:
+    mode: random
+  sampling:
+    steps: 2
+    initial_width: 0.02
+    adapt_frequency: 100
+    pmove_range: [0.5, 0.55]
+  evaluation:
+    matrix_dtype: complex128
+  diagnostics:
+    condition_warning: 1.0e10
+    solve_residual_warning: 1.0e-8
+    max_imag_eigenvalue_warning: 1.0e-6
+
+pretrain:
+  enabled: true
+  tda:
+    kshift: 0
+    oversample: 4
+    candidate_topk: 8
+    min_selected_weight: 1.0e-4
+    require_converged: true
+    require_same_k: true
+    occupation_tolerance: 1.0e-6
+  run:
+    iterations: 200
+    burn_in: 20
+    save_time_interval: 0
+    save_step_interval: 100
+    timing_warmup_steps: 1
+    stop_on_nan: loss
+  optim:
+    module: jaqmc.optimizer.optax:adam
+    learning_rate: 3.0e-4
+
+train:
+  run:
+    iterations: 3
+    burn_in: 2
+    save_time_interval: 0
+    save_step_interval: 1
+    timing_warmup_steps: 1
+    stop_on_nan: loss
+  optim:
+    module: jaqmc.optimizer.optax:adam
+    learning_rate: 1.0e-4
+  grads:
+    module: jaqmc.estimator.streaming_loss_grad:StreamingLossAndGrad
+    clip_method: mad
+    clip_scale: 5.0
+
+estimators:
+  energy:
+    kinetic:
+      mode: forward_laplacian
+      sparse: true
+  enabled:
+    spin: false
+    density: false

--- a/docs/api-reference/atomic.md
+++ b/docs/api-reference/atomic.md
@@ -117,3 +117,16 @@ from each PH-supported element to the ECP used to bootstrap the SCF pretrain.
 .. autofunction:: jaqmc.utils.atomic.pretrain.make_pretrain_log_amplitude
 .. autofunction:: jaqmc.utils.atomic.pretrain.make_pretrain_loss
 ```
+
+### Periodic subspace references
+
+```{eval-rst}
+.. autoclass:: jaqmc.utils.atomic.pbc_tda.PBCTDAReferenceConfig
+.. autoclass:: jaqmc.utils.atomic.pbc_tda.PBCSinglePromotion
+.. autoclass:: jaqmc.utils.atomic.pbc_tda.PeriodicStateOrbitalReference
+   :members: prepare, eval_orbitals, eval_slater
+.. autofunction:: jaqmc.utils.atomic.pbc_tda.run_pbc_tda_promotions
+.. autoclass:: jaqmc.utils.atomic.subspace_pretrain.StateOrbitalReference
+.. autofunction:: jaqmc.utils.atomic.subspace_pretrain.make_subspace_pretrain_loss
+.. autofunction:: jaqmc.utils.atomic.subspace_pretrain.make_subspace_reference_log_amplitude
+```

--- a/docs/api-reference/estimators.md
+++ b/docs/api-reference/estimators.md
@@ -93,6 +93,7 @@ API reference for built-in estimators. For background, formulas, and configurati
 
 ```{eval-rst}
 .. autoclass:: jaqmc.estimator.loss_grad.LossAndGrad
+.. autoclass:: jaqmc.estimator.loss_grad.StreamingLossAndGrad
 ```
 
 ### Variational subspace Rayleigh matrix

--- a/docs/api-reference/estimators.md
+++ b/docs/api-reference/estimators.md
@@ -93,7 +93,7 @@ API reference for built-in estimators. For background, formulas, and configurati
 
 ```{eval-rst}
 .. autoclass:: jaqmc.estimator.loss_grad.LossAndGrad
-.. autoclass:: jaqmc.estimator.loss_grad.StreamingLossAndGrad
+.. autoclass:: jaqmc.estimator.streaming_loss_grad.StreamingLossAndGrad
 ```
 
 ### Variational subspace Rayleigh matrix

--- a/docs/api-reference/estimators.md
+++ b/docs/api-reference/estimators.md
@@ -94,3 +94,10 @@ API reference for built-in estimators. For background, formulas, and configurati
 ```{eval-rst}
 .. autoclass:: jaqmc.estimator.loss_grad.LossAndGrad
 ```
+
+### Variational subspace Rayleigh matrix
+
+```{eval-rst}
+.. autoclass:: jaqmc.estimator.RayleighMatrixEstimator
+   :members:
+```

--- a/docs/api-reference/estimators.md
+++ b/docs/api-reference/estimators.md
@@ -101,4 +101,5 @@ API reference for built-in estimators. For background, formulas, and configurati
 ```{eval-rst}
 .. autoclass:: jaqmc.estimator.RayleighMatrixEstimator
    :members:
+.. autofunction:: jaqmc.estimator.grassmann_hamiltonian_statistics
 ```

--- a/docs/api-reference/optimizers.md
+++ b/docs/api-reference/optimizers.md
@@ -23,8 +23,14 @@ For optimizer config keys, see the configuration reference: [Molecule](#train-op
 
 ```{eval-rst}
 .. autoclass:: jaqmc.optimizer.sr.SROptimizer
+.. autoclass:: jaqmc.optimizer.gvmc_reference_sr.GVMCReferenceSROptimizer
 .. autoclass:: jaqmc.optimizer.kfac.kfac.KFACOptimizer
 ```
+
+The GVMC reference backend is intended only for source-equation comparisons on
+one device. Determinant-state production runs should use
+{class}`jaqmc.optimizer.sr.SROptimizer`, which evaluates the same Grassmann
+score with JaQMC's distributed and chunked solver.
 
 ## Optimizers provided by <inv:optax:*:doc#index>
 

--- a/docs/api-reference/samplers.md
+++ b/docs/api-reference/samplers.md
@@ -36,4 +36,8 @@ For sampler config keys, see the configuration reference: [Molecule](#train-samp
    :special-members: __call__
 
 .. autoclass:: jaqmc.sampler.mcmc.MCMCState
+
+.. autoclass:: jaqmc.sampler.DeterminantMCMCSampler
+   :members:
+   :inherited-members:
 ```

--- a/docs/api-reference/wavefunctions.md
+++ b/docs/api-reference/wavefunctions.md
@@ -30,6 +30,15 @@ For architecture-specific options (FermiNet, LapNet, Psiformer, and system-speci
 .. autoclass:: jaqmc.wavefunction.base.LogPsiWFOutput
 ```
 
+## Variational subspace adapters
+
+```{eval-rst}
+.. autoclass:: jaqmc.wavefunction.DeterminantStateWavefunction
+   :members:
+.. autoclass:: jaqmc.wavefunction.IndependentStateBundle
+   :members:
+```
+
 ### Log-determinant output (used by FermiNet / LapNet / Psiformer)
 
 ```{eval-rst}

--- a/docs/api-reference/workflows.md
+++ b/docs/api-reference/workflows.md
@@ -13,6 +13,9 @@ Use the built-in {class}`~jaqmc.workflow.vmc.VMCWorkflow` and {class}`~jaqmc.wor
 
 .. autoclass:: jaqmc.workflow.evaluation.EvaluationWorkflow
    :members: run
+
+.. autoclass:: jaqmc.workflow.SubspaceVMCWorkflow
+   :members:
 ```
 
 ## Workflow configuration

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -19,6 +19,7 @@ Use this section when you already picked a system and want to run, analyze, tune
 - <project:wavefunction.md> — choose and tune built-in wavefunction architectures.
 - <project:optimizers/index.md> — pick and configure optimization methods.
 - <project:sampling.md> — tune MCMC behavior and acceptance.
+- <project:subspace-variational.md> — jointly optimize low-energy variational subspaces.
 - <project:writers.md> — control which statistics are written and where.
 
 ## Physics and Estimators
@@ -42,6 +43,7 @@ wavefunction.md
 estimators/index.md
 optimizers/index.md
 sampling.md
+subspace-variational.md
 periodic-boundaries.md
 writers.md
 multi-device.md

--- a/docs/guide/subspace-variational.md
+++ b/docs/guide/subspace-variational.md
@@ -1,0 +1,80 @@
+# Variational subspaces
+
+JaQMC can jointly optimize a low-energy subspace without changing the physical
+FermiNet, LapNet, or Psiformer implementation.  The extension evaluates one
+native ansatz architecture with independent parameter sets, samples the
+determinant state, and minimizes the real trace of its local Rayleigh matrix.
+
+Use a separate workflow so ordinary ground-state commands and configuration
+remain unchanged:
+
+```console
+jaqmc molecule subspace-train --yml config.yaml
+jaqmc solid subspace-train --yml config.yaml
+```
+
+The determinant walker stores coordinates as `[walkers, states, electrons, 3]`.
+The state/replica axis is never flattened into the physical electron axis, so
+Hamiltonian estimators do not introduce interactions between replicas.  Initial
+replicas are independent samples produced by the app's existing data
+initializer.
+
+## Configuration
+
+The optimizer stays under the native `train.optim` namespace.  KFAC remains the
+production default; SR and Optax can be selected in the same way as for normal
+VMC training.
+
+```yaml
+subspace:
+  n_states: 2
+
+  sampling:
+    steps: 10
+    initial_width: 0.02
+    update_mode: full
+
+  evaluation:
+    pair_chunk_size: 4
+    matrix_dtype: complex128
+
+  diagnostics:
+    condition_warning: 1.0e10
+    solve_residual_warning: 1.0e-6
+    max_imag_eigenvalue_warning: 1.0e-6
+
+train:
+  optim:
+    module: jaqmc.optimizer.kfac:KFACOptimizer
+```
+
+`pair_chunk_size` limits peak memory in the $M^2$ cross-local-energy
+evaluation.  Walker sharding remains the existing JaQMC behavior; every device
+keeps the complete state axis.
+
+## Reused native components
+
+For every replica $R_r$ and component state $s$, the estimator calls the
+already configured physical JaQMC energy pipeline to obtain
+$E_{L,s}(R_r)$.  It then forms
+
+$$
+\Phi^{(H)}_{rs}=\Phi_{rs}E_{L,s}(R_r),\qquad
+R_L=\operatorname{solve}(\Phi,\Phi^{(H)}).
+$$
+
+The scalar training loss is $\operatorname{Re}\operatorname{Tr}R_L$ and its
+gradient is computed by the existing `LossAndGrad`.  No NetKet runtime or
+second Hamiltonian implementation is used.
+
+## Diagnostics
+
+Monitor `amplitude_sigma_min`, `amplitude_condition`,
+`rayleigh_solve_residual`, `max_ritz_imag`, and their warning fields.  A large
+condition number indicates nearly dependent component states.  Non-finite
+Rayleigh matrices are reported explicitly rather than silently hidden.
+
+The current sampler is the correctness-first full-recompute implementation: one
+replica row moves per proposal while the determinant is reevaluated through the
+normal sample-plan log-probability callback.  A cached Sherman--Morrison backend
+can be added later behind the same sampler/wavefunction interfaces.

--- a/docs/guide/subspace-variational.md
+++ b/docs/guide/subspace-variational.md
@@ -140,6 +140,46 @@ Python, JAX, device, and CUDA environment before starting. JaQMC writes the
 resolved configuration into the run directory through its native workflow
 checkpoint/configuration path.
 
+## KUHF-TDA orbital pretraining
+
+Periodic solid subspaces can optionally pretrain their component networks from
+one ground KUHF determinant plus distinct dominant single promotions selected
+from PySCF PBC-TDA roots. PySCF performs both HF and TDA; JaQMC does not copy or
+reimplement the response solver. The selected determinants are initialization
+proxies for the low-energy span, not a claim that a full TDA root is a single
+determinant.
+
+Version 1 intentionally supports KUHF, `full_det: true`, integer occupations,
+and same-k (`kshift: 0`) promotions only. It rejects checkpoint-based component
+initialization when TDA pretraining is enabled. Pretraining uses the same
+`DeterminantStateWavefunction`, `DeterminantMCMCSampler`, `VMCWorkStage`, Adam
+adapter, writers, checkpoints, and pretrain-to-train state transfer as native
+JaQMC. Its diagonal state/replica orbital loss requires only $O(M)$ neural
+forward/gradient evaluations.
+
+```yaml
+pretrain:
+  enabled: true
+  tda:
+    kshift: 0
+    oversample: 4
+    candidate_topk: 8
+    min_selected_weight: 1.0e-4
+    require_converged: true
+    require_same_k: true
+  run:
+    iterations: 200
+    burn_in: 20
+  optim:
+    module: jaqmc.optimizer.optax:adam
+    learning_rate: 3.0e-4
+```
+
+Use `examples/solid/hchain_subspace_tda_pretrain_smoke.yml` for a one-step
+single-device check. For H24, combine `configs/systems/h24_base.yml`,
+`configs/workflows/subspace_tda_pretrain_smoke.yml`, and the appropriate
+hardware overlay in that order.
+
 The current sampler is the correctness-first full-recompute implementation: one
 replica row moves per proposal while the determinant is reevaluated through the
 normal sample-plan log-probability callback.  A cached Sherman--Morrison backend

--- a/docs/guide/subspace-variational.md
+++ b/docs/guide/subspace-variational.md
@@ -4,6 +4,8 @@ JaQMC can jointly optimize a low-energy subspace without changing the physical
 FermiNet, LapNet, or Psiformer implementation.  The extension evaluates one
 native ansatz architecture with independent parameter sets, samples the
 determinant state, and minimizes the real trace of its local Rayleigh matrix.
+For complex wavefunctions the gradient estimator retains the complete complex
+local trace; the real and imaginary parts are split only for reporting.
 
 Use a separate workflow so ordinary ground-state commands and configuration
 remain unchanged:
@@ -29,6 +31,10 @@ VMC training.
 subspace:
   n_states: 2
 
+  initialization:
+    mode: random  # or checkpoints
+    # checkpoints: [/path/to/state0, /path/to/state1]
+
   sampling:
     steps: 10
     initial_width: 0.02
@@ -40,6 +46,8 @@ subspace:
 
   diagnostics:
     condition_warning: 1.0e10
+    condition_hard_limit: 1.0e14
+    min_valid_fraction: 0.99
     solve_residual_warning: 1.0e-6
     max_imag_eigenvalue_warning: 1.0e-6
 
@@ -49,8 +57,15 @@ train:
 ```
 
 `pair_chunk_size` limits peak memory in the $M^2$ cross-local-energy
-evaluation.  Walker sharding remains the existing JaQMC behavior; every device
-keeps the complete state axis.
+evaluation. Parameters and replica data remain in their original $M$-sized
+containers and are selected dynamically inside each chunk. State-independent
+potential energy is evaluated $M$ times and reused across state columns.
+Walker sharding remains the existing JaQMC behavior; every device keeps the
+complete state axis.
+
+With `initialization.mode: checkpoints`, provide exactly `n_states` native
+JaQMC checkpoint files or directories. Parameter PyTree structure and leaf
+shapes are checked before the states are stacked.
 
 ## Reused native components
 
@@ -63,16 +78,19 @@ $$
 R_L=\operatorname{solve}(\Phi,\Phi^{(H)}).
 $$
 
-The scalar training loss is $\operatorname{Re}\operatorname{Tr}R_L$ and its
-gradient is computed by the existing `LossAndGrad`.  No NetKet runtime or
-second Hamiltonian implementation is used.
+The reported scalar energy is $\operatorname{Re}\operatorname{Tr}R_L$; the
+gradient uses the full complex $\operatorname{Tr}R_L$ through the existing
+`LossAndGrad`. No NetKet runtime or second Hamiltonian implementation is used.
 
 ## Diagnostics
 
 Monitor `amplitude_sigma_min`, `amplitude_condition`,
 `rayleigh_solve_residual`, `max_ritz_imag`, and their warning fields.  A large
 condition number indicates nearly dependent component states.  Non-finite
-Rayleigh matrices are reported explicitly rather than silently hidden.
+Rayleigh matrices are reported explicitly rather than silently hidden. All
+matrix elements, diagnostics, and gradients use one whole-walker validity
+mask. A step below `min_valid_fraction` is rolled back and aborts through the
+native checkpoint recovery path before invalid optimizer state is retained.
 
 The current sampler is the correctness-first full-recompute implementation: one
 replica row moves per proposal while the determinant is reevaluated through the

--- a/docs/guide/subspace-variational.md
+++ b/docs/guide/subspace-variational.md
@@ -41,6 +41,7 @@ subspace:
     update_mode: full
 
   evaluation:
+    vmap_chunk_size: 1
     pair_chunk_size: 4
     matrix_dtype: complex128
 
@@ -53,14 +54,27 @@ train:
   optim:
     module: jaqmc.optimizer.optax:adam
     learning_rate: 0.0001
+  grads:
+    vmap_chunk_size: 1
+    clip_method: mad
+    clip_scale: 5.0
 ```
 
-`pair_chunk_size` limits peak memory in the $M^2$ cross-local-energy
-evaluation. Parameters and replica data remain in their original $M$-sized
-containers and are selected dynamically inside each chunk. State-independent
-potential energy is evaluated $M$ times and reused across state columns.
-Walker sharding remains the existing JaQMC behavior; every device keeps the
-complete state axis.
+The three chunk controls apply to different axes:
+
+- `subspace.evaluation.vmap_chunk_size` controls determinant walkers entering
+  the Rayleigh/local-energy estimator concurrently.
+- `subspace.evaluation.pair_chunk_size` controls concurrent $(r,s)$ energy
+  pairs inside one determinant walker.
+- `train.grads.vmap_chunk_size` controls determinant walkers entering the
+  streaming log-determinant gradient calculation.
+
+Parameters and replica data remain in their original $M$-sized containers.
+The streaming gradient estimator reduces each chunk immediately to parameter
+PyTree sufficient statistics instead of reconstructing a
+`[walkers, ...parameters]` tree. State-independent potential energy is
+evaluated $M$ times and reused across state columns. Walker sharding remains
+the existing JaQMC behavior; every device keeps the complete state axis.
 
 With `initialization.mode: checkpoints`, provide exactly `n_states` native
 JaQMC checkpoint files or directories. Parameter PyTree structure and leaf
@@ -78,8 +92,10 @@ R_L=\operatorname{solve}(\Phi,\Phi^{(H)}).
 $$
 
 The reported scalar energy is $\operatorname{Re}\operatorname{Tr}R_L$; the
-gradient uses the full complex $\operatorname{Tr}R_L$ through the existing
-`LossAndGrad`. No NetKet runtime or second Hamiltonian implementation is used.
+gradient uses the full complex $\operatorname{Tr}R_L$ through
+`StreamingLossAndGrad`. The workflow forces this loss key while preserving
+`train.grads` configuration for chunking and clipping. No NetKet runtime or
+second Hamiltonian implementation is used.
 
 ## Diagnostics
 
@@ -96,6 +112,9 @@ averaging.
 For a first periodic smoke test, use
 [`examples/solid/hchain_subspace_smoke.yml`](../../examples/solid/hchain_subspace_smoke.yml)
 with `jax.enable_x64: true`, a small batch, $M=2$, and Adam.
+For the memory-conservative H24 test, use
+[`examples/solid/h24_subspace_smoke.yml`](../../examples/solid/h24_subspace_smoke.yml)
+starting at four determinant walkers.
 
 The current sampler is the correctness-first full-recompute implementation: one
 replica row moves per proposal while the determinant is reevaluated through the

--- a/docs/guide/subspace-variational.md
+++ b/docs/guide/subspace-variational.md
@@ -23,9 +23,9 @@ initializer.
 
 ## Configuration
 
-The optimizer stays under the native `train.optim` namespace.  KFAC remains the
-production default; SR and Optax can be selected in the same way as for normal
-VMC training.
+The optimizer stays under the native `train.optim` namespace. Adam is the
+correctness-first subspace default; KFAC can be selected explicitly after the
+determinant-state curvature path has been validated for the target network.
 
 ```yaml
 subspace:
@@ -46,14 +46,13 @@ subspace:
 
   diagnostics:
     condition_warning: 1.0e10
-    condition_hard_limit: 1.0e14
-    min_valid_fraction: 0.99
     solve_residual_warning: 1.0e-6
     max_imag_eigenvalue_warning: 1.0e-6
 
 train:
   optim:
-    module: jaqmc.optimizer.kfac:KFACOptimizer
+    module: jaqmc.optimizer.optax:adam
+    learning_rate: 0.0001
 ```
 
 `pair_chunk_size` limits peak memory in the $M^2$ cross-local-energy
@@ -86,11 +85,17 @@ gradient uses the full complex $\operatorname{Tr}R_L$ through the existing
 
 Monitor `amplitude_sigma_min`, `amplitude_condition`,
 `rayleigh_solve_residual`, `max_ritz_imag`, and their warning fields.  A large
-condition number indicates nearly dependent component states.  Non-finite
-Rayleigh matrices are reported explicitly rather than silently hidden. All
-matrix elements, diagnostics, and gradients use one whole-walker validity
-mask. A step below `min_valid_fraction` is rolled back and aborts through the
-native checkpoint recovery path before invalid optimizer state is retained.
+condition number indicates nearly dependent component states, but is diagnostic
+only and does not remove a sample from the Monte Carlo measure. Every finite
+input attempts the Rayleigh solve. `rayleigh_valid` becomes false only for a
+catastrophic numerical failure such as non-finite input, solution, or residual;
+then the entire optimizer step is rolled back and aborted through the native
+checkpoint path. Normal gradients use every determinant sample without masked
+averaging.
+
+For a first periodic smoke test, use
+[`examples/solid/hchain_subspace_smoke.yml`](../../examples/solid/hchain_subspace_smoke.yml)
+with `jax.enable_x64: true`, a small batch, $M=2$, and Adam.
 
 The current sampler is the correctness-first full-recompute implementation: one
 replica row moves per proposal while the determinant is reevaluated through the

--- a/docs/guide/subspace-variational.md
+++ b/docs/guide/subspace-variational.md
@@ -76,6 +76,11 @@ PyTree sufficient statistics instead of reconstructing a
 evaluated $M$ times and reused across state columns. Walker sharding remains
 the existing JaQMC behavior; every device keeps the complete state axis.
 
+This is intentionally walker-axis data parallelism. With a global determinant
+batch of $B$ and $N$ devices, each device receives approximately $B/N$ walkers
+while retaining all $M$ component states. Pair and gradient chunk sizes control
+single-device concurrency and memory; they do not shard the state axis.
+
 With `initialization.mode: checkpoints`, provide exactly `n_states` native
 JaQMC checkpoint files or directories. Parameter PyTree structure and leaf
 shapes are checked before the states are stacked.
@@ -105,9 +110,11 @@ condition number indicates nearly dependent component states, but is diagnostic
 only and does not remove a sample from the Monte Carlo measure. Every finite
 input attempts the Rayleigh solve. `rayleigh_valid` becomes false only for a
 catastrophic numerical failure such as non-finite input, solution, or residual;
-then the entire optimizer step is rolled back and aborted through the native
-checkpoint path. Normal gradients use every determinant sample without masked
-averaging.
+then the optimizer update is skipped before it can change parameters or
+optimizer state, and training aborts through the native checkpoint path. Normal
+gradients use every determinant sample without masked averaging. Training logs
+also include `grad_norm` and `update_norm`; an invalid gated step reports a zero
+update norm.
 
 For a first periodic smoke test, use
 [`examples/solid/hchain_subspace_smoke.yml`](../../examples/solid/hchain_subspace_smoke.yml)
@@ -115,6 +122,23 @@ with `jax.enable_x64: true`, a small batch, $M=2$, and Adam.
 For the memory-conservative H24 test, use
 [`examples/solid/h24_subspace_smoke.yml`](../../examples/solid/h24_subspace_smoke.yml)
 starting at four determinant walkers.
+
+For repeatable H24 server runs, use the layered configurations in `configs/`
+in fixed base → workflow → hardware order:
+
+```console
+jaqmc solid subspace-train \
+  --yml configs/systems/h24_base.yml \
+  --yml configs/workflows/subspace_smoke.yml \
+  --yml configs/hardware/single_v100.yml
+```
+
+Replace the final file with `multi_v100_2gpu.yml` or
+`multi_v100_4gpu.yml`; these keep four local walkers per device and $M=2$.
+The parameterized launcher `configs/run_subspace_smoke.sbatch` records the Git,
+Python, JAX, device, and CUDA environment before starting. JaQMC writes the
+resolved configuration into the run directory through its native workflow
+checkpoint/configuration path.
 
 The current sampler is the correctness-first full-recompute implementation: one
 replica row moves per proposal while the determinant is reevaluated through the

--- a/docs/guide/subspace-variational.md
+++ b/docs/guide/subspace-variational.md
@@ -123,7 +123,12 @@ For small, single-device A/B checks,
 `GVMCReferenceSROptimizer`. This backend independently implements the published
 GVMC sample-space minSR and Kaczmarz/SPRING equations from the
 [official accompanying repository](https://github.com/cqsl/GVMC) behind
-JaQMC's unchanged `OptimizerLike` interface, including the reference learning-rate scaling
+JaQMC's unchanged `OptimizerLike` interface. JaQMC supplies the native VMC
+gradient $2\operatorname{Re}(J^\dagger B)$; the reference adapter converts it
+to the GVMC convention $\operatorname{Re}(J^\dagger B)$ before minSR and
+stores its Kaczmarz direction in that convention. This conversion intentionally
+does not change the shared gradient estimator or compensate through the learning
+rate. The backend also includes the reference learning-rate scaling
 $\eta/\sqrt M$. It is a numerical oracle, not an H24 production backend.
 Both presets set `train.grads.clip_method: none`, matching the unclipped force
 used for the reference algorithm.

--- a/docs/guide/subspace-variational.md
+++ b/docs/guide/subspace-variational.md
@@ -128,10 +128,17 @@ gradient $2\operatorname{Re}(J^\dagger B)$; the reference adapter converts it
 to the GVMC convention $\operatorname{Re}(J^\dagger B)$ before minSR and
 stores its Kaczmarz direction in that convention. This conversion intentionally
 does not change the shared gradient estimator or compensate through the learning
-rate. The backend also includes the reference learning-rate scaling
-$\eta/\sqrt M$. It is a numerical oracle, not an H24 production backend.
+rate. The configured learning rate is applied directly as $-\eta\delta$, matching
+the actual parameter update in `cqsl/GVMC`. Its source computes an auxiliary
+normalized displacement with $\eta/\sqrt M$, but does not apply that quantity
+to parameters. It is a numerical oracle, not an H24 production backend.
 Both presets set `train.grads.clip_method: none`, matching the unclipped force
 used for the reference algorithm.
+
+For a controlled plain-SR comparison, JaQMC native SR receives the factor-two
+gradient directly, so `learning_rate_native` is approximately
+`learning_rate_gvmc / 2`. This is only an initial A/B scale convention; robust
+SR, adaptive damping, MARCH, or norm clipping need separate comparisons.
 
 The Rayleigh estimator also reports the Grassmann Hamiltonian variance without
 another Hamiltonian evaluation:

--- a/docs/guide/subspace-variational.md
+++ b/docs/guide/subspace-variational.md
@@ -102,9 +102,51 @@ gradient uses the full complex $\operatorname{Tr}R_L$ through
 `train.grads` configuration for chunking and clipping. No NetKet runtime or
 second Hamiltonian implementation is used.
 
+## Grassmann optimization
+
+No separate Grassmann wavefunction or QGT implementation is required. For the
+determinant state,
+
+$$
+\partial_\mu\log\det\Phi
+=\operatorname{Tr}(\Phi^{-1}\partial_\mu\Phi),
+$$
+
+so passing `DeterminantStateWavefunction.logpsi` to JaQMC's existing
+`SROptimizer` produces the Grassmann score and metric. The recommended
+production preset is `configs/workflows/subspace_grassmann_sr.yml`; it retains
+JaQMC's chunking, mixed-precision solve, SPRING, and multi-device reductions
+while disabling robustness extensions for a controlled first comparison.
+
+For small, single-device A/B checks,
+`configs/workflows/subspace_gvmc_reference_sr.yml` selects
+`GVMCReferenceSROptimizer`. This backend independently implements the published
+GVMC sample-space minSR and Kaczmarz/SPRING equations from the
+[official accompanying repository](https://github.com/cqsl/GVMC) behind
+JaQMC's unchanged `OptimizerLike` interface, including the reference learning-rate scaling
+$\eta/\sqrt M$. It is a numerical oracle, not an H24 production backend.
+Both presets set `train.grads.clip_method: none`, matching the unclipped force
+used for the reference algorithm.
+
+The Rayleigh estimator also reports the Grassmann Hamiltonian variance without
+another Hamiltonian evaluation:
+
+$$
+\Sigma_H=\mathbb E[R_LE_L^*]-\mathbb E[R_L]\mathbb E[E_L]^*,\qquad
+\operatorname{Var}_V(H)=\frac1M\operatorname{Re}\operatorname{Tr}\Sigma_H.
+$$
+
+The appended writer fields are `grassmann_average_energy`,
+`grassmann_hamiltonian_variance`,
+`grassmann_hamiltonian_variance_matrix`, and `grassmann_hamiltonian_std`.
+Existing Rayleigh and subspace-energy fields are unchanged. In particular,
+`grassmann_hamiltonian_variance` diagnoses invariance of the entire span and is
+not interchangeable with `subspace_energy_var` or elementwise
+`local_rayleigh_variance`.
+
 ## Diagnostics
 
-Monitor `amplitude_sigma_min`, `amplitude_condition`,
+Monitor `grassmann_hamiltonian_variance`, `amplitude_sigma_min`, `amplitude_condition`,
 `rayleigh_solve_residual`, `max_ritz_imag`, and their warning fields.  A large
 condition number indicates nearly dependent component states, but is diagnostic
 only and does not remove a sample from the Monte Carlo measure. Every finite

--- a/examples/atoms/jaqmc_h_atom_subspace_repro
+++ b/examples/atoms/jaqmc_h_atom_subspace_repro
@@ -1,0 +1,115 @@
+# JaQMC isolated hydrogen-atom determinant-subspace validation.
+#
+# Primary validation target:
+#   M = 5 lowest spatial states of nonrelativistic H
+#
+# Exact spectrum in Hartree:
+#   E_1s = -1/2 = -0.500000000000
+#   n=2 manifold (2s, 2px, 2py, 2pz):
+#          = -1/8 = -0.125000000000  (fourfold spatial degeneracy)
+#
+# Therefore for M=5 the sorted Ritz spectrum should approach:
+#   [-0.5, -0.125, -0.125, -0.125, -0.125]
+# and the Ky-Fan trace should approach:
+#   -1.0 Ha
+#
+# IMPORTANT:
+# - The four n=2 Ritz vectors need not individually equal 2s/2px/2py/2pz.
+#   Any orthogonal basis spanning the degenerate n=2 subspace is valid.
+# - This file intentionally uses random multi-state initialization and does
+#   NOT enable the periodic KUHF/TDA pretrain path used by the H-chain.
+# - Use:
+#       jaqmc molecule subspace-train --yml jaqmc_h_atom_subspace_repro.yml
+#
+# The M=5 batch is chosen using the same M^2-cost idea as the H-chain config:
+# 1024 walkers.
+# Increase to 160/320 for a lower-variance production comparison if memory
+# and runtime are comfortable.
+
+logging:
+  level: info
+  stream: stdout
+
+jax:
+  enable_x64: true
+
+workflow:
+  seed: 20260903
+  batch_size: 1024
+
+system:
+  module: atom
+  symbol: H
+  # All-electron hydrogen.  Do not set a pseudopotential.
+  electron_init_width: 1.0
+
+# Use the standard molecule FermiNet implementation.
+# Architecture defaults are intentionally retained so this validation tests
+# the native molecule path instead of copying solid-only H-chain parameters.
+wf:
+  module: ferminet
+
+subspace:
+  # 1s + complete n=2 spatial manifold.
+  n_states: 5
+
+  # Current generic subspace path supports independent random state parameters.
+  initialization:
+    mode: random
+
+  sampling:
+    steps: 20
+    initial_width: 0.02
+    adapt_frequency: 100
+    pmove_range: [0.5, 0.55]
+
+  evaluation:
+    # Keep the H-chain validated walker chunk size.
+    vmap_chunk_size: 64
+
+    # M=5 -> 25 (replica,state) pairs.  Process five at a time as a
+    # conservative first production setting.
+    pair_chunk_size: 5
+
+    # Rayleigh/overlap solves are especially sensitive to conditioning.
+    matrix_dtype: complex128
+
+train:
+  run:
+    iterations: 40000
+    burn_in: 100
+    save_time_interval: 1800
+    save_step_interval: 500
+    timing_warmup_steps: 10
+    stop_on_nan: loss
+
+  # Retain the optimizer already used by the current H-chain subspace file.
+  optim:
+    module: jaqmc.optimizer.sr:SROptimizer
+
+    # Controlled Grassmann-SR reference scale.
+    # JaQMC native VMC gradient has the factor-2 convention,
+    # so lr=0.05 corresponds approximately to GVMC reference lr=0.10.
+    learning_rate: 0.05
+
+    damping: 1.0e-3
+    spring_mu: 0.9
+
+    # Disable JaQMC production extensions for the first controlled test.
+    robust_gamma: null
+    march_beta: null
+    max_cond_num: null
+    max_norm: null
+
+    mixed_precision: true
+    score_chunk_size: 64
+    gram_num_chunks: 4
+    score_norm_clip: null
+    gram_dot_prec: F64
+
+  # Retain the current subspace streaming-gradient path.
+  grads:
+    module: jaqmc.estimator.streaming_loss_grad:StreamingLossAndGrad
+    vmap_chunk_size: 64
+    clip_method: mad
+    clip_scale: 5.0

--- a/examples/solid/h24_subspace_smoke.yml
+++ b/examples/solid/h24_subspace_smoke.yml
@@ -10,7 +10,7 @@ jax:
 
 workflow:
   seed: 20260820
-  batch_size: 4
+  batch_size: 512
   save_path: runs/h24_subspace_m2_smoke
 
 system:

--- a/examples/solid/h24_subspace_smoke.yml
+++ b/examples/solid/h24_subspace_smoke.yml
@@ -1,6 +1,5 @@
-# Minimal single-GPU determinant-subspace smoke test for a periodic H chain.
-# This intentionally uses the subspace namespaces rather than ground-state
-# pretrain/sampler/grads configuration.
+# Memory-conservative H24, M=2 server smoke test. Increase batch size only
+# after recording stable peak memory and step time at each smaller size.
 
 logging:
   level: info
@@ -11,22 +10,22 @@ jax:
 
 workflow:
   seed: 20260820
-  batch_size: 32
-  save_path: runs/subspace_smoke
+  batch_size: 4
+  save_path: runs/h24_subspace_m2_smoke
 
 system:
   module: two_atom_chain
   symbol: H
   bond_length: 2.0
   unit: bohr
-  supercell: 1
+  supercell: 12
   vacuum_separation: 20.0
   s_z: 0
   electron_init_width: 0.8
 
 wf:
-  hidden_dims_single: [64, 64]
-  hidden_dims_double: [16, 16]
+  hidden_dims_single: [256, 256, 256, 256]
+  hidden_dims_double: [32, 32, 32, 32]
   ndets: 1
   distance_type: nu
   envelope_type: abs_isotropic
@@ -58,13 +57,15 @@ subspace:
 
 train:
   run:
-    iterations: 2
+    iterations: 3
     burn_in: 2
+    save_time_interval: 0
     save_step_interval: 1
+    timing_warmup_steps: 1
     stop_on_nan: loss
   optim:
     module: jaqmc.optimizer.optax:adam
-    learning_rate: 0.0001
+    learning_rate: 1.0e-4
   grads:
     vmap_chunk_size: 1
     clip_method: mad
@@ -73,6 +74,9 @@ train:
 estimators:
   energy:
     kinetic:
-      vmap_chunk_size: 8
+      vmap_chunk_size: 1
       mode: forward_laplacian
       sparse: true
+  enabled:
+    spin: false
+    density: false

--- a/examples/solid/hchain_subspace_smoke.yml
+++ b/examples/solid/hchain_subspace_smoke.yml
@@ -11,7 +11,7 @@ jax:
 
 workflow:
   seed: 20260820
-  batch_size: 32
+  batch_size: 512
   save_path: runs/subspace_smoke
 
 system:

--- a/examples/solid/hchain_subspace_smoke.yml
+++ b/examples/solid/hchain_subspace_smoke.yml
@@ -1,0 +1,73 @@
+# Minimal single-GPU determinant-subspace smoke test for a periodic H chain.
+# This intentionally uses the subspace namespaces rather than ground-state
+# pretrain/sampler/grads configuration.
+
+logging:
+  level: info
+  stream: stdout
+
+jax:
+  enable_x64: true
+
+workflow:
+  seed: 20260820
+  batch_size: 32
+  save_path: runs/subspace_smoke
+
+system:
+  module: two_atom_chain
+  symbol: H
+  bond_length: 2.0
+  unit: bohr
+  supercell: 1
+  vacuum_separation: 20.0
+  s_z: 0
+  electron_init_width: 0.8
+
+wf:
+  hidden_dims_single: [64, 64]
+  hidden_dims_double: [16, 16]
+  ndets: 1
+  distance_type: nu
+  envelope_type: abs_isotropic
+  full_det: true
+
+reference:
+  basis: sto-3g
+  sample_fraction: 1.0
+  verbose: 0
+  method: KUHF
+
+subspace:
+  n_states: 2
+  initialization:
+    mode: random
+  sampling:
+    steps: 2
+    initial_width: 0.02
+    adapt_frequency: 100
+    pmove_range: [0.5, 0.55]
+  evaluation:
+    pair_chunk_size: 1
+    matrix_dtype: complex128
+  diagnostics:
+    condition_warning: 1.0e10
+    solve_residual_warning: 1.0e-8
+    max_imag_eigenvalue_warning: 1.0e-6
+
+train:
+  run:
+    iterations: 2
+    burn_in: 2
+    save_step_interval: 1
+    stop_on_nan: loss
+  optim:
+    module: jaqmc.optimizer.optax:adam
+    learning_rate: 0.0001
+
+estimators:
+  energy:
+    kinetic:
+      vmap_chunk_size: 8
+      mode: forward_laplacian
+      sparse: true

--- a/examples/solid/hchain_subspace_tda_pretrain_smoke.yml
+++ b/examples/solid/hchain_subspace_tda_pretrain_smoke.yml
@@ -1,0 +1,96 @@
+# Minimal single-GPU KUHF-TDA pretrain -> subspace VMC smoke test.
+logging:
+  level: info
+  stream: stdout
+
+jax:
+  enable_x64: true
+
+workflow:
+  seed: 20260820
+  batch_size: 4
+  save_path: runs/hchain_subspace_tda_pretrain_smoke
+
+system:
+  module: two_atom_chain
+  symbol: H
+  bond_length: 2.0
+  unit: bohr
+  supercell: 1
+  vacuum_separation: 20.0
+  s_z: 0
+  electron_init_width: 0.8
+
+wf:
+  hidden_dims_single: [32, 32]
+  hidden_dims_double: [8, 8]
+  ndets: 1
+  distance_type: nu
+  envelope_type: abs_isotropic
+  full_det: true
+
+reference:
+  basis: sto-3g
+  sample_fraction: 1.0
+  verbose: 0
+  method: KUHF
+
+subspace:
+  n_states: 2
+  initialization:
+    mode: random
+  sampling:
+    steps: 1
+    initial_width: 0.02
+    adapt_frequency: 100
+    pmove_range: [0.5, 0.55]
+  evaluation:
+    vmap_chunk_size: 1
+    pair_chunk_size: 1
+    matrix_dtype: complex128
+
+pretrain:
+  enabled: true
+  tda:
+    kshift: 0
+    oversample: 0
+    candidate_topk: 4
+    min_selected_weight: 1.0e-6
+    require_converged: true
+    require_same_k: true
+  run:
+    iterations: 1
+    burn_in: 1
+    save_time_interval: 0
+    save_step_interval: 1
+    timing_warmup_steps: 0
+    stop_on_nan: loss
+  optim:
+    module: jaqmc.optimizer.optax:adam
+    learning_rate: 3.0e-4
+
+train:
+  run:
+    iterations: 1
+    burn_in: 1
+    save_time_interval: 0
+    save_step_interval: 1
+    timing_warmup_steps: 0
+    stop_on_nan: loss
+  optim:
+    module: jaqmc.optimizer.optax:adam
+    learning_rate: 1.0e-4
+  grads:
+    vmap_chunk_size: 1
+    clip_method: mad
+    clip_scale: 5.0
+
+estimators:
+  energy:
+    kinetic:
+      vmap_chunk_size: 1
+      mode: forward_laplacian
+      sparse: true
+  enabled:
+    spin: false
+    density: false

--- a/src/jaqmc/app/cli.py
+++ b/src/jaqmc/app/cli.py
@@ -79,6 +79,14 @@ def molecule_evaluate(cfg: ConfigManager, dry_run: bool):
     MoleculeEvalWorkflow(cfg)(dry_run)
 
 
+@molecule.add_command
+@make_cli(name="subspace-train", help="Train a molecular low-energy subspace.")
+def molecule_subspace_train(cfg: ConfigManager, dry_run: bool):
+    from .molecule import MoleculeSubspaceTrainWorkflow
+
+    MoleculeSubspaceTrainWorkflow(cfg)(dry_run)
+
+
 # --- solid ---
 
 

--- a/src/jaqmc/app/cli.py
+++ b/src/jaqmc/app/cli.py
@@ -111,6 +111,14 @@ def solid_evaluate(cfg: ConfigManager, dry_run: bool):
     SolidEvalWorkflow(cfg)(dry_run)
 
 
+@solid.add_command
+@make_cli(name="subspace-train", help="Train a solid-state low-energy subspace.")
+def solid_subspace_train(cfg: ConfigManager, dry_run: bool):
+    from .solid import SolidSubspaceTrainWorkflow
+
+    SolidSubspaceTrainWorkflow(cfg)(dry_run)
+
+
 # --- electron_gas ---
 
 

--- a/src/jaqmc/app/molecule/__init__.py
+++ b/src/jaqmc/app/molecule/__init__.py
@@ -1,6 +1,14 @@
 # Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
 # SPDX-License-Identifier: Apache-2.0
 
-from .workflow import MoleculeEvalWorkflow, MoleculeTrainWorkflow
+from .workflow import (
+    MoleculeEvalWorkflow,
+    MoleculeSubspaceTrainWorkflow,
+    MoleculeTrainWorkflow,
+)
 
-__all__ = ["MoleculeEvalWorkflow", "MoleculeTrainWorkflow"]
+__all__ = [
+    "MoleculeEvalWorkflow",
+    "MoleculeSubspaceTrainWorkflow",
+    "MoleculeTrainWorkflow",
+]

--- a/src/jaqmc/app/molecule/workflow.py
+++ b/src/jaqmc/app/molecule/workflow.py
@@ -25,6 +25,10 @@ from jaqmc.wavefunction import Wavefunction
 from jaqmc.workflow.evaluation import EvaluationWorkflow
 from jaqmc.workflow.stage.evaluation import EvaluationWorkStage
 from jaqmc.workflow.stage.vmc import VMCWorkStage
+from jaqmc.workflow.subspace_vmc import (
+    SubspaceVMCWorkflow,
+    energy_estimators_only,
+)
 from jaqmc.workflow.vmc import VMCWorkflow
 
 from .config import MoleculeConfig, MoleculePretrainReferenceConfig
@@ -70,15 +74,12 @@ class MoleculeTrainWorkflow(VMCWorkflow):
         sampler = cfg.get("sampler", MCMCSampler)
 
         pretrain_loss = make_pretrain_loss(
-            orbitals_fn=wf.orbitals,
-            orbital_ref=self.scf,
-            nspins=nspins,
-            full_det=wf.full_det,
+            orbitals_fn=wf.orbitals, scf=self.scf, nspins=nspins, full_det=wf.full_det
         )
         pretrain_f_log_amplitude = make_pretrain_log_amplitude(
             wf.logpsi,
             lambda data: self.scf.eval_slater(data.electrons, nspins)[1],
-            ref_fraction=pretrain_config.sample_fraction,
+            scf_fraction=pretrain_config.sample_fraction,
         )
 
         pretrain = VMCWorkStage.builder(cfg.scoped("pretrain"), wf)
@@ -117,6 +118,23 @@ class MoleculeEvalWorkflow(EvaluationWorkflow):
         evaluation.configure_estimators(**eval_estimators)
 
         self.evaluation_stage = evaluation.build()
+
+
+class MoleculeSubspaceTrainWorkflow(SubspaceVMCWorkflow):
+    """Jointly optimize a low-energy molecular variational subspace."""
+
+    def __init__(self, cfg: ConfigManager) -> None:
+        super().__init__(cfg)
+        system_config, wf = configure_system(cfg)
+        physical_data_init = partial(data_init, system_config)
+        physical_estimators = make_estimators(
+            cfg, wf, system_config, always_enable_energy=True
+        )
+        self.configure_subspace(
+            base_wavefunction=wf,
+            physical_data_init=physical_data_init,
+            physical_energy_estimators=energy_estimators_only(physical_estimators),
+        )
 
 
 def configure_system(

--- a/src/jaqmc/app/molecule/workflow.py
+++ b/src/jaqmc/app/molecule/workflow.py
@@ -74,12 +74,15 @@ class MoleculeTrainWorkflow(VMCWorkflow):
         sampler = cfg.get("sampler", MCMCSampler)
 
         pretrain_loss = make_pretrain_loss(
-            orbitals_fn=wf.orbitals, scf=self.scf, nspins=nspins, full_det=wf.full_det
+            orbitals_fn=wf.orbitals,
+            orbital_ref=self.scf,
+            nspins=nspins,
+            full_det=wf.full_det,
         )
         pretrain_f_log_amplitude = make_pretrain_log_amplitude(
             wf.logpsi,
             lambda data: self.scf.eval_slater(data.electrons, nspins)[1],
-            scf_fraction=pretrain_config.sample_fraction,
+            ref_fraction=pretrain_config.sample_fraction,
         )
 
         pretrain = VMCWorkStage.builder(cfg.scoped("pretrain"), wf)

--- a/src/jaqmc/app/solid/__init__.py
+++ b/src/jaqmc/app/solid/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
 # SPDX-License-Identifier: Apache-2.0
 
-from .workflow import SolidEvalWorkflow, SolidTrainWorkflow
+from .workflow import SolidEvalWorkflow, SolidSubspaceTrainWorkflow, SolidTrainWorkflow
 
-__all__ = ["SolidEvalWorkflow", "SolidTrainWorkflow"]
+__all__ = ["SolidEvalWorkflow", "SolidSubspaceTrainWorkflow", "SolidTrainWorkflow"]

--- a/src/jaqmc/app/solid/workflow.py
+++ b/src/jaqmc/app/solid/workflow.py
@@ -28,6 +28,10 @@ from jaqmc.wavefunction import Wavefunction
 from jaqmc.workflow.evaluation import EvaluationWorkflow
 from jaqmc.workflow.stage.evaluation import EvaluationWorkStage
 from jaqmc.workflow.stage.vmc import VMCWorkStage
+from jaqmc.workflow.subspace_vmc import (
+    SubspaceVMCWorkflow,
+    energy_estimators_only,
+)
 from jaqmc.workflow.vmc import VMCWorkflow
 
 from .config import SolidConfig, SolidPretrainReferenceConfig
@@ -77,15 +81,12 @@ class SolidTrainWorkflow(VMCWorkflow):
         self.data_init = partial(data_init, system_config)
 
         loss_estimator = make_pretrain_loss(
-            orbitals_fn=wf.orbitals,
-            orbital_ref=self.scf,
-            nspins=nspins,
-            full_det=wf.full_det,
+            orbitals_fn=wf.orbitals, scf=self.scf, nspins=nspins, full_det=wf.full_det
         )
         f_log_amplitude = make_pretrain_log_amplitude(
             wf.logpsi,
             lambda data: self.scf.eval_slater(data.electrons, nspins).real,
-            ref_fraction=pretrain_config.sample_fraction,
+            scf_fraction=pretrain_config.sample_fraction,
         )
         sampler = cfg.get("sampler", MCMCSampler(sampling_proposal=sampling_proposal))
 
@@ -146,6 +147,30 @@ class SolidEvalWorkflow(EvaluationWorkflow):
                 for kpt, alpha, beta in self.scf.get_kpoint_occupancies()
             ),
         )
+        super().run()
+
+
+class SolidSubspaceTrainWorkflow(SubspaceVMCWorkflow):
+    """Jointly optimize a low-energy periodic-solid variational subspace."""
+
+    def __init__(self, cfg: ConfigManager) -> None:
+        super().__init__(cfg)
+        system_config, wf, sampling_proposal = configure_system(cfg)
+        reference_config = cfg.get("reference", SolidPretrainReferenceConfig)
+        self.scf = make_scf(reference_config, system_config)
+        physical_estimators = make_estimators(
+            cfg, wf, system_config, always_enable_energy=True
+        )
+        self.configure_subspace(
+            base_wavefunction=wf,
+            physical_data_init=partial(data_init, system_config),
+            physical_energy_estimators=energy_estimators_only(physical_estimators),
+            physical_proposal=sampling_proposal,
+        )
+
+    def run(self) -> None:
+        self.scf.run()
+        self.base_wavefunction.klist = self.scf.get_orbital_kpoints()
         super().run()
 
 

--- a/src/jaqmc/app/solid/workflow.py
+++ b/src/jaqmc/app/solid/workflow.py
@@ -20,6 +20,10 @@ from jaqmc.optimizer.kfac import KFACOptimizer
 from jaqmc.optimizer.optax import adam
 from jaqmc.sampler.mcmc import MCMCSampler
 from jaqmc.utils.atomic import PeriodicSCF
+from jaqmc.utils.atomic.pbc_tda import (
+    PBCTDAReferenceConfig,
+    PeriodicStateOrbitalReference,
+)
 from jaqmc.utils.atomic.pretrain import make_pretrain_log_amplitude, make_pretrain_loss
 from jaqmc.utils.config import ConfigManager, ConfigManagerLike
 from jaqmc.utils.supercell import get_reciprocal_vectors, get_supercell_kpts
@@ -170,10 +174,29 @@ class SolidSubspaceTrainWorkflow(SubspaceVMCWorkflow):
             physical_energy_estimators=energy_estimators_only(physical_estimators),
             physical_proposal=sampling_proposal,
         )
+        self.pretrain_enabled = cfg.get("pretrain.enabled", False)
+        self.subspace_reference = None
+        if self.pretrain_enabled:
+            tda_config = cfg.get("pretrain.tda", PBCTDAReferenceConfig)
+            self.subspace_reference = PeriodicStateOrbitalReference(
+                self.scf, self.spec.n_states, tda_config
+            )
+            nspins = (
+                system_config.electron_spins[0] * system_config.scale,
+                system_config.electron_spins[1] * system_config.scale,
+            )
+            self.configure_subspace_pretrain(
+                orbital_reference=self.subspace_reference,
+                nspins=nspins,
+                full_det=wf.full_det,
+                ref_fraction=reference_config.sample_fraction,
+            )
 
     def run(self) -> None:
         self.scf.run()
         self.base_wavefunction.klist = self.scf.get_orbital_kpoints()
+        if self.subspace_reference is not None:
+            self.subspace_reference.prepare()
         super().run()
 
 

--- a/src/jaqmc/app/solid/workflow.py
+++ b/src/jaqmc/app/solid/workflow.py
@@ -81,12 +81,15 @@ class SolidTrainWorkflow(VMCWorkflow):
         self.data_init = partial(data_init, system_config)
 
         loss_estimator = make_pretrain_loss(
-            orbitals_fn=wf.orbitals, scf=self.scf, nspins=nspins, full_det=wf.full_det
+            orbitals_fn=wf.orbitals,
+            orbital_ref=self.scf,
+            nspins=nspins,
+            full_det=wf.full_det,
         )
         f_log_amplitude = make_pretrain_log_amplitude(
             wf.logpsi,
             lambda data: self.scf.eval_slater(data.electrons, nspins).real,
-            scf_fraction=pretrain_config.sample_fraction,
+            ref_fraction=pretrain_config.sample_fraction,
         )
         sampler = cfg.get("sampler", MCMCSampler(sampling_proposal=sampling_proposal))
 

--- a/src/jaqmc/estimator/__init__.py
+++ b/src/jaqmc/estimator/__init__.py
@@ -9,6 +9,7 @@ from .base import (
     FunctionEstimator,
     PerWalkerEstimator,
 )
+from .rayleigh import CrossLocalEnergyEvaluator, RayleighMatrixEstimator
 
 __all__ = [
     "EstimateFn",
@@ -17,4 +18,6 @@ __all__ = [
     "EstimatorPipeline",
     "FunctionEstimator",
     "PerWalkerEstimator",
+    "CrossLocalEnergyEvaluator",
+    "RayleighMatrixEstimator",
 ]

--- a/src/jaqmc/estimator/__init__.py
+++ b/src/jaqmc/estimator/__init__.py
@@ -9,7 +9,11 @@ from .base import (
     FunctionEstimator,
     PerWalkerEstimator,
 )
-from .rayleigh import CrossLocalEnergyEvaluator, RayleighMatrixEstimator
+from .rayleigh import (
+    CrossLocalEnergyEvaluator,
+    PhysicalEnergyPlan,
+    RayleighMatrixEstimator,
+)
 
 __all__ = [
     "EstimateFn",
@@ -19,5 +23,6 @@ __all__ = [
     "FunctionEstimator",
     "PerWalkerEstimator",
     "CrossLocalEnergyEvaluator",
+    "PhysicalEnergyPlan",
     "RayleighMatrixEstimator",
 ]

--- a/src/jaqmc/estimator/__init__.py
+++ b/src/jaqmc/estimator/__init__.py
@@ -9,6 +9,7 @@ from .base import (
     FunctionEstimator,
     PerWalkerEstimator,
 )
+from .loss_grad import LossAndGrad, StreamingLossAndGrad
 from .rayleigh import (
     CrossLocalEnergyEvaluator,
     PhysicalEnergyPlan,
@@ -22,6 +23,8 @@ __all__ = [
     "EstimatorPipeline",
     "FunctionEstimator",
     "PerWalkerEstimator",
+    "LossAndGrad",
+    "StreamingLossAndGrad",
     "CrossLocalEnergyEvaluator",
     "PhysicalEnergyPlan",
     "RayleighMatrixEstimator",

--- a/src/jaqmc/estimator/__init__.py
+++ b/src/jaqmc/estimator/__init__.py
@@ -9,12 +9,13 @@ from .base import (
     FunctionEstimator,
     PerWalkerEstimator,
 )
-from .loss_grad import LossAndGrad, StreamingLossAndGrad
+from .loss_grad import LossAndGrad
 from .rayleigh import (
     CrossLocalEnergyEvaluator,
     PhysicalEnergyPlan,
     RayleighMatrixEstimator,
 )
+from .streaming_loss_grad import StreamingLossAndGrad
 
 __all__ = [
     "EstimateFn",

--- a/src/jaqmc/estimator/__init__.py
+++ b/src/jaqmc/estimator/__init__.py
@@ -14,6 +14,7 @@ from .rayleigh import (
     CrossLocalEnergyEvaluator,
     PhysicalEnergyPlan,
     RayleighMatrixEstimator,
+    grassmann_hamiltonian_statistics,
 )
 from .streaming_loss_grad import StreamingLossAndGrad
 
@@ -29,4 +30,5 @@ __all__ = [
     "CrossLocalEnergyEvaluator",
     "PhysicalEnergyPlan",
     "RayleighMatrixEstimator",
+    "grassmann_hamiltonian_statistics",
 ]

--- a/src/jaqmc/estimator/_loss_grad.py
+++ b/src/jaqmc/estimator/_loss_grad.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared mathematical helpers for VMC loss-gradient estimators."""
+
+import jax
+import optax
+from jax import numpy as jnp
+
+from jaqmc.array_types import Params
+
+
+def vmc_energy_gradient(
+    mean_grad_logpsi: Params,
+    mean_grad_logpsi_loss: Params,
+    mean_clipped_loss: jax.Array,
+) -> Params:
+    r"""Return the real VMC energy gradient from sufficient statistics.
+
+    This helper is shared by the materialized and streaming estimators so
+    complex conjugation, real projection, scaling, and dtype preservation
+    cannot drift between the two implementations.
+    """
+    grads = optax.tree.add(
+        mean_grad_logpsi_loss,
+        optax.tree.real(
+            optax.tree.scale(
+                -mean_clipped_loss,
+                jax.tree.map(jnp.conj, mean_grad_logpsi),
+            )
+        ),
+    )
+    grads = jax.tree.map(
+        lambda grad, log_grad: grad.astype(jnp.real(log_grad).dtype),
+        grads,
+        mean_grad_logpsi,
+    )
+    return optax.tree.scale(2, grads)

--- a/src/jaqmc/estimator/loss_grad.py
+++ b/src/jaqmc/estimator/loss_grad.py
@@ -65,6 +65,7 @@ class LossAndGrad(PerWalkerEstimator):
     loss_key: str = "total_energy"
     clip_method: Literal["iqr", "mad", "none"] = "mad"
     clip_scale: float = 5.0
+    validity_key: str | None = None
     f_log_psi: NumericWavefunctionEvaluate = runtime_dep()
 
     def evaluate_single_walker(
@@ -87,26 +88,36 @@ class LossAndGrad(PerWalkerEstimator):
                 f"{prev_walker_stats[self.loss_key].shape}."
             )
         # We copy over loss stats because we need to do customized reduce
-        return {
+        result = {
             "logpsi": primals,
             "grad_logpsi": grads,
             "loss": prev_walker_stats[self.loss_key],
-        }, state
+        }
+        if self.validity_key is not None:
+            result["loss_valid"] = prev_walker_stats[self.validity_key]
+        return result, state
 
     def reduce(self, walker_stats: Mapping[str, Any]) -> dict[str, Any]:
-        clipped_loss = clip_observable(
-            walker_stats["loss"], self.clip_method, scale=self.clip_scale
-        )
+        loss = walker_stats["loss"]
+        grad_logpsi = walker_stats["grad_logpsi"]
+        if self.validity_key is not None:
+            valid = walker_stats["loss_valid"]
+            loss = jnp.where(valid, loss, jnp.nan)
+            grad_logpsi = jax.tree.map(
+                lambda x: jnp.where(match_first_axis_of(valid, x), x, jnp.nan),
+                grad_logpsi,
+            )
+        clipped_loss = clip_observable(loss, self.clip_method, scale=self.clip_scale)
         grad_logpsi_and_loss = jax.tree.map(
             lambda x: jnp.real(jnp.conj(x) * match_first_axis_of(clipped_loss, x)),
-            walker_stats["grad_logpsi"],
+            grad_logpsi,
         )
         return mean_reduce(
             {
                 "grad_logpsi_and_loss": grad_logpsi_and_loss,
-                "loss": walker_stats["loss"],
+                "loss": loss,
                 "clipped_loss": clipped_loss,
-                "grad_logpsi": walker_stats["grad_logpsi"],
+                "grad_logpsi": grad_logpsi,
             }
         )
 
@@ -123,6 +134,10 @@ class LossAndGrad(PerWalkerEstimator):
         loss = batch_mean(batch_stats["loss"])
         grads = optax.tree.add(
             grad_logpsi_and_loss,
-            optax.tree.real(optax.tree.scale(-clipped_loss, grad_logpsi)),
+            optax.tree.real(
+                optax.tree.scale(
+                    -clipped_loss, jax.tree.map(jnp.conj, grad_logpsi)
+                )
+            ),
         )
         return {"loss": loss, "grads": optax.tree.scale(2, grads)}

--- a/src/jaqmc/estimator/loss_grad.py
+++ b/src/jaqmc/estimator/loss_grad.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
 # SPDX-License-Identifier: Apache-2.0
 
+import dataclasses
 from collections.abc import Mapping
 from functools import partial
 from typing import Any, Literal
@@ -10,8 +11,8 @@ import optax
 from jax import numpy as jnp
 
 from jaqmc.array_types import Params, PRNGKey
-from jaqmc.data import Data
-from jaqmc.estimator.base import PerWalkerEstimator, mean_reduce
+from jaqmc.data import BatchedData, Data
+from jaqmc.estimator.base import Estimator, PerWalkerEstimator, mean_reduce
 from jaqmc.utils import parallel_jax
 from jaqmc.utils.array import match_first_axis_of
 from jaqmc.utils.clip import clip_observable
@@ -118,7 +119,8 @@ class LossAndGrad(PerWalkerEstimator):
                 "loss": loss,
                 "clipped_loss": clipped_loss,
                 "grad_logpsi": grad_logpsi,
-            }
+            },
+            include_variance=False,
         )
 
     def finalize_stats(
@@ -139,5 +141,187 @@ class LossAndGrad(PerWalkerEstimator):
                     -clipped_loss, jax.tree.map(jnp.conj, grad_logpsi)
                 )
             ),
+        )
+        grads = jax.tree.map(
+            lambda grad, log_grad: grad.astype(jnp.real(log_grad).dtype),
+            grads,
+            grad_logpsi,
+        )
+        return {"loss": loss, "grads": optax.tree.scale(2, grads)}
+
+
+@configurable_dataclass
+class StreamingLossAndGrad(Estimator):
+    """Compute VMC gradients with chunk-local sufficient-statistic reduction.
+
+    Unlike :class:`LossAndGrad`, this estimator never materializes a
+    ``[walkers, ...parameters]`` gradient tree. Each chunk's per-walker
+    gradients are reduced immediately inside ``lax.scan``.
+    """
+
+    loss_key: str = "total_energy"
+    vmap_chunk_size: int | None = None
+    clip_method: Literal["iqr", "mad", "none"] = "mad"
+    clip_scale: float = 5.0
+    f_log_psi: NumericWavefunctionEvaluate = runtime_dep()
+
+    def evaluate_batch_walkers(
+        self,
+        params: Params,
+        batched_data: BatchedData,
+        prev_walker_stats: Mapping[str, Any],
+        state: None,
+        rngs: PRNGKey,
+    ) -> tuple[dict[str, Any], None]:
+        del rngs
+        loss = prev_walker_stats[self.loss_key]
+        if loss.ndim != 1:
+            raise ValueError(
+                f"Expected one scalar loss per walker, got shape {loss.shape}."
+            )
+        batch_size = batched_data.batch_size
+        if batch_size < 1:
+            raise ValueError("StreamingLossAndGrad requires a non-empty batch.")
+        chunk_size = self.vmap_chunk_size or batch_size
+        if chunk_size < 1:
+            raise ValueError("vmap_chunk_size must be positive or None.")
+        chunk_size = min(chunk_size, batch_size)
+        n_chunks = (batch_size + chunk_size - 1) // chunk_size
+        padded_size = n_chunks * chunk_size
+        pad_size = padded_size - batch_size
+
+        clipped_loss = clip_observable(
+            loss, self.clip_method, scale=self.clip_scale
+        )
+
+        def pad_leaf(x):
+            if pad_size == 0:
+                return x
+            pad_width = ((0, pad_size),) + ((0, 0),) * (x.ndim - 1)
+            return jnp.pad(x, pad_width, mode="edge")
+
+        padded_data = dataclasses.replace(
+            batched_data.data,
+            **{
+                name: jax.tree.map(pad_leaf, batched_data.data[name])
+                for name in batched_data.fields_with_batch
+            },
+        )
+        padded_loss = pad_leaf(clipped_loss)
+        padded_mask = jnp.arange(padded_size) < batch_size
+
+        value_and_grad_f = transform_maybe_complex(
+            self.f_log_psi, jax.value_and_grad
+        )
+        grad_shape = jax.eval_shape(
+            lambda p, d: value_and_grad_f(p, d)[1],
+            params,
+            batched_data.unbatched_example(),
+        )
+        sum_grad = jax.tree.map(
+            lambda x: jnp.zeros(x.shape, x.dtype), grad_shape
+        )
+        sum_grad_loss = jax.tree.map(
+            lambda x: jnp.zeros(x.shape, jnp.real(jnp.zeros((), x.dtype)).dtype),
+            grad_shape,
+        )
+        # Chunk sums vary across data shards even though parameters are shared.
+        # Mark the scan carry accordingly so shard_map VMA stays stable.
+        sum_grad = parallel_jax.pvary(sum_grad)
+        sum_grad_loss = parallel_jax.pvary(sum_grad_loss)
+        vmap_axis = batched_data.vmap_axis
+        vmapped_grad = jax.vmap(value_and_grad_f, in_axes=(None, vmap_axis))
+
+        def scan_body(carry, chunk_index):
+            start = chunk_index * chunk_size
+            chunk_data = dataclasses.replace(
+                padded_data,
+                **{
+                    name: jax.tree.map(
+                        lambda x: jax.lax.dynamic_slice_in_dim(
+                            x, start, chunk_size, axis=0
+                        ),
+                        padded_data[name],
+                    )
+                    for name in batched_data.fields_with_batch
+                },
+            )
+            loss_chunk = jax.lax.dynamic_slice_in_dim(
+                padded_loss, start, chunk_size, axis=0
+            )
+            mask_chunk = jax.lax.dynamic_slice_in_dim(
+                padded_mask, start, chunk_size, axis=0
+            )
+            _, grads = vmapped_grad(parallel_jax.pvary(params), chunk_data)
+            grads = jax.tree.map(
+                lambda x: jnp.where(match_first_axis_of(mask_chunk, x), x, 0),
+                grads,
+            )
+            grad_loss = jax.tree.map(
+                lambda x: jnp.real(
+                    jnp.conj(x) * match_first_axis_of(loss_chunk, x)
+                ).astype(jnp.real(x).dtype),
+                grads,
+            )
+            chunk_sum_grad = jax.tree.map(lambda x: jnp.sum(x, axis=0), grads)
+            chunk_sum_grad_loss = jax.tree.map(
+                lambda x: jnp.sum(x, axis=0), grad_loss
+            )
+            return (
+                jax.tree.map(jnp.add, carry[0], chunk_sum_grad),
+                jax.tree.map(jnp.add, carry[1], chunk_sum_grad_loss),
+            ), None
+
+        (sum_grad, sum_grad_loss), _ = jax.lax.scan(
+            scan_body, (sum_grad, sum_grad_loss), jnp.arange(n_chunks)
+        )
+        return {
+            "sum_grad_logpsi": sum_grad,
+            "sum_grad_logpsi_and_loss": sum_grad_loss,
+            "sum_loss": jnp.sum(loss),
+            "sum_clipped_loss": jnp.sum(clipped_loss),
+            "count": jnp.asarray(batch_size),
+        }, state
+
+    def reduce(self, stats: Mapping[str, Any]) -> dict[str, Any]:
+        count = parallel_jax.psum(stats["count"])
+        return {
+            "grad_logpsi": jax.tree.map(
+                lambda x: parallel_jax.psum(x) / count,
+                stats["sum_grad_logpsi"],
+            ),
+            "grad_logpsi_and_loss": jax.tree.map(
+                lambda x: parallel_jax.psum(x) / count,
+                stats["sum_grad_logpsi_and_loss"],
+            ),
+            "loss": parallel_jax.psum(stats["sum_loss"]) / count,
+            "clipped_loss": (
+                parallel_jax.psum(stats["sum_clipped_loss"]) / count
+            ),
+        }
+
+    def finalize_stats(
+        self, batch_stats: Mapping[str, Any], state: None
+    ) -> dict[str, Any]:
+        del state
+        batch_mean = partial(jnp.mean, axis=0)
+        grad_logpsi_and_loss = jax.tree.map(
+            batch_mean, batch_stats["grad_logpsi_and_loss"]
+        )
+        grad_logpsi = jax.tree.map(batch_mean, batch_stats["grad_logpsi"])
+        clipped_loss = batch_mean(batch_stats["clipped_loss"])
+        loss = batch_mean(batch_stats["loss"])
+        grads = optax.tree.add(
+            grad_logpsi_and_loss,
+            optax.tree.real(
+                optax.tree.scale(
+                    -clipped_loss, jax.tree.map(jnp.conj, grad_logpsi)
+                )
+            ),
+        )
+        grads = jax.tree.map(
+            lambda grad, log_grad: grad.astype(jnp.real(log_grad).dtype),
+            grads,
+            grad_logpsi,
         )
         return {"loss": loss, "grads": optax.tree.scale(2, grads)}

--- a/src/jaqmc/estimator/loss_grad.py
+++ b/src/jaqmc/estimator/loss_grad.py
@@ -1,18 +1,17 @@
 # Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
 # SPDX-License-Identifier: Apache-2.0
 
-import dataclasses
 from collections.abc import Mapping
 from functools import partial
 from typing import Any, Literal
 
 import jax
-import optax
 from jax import numpy as jnp
 
 from jaqmc.array_types import Params, PRNGKey
-from jaqmc.data import BatchedData, Data
-from jaqmc.estimator.base import Estimator, PerWalkerEstimator, mean_reduce
+from jaqmc.data import Data
+from jaqmc.estimator._loss_grad import vmc_energy_gradient
+from jaqmc.estimator.base import PerWalkerEstimator, mean_reduce
 from jaqmc.utils import parallel_jax
 from jaqmc.utils.array import match_first_axis_of
 from jaqmc.utils.clip import clip_observable
@@ -134,194 +133,9 @@ class LossAndGrad(PerWalkerEstimator):
         grad_logpsi = jax.tree.map(batch_mean, batch_stats["grad_logpsi"])
         clipped_loss = batch_mean(batch_stats["clipped_loss"])
         loss = batch_mean(batch_stats["loss"])
-        grads = optax.tree.add(
-            grad_logpsi_and_loss,
-            optax.tree.real(
-                optax.tree.scale(
-                    -clipped_loss, jax.tree.map(jnp.conj, grad_logpsi)
-                )
-            ),
-        )
-        grads = jax.tree.map(
-            lambda grad, log_grad: grad.astype(jnp.real(log_grad).dtype),
-            grads,
-            grad_logpsi,
-        )
-        return {"loss": loss, "grads": optax.tree.scale(2, grads)}
-
-
-@configurable_dataclass
-class StreamingLossAndGrad(Estimator):
-    """Compute VMC gradients with chunk-local sufficient-statistic reduction.
-
-    Unlike :class:`LossAndGrad`, this estimator never materializes a
-    ``[walkers, ...parameters]`` gradient tree. Each chunk's per-walker
-    gradients are reduced immediately inside ``lax.scan``.
-    """
-
-    loss_key: str = "total_energy"
-    vmap_chunk_size: int | None = None
-    clip_method: Literal["iqr", "mad", "none"] = "mad"
-    clip_scale: float = 5.0
-    f_log_psi: NumericWavefunctionEvaluate = runtime_dep()
-
-    def evaluate_batch_walkers(
-        self,
-        params: Params,
-        batched_data: BatchedData,
-        prev_walker_stats: Mapping[str, Any],
-        state: None,
-        rngs: PRNGKey,
-    ) -> tuple[dict[str, Any], None]:
-        del rngs
-        loss = prev_walker_stats[self.loss_key]
-        if loss.ndim != 1:
-            raise ValueError(
-                f"Expected one scalar loss per walker, got shape {loss.shape}."
-            )
-        batch_size = batched_data.batch_size
-        if batch_size < 1:
-            raise ValueError("StreamingLossAndGrad requires a non-empty batch.")
-        chunk_size = self.vmap_chunk_size or batch_size
-        if chunk_size < 1:
-            raise ValueError("vmap_chunk_size must be positive or None.")
-        chunk_size = min(chunk_size, batch_size)
-        n_chunks = (batch_size + chunk_size - 1) // chunk_size
-        padded_size = n_chunks * chunk_size
-        pad_size = padded_size - batch_size
-
-        clipped_loss = clip_observable(
-            loss, self.clip_method, scale=self.clip_scale
-        )
-
-        def pad_leaf(x):
-            if pad_size == 0:
-                return x
-            pad_width = ((0, pad_size),) + ((0, 0),) * (x.ndim - 1)
-            return jnp.pad(x, pad_width, mode="edge")
-
-        padded_data = dataclasses.replace(
-            batched_data.data,
-            **{
-                name: jax.tree.map(pad_leaf, batched_data.data[name])
-                for name in batched_data.fields_with_batch
-            },
-        )
-        padded_loss = pad_leaf(clipped_loss)
-        padded_mask = jnp.arange(padded_size) < batch_size
-
-        value_and_grad_f = transform_maybe_complex(
-            self.f_log_psi, jax.value_and_grad
-        )
-        grad_shape = jax.eval_shape(
-            lambda p, d: value_and_grad_f(p, d)[1],
-            params,
-            batched_data.unbatched_example(),
-        )
-        sum_grad = jax.tree.map(
-            lambda x: jnp.zeros(x.shape, x.dtype), grad_shape
-        )
-        sum_grad_loss = jax.tree.map(
-            lambda x: jnp.zeros(x.shape, jnp.real(jnp.zeros((), x.dtype)).dtype),
-            grad_shape,
-        )
-        # Chunk sums vary across data shards even though parameters are shared.
-        # Mark the scan carry accordingly so shard_map VMA stays stable.
-        sum_grad = parallel_jax.pvary(sum_grad)
-        sum_grad_loss = parallel_jax.pvary(sum_grad_loss)
-        vmap_axis = batched_data.vmap_axis
-        vmapped_grad = jax.vmap(value_and_grad_f, in_axes=(None, vmap_axis))
-
-        def scan_body(carry, chunk_index):
-            start = chunk_index * chunk_size
-            chunk_data = dataclasses.replace(
-                padded_data,
-                **{
-                    name: jax.tree.map(
-                        lambda x: jax.lax.dynamic_slice_in_dim(
-                            x, start, chunk_size, axis=0
-                        ),
-                        padded_data[name],
-                    )
-                    for name in batched_data.fields_with_batch
-                },
-            )
-            loss_chunk = jax.lax.dynamic_slice_in_dim(
-                padded_loss, start, chunk_size, axis=0
-            )
-            mask_chunk = jax.lax.dynamic_slice_in_dim(
-                padded_mask, start, chunk_size, axis=0
-            )
-            _, grads = vmapped_grad(parallel_jax.pvary(params), chunk_data)
-            grads = jax.tree.map(
-                lambda x: jnp.where(match_first_axis_of(mask_chunk, x), x, 0),
-                grads,
-            )
-            grad_loss = jax.tree.map(
-                lambda x: jnp.real(
-                    jnp.conj(x) * match_first_axis_of(loss_chunk, x)
-                ).astype(jnp.real(x).dtype),
-                grads,
-            )
-            chunk_sum_grad = jax.tree.map(lambda x: jnp.sum(x, axis=0), grads)
-            chunk_sum_grad_loss = jax.tree.map(
-                lambda x: jnp.sum(x, axis=0), grad_loss
-            )
-            return (
-                jax.tree.map(jnp.add, carry[0], chunk_sum_grad),
-                jax.tree.map(jnp.add, carry[1], chunk_sum_grad_loss),
-            ), None
-
-        (sum_grad, sum_grad_loss), _ = jax.lax.scan(
-            scan_body, (sum_grad, sum_grad_loss), jnp.arange(n_chunks)
-        )
         return {
-            "sum_grad_logpsi": sum_grad,
-            "sum_grad_logpsi_and_loss": sum_grad_loss,
-            "sum_loss": jnp.sum(loss),
-            "sum_clipped_loss": jnp.sum(clipped_loss),
-            "count": jnp.asarray(batch_size),
-        }, state
-
-    def reduce(self, stats: Mapping[str, Any]) -> dict[str, Any]:
-        count = parallel_jax.psum(stats["count"])
-        return {
-            "grad_logpsi": jax.tree.map(
-                lambda x: parallel_jax.psum(x) / count,
-                stats["sum_grad_logpsi"],
-            ),
-            "grad_logpsi_and_loss": jax.tree.map(
-                lambda x: parallel_jax.psum(x) / count,
-                stats["sum_grad_logpsi_and_loss"],
-            ),
-            "loss": parallel_jax.psum(stats["sum_loss"]) / count,
-            "clipped_loss": (
-                parallel_jax.psum(stats["sum_clipped_loss"]) / count
+            "loss": loss,
+            "grads": vmc_energy_gradient(
+                grad_logpsi, grad_logpsi_and_loss, clipped_loss
             ),
         }
-
-    def finalize_stats(
-        self, batch_stats: Mapping[str, Any], state: None
-    ) -> dict[str, Any]:
-        del state
-        batch_mean = partial(jnp.mean, axis=0)
-        grad_logpsi_and_loss = jax.tree.map(
-            batch_mean, batch_stats["grad_logpsi_and_loss"]
-        )
-        grad_logpsi = jax.tree.map(batch_mean, batch_stats["grad_logpsi"])
-        clipped_loss = batch_mean(batch_stats["clipped_loss"])
-        loss = batch_mean(batch_stats["loss"])
-        grads = optax.tree.add(
-            grad_logpsi_and_loss,
-            optax.tree.real(
-                optax.tree.scale(
-                    -clipped_loss, jax.tree.map(jnp.conj, grad_logpsi)
-                )
-            ),
-        )
-        grads = jax.tree.map(
-            lambda grad, log_grad: grad.astype(jnp.real(log_grad).dtype),
-            grads,
-            grad_logpsi,
-        )
-        return {"loss": loss, "grads": optax.tree.scale(2, grads)}

--- a/src/jaqmc/estimator/rayleigh.py
+++ b/src/jaqmc/estimator/rayleigh.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rayleigh-matrix estimators built from JaQMC physical-energy components."""
+
+import dataclasses
+from collections.abc import Mapping
+from typing import Any
+
+import jax
+from jax import numpy as jnp
+
+from jaqmc.array_types import Params, PRNGKey
+from jaqmc.data import Data
+from jaqmc.estimator.base import Estimator, PerWalkerEstimator, mean_reduce
+from jaqmc.utils import parallel_jax
+from jaqmc.utils.chunked_vmap import chunked_vmap
+from jaqmc.utils.config import configurable_dataclass
+from jaqmc.utils.subspace_linalg import (
+    complex_variance,
+    rayleigh_solve,
+    row_scaled_matrix,
+    singular_value_diagnostics,
+    solve_residual,
+)
+from jaqmc.utils.wiring import runtime_dep
+from jaqmc.wavefunction.determinant_state import SubspaceSpec, take_replica
+
+
+class CrossLocalEnergyEvaluator:
+    """Apply an existing JaQMC physical-energy pipeline to all ``(r, s)`` pairs."""
+
+    def __init__(
+        self,
+        estimators: Mapping[str, Estimator | Any],
+        spec: SubspaceSpec,
+        *,
+        pair_chunk_size: int | None = None,
+    ):
+        self.estimators = dict(estimators)
+        self.spec = spec
+        self.pair_chunk_size = pair_chunk_size
+        self._states: dict[str, Any] = {}
+
+    def init(self, replica_data: Data, rngs: PRNGKey) -> None:
+        """Initialize reused physical estimators from one physical replica."""
+        physical_data = take_replica(replica_data, 0, self.spec)
+        keys = jax.random.split(rngs, len(self.estimators))
+        self._states = {
+            name: estimator.init(physical_data, key)
+            if isinstance(estimator, Estimator)
+            else None
+            for (name, estimator), key in zip(self.estimators.items(), keys)
+        }
+        stateful = [name for name, state in self._states.items() if state is not None]
+        if stateful:
+            raise ValueError(
+                "CrossLocalEnergyEvaluator currently requires stateless physical "
+                f"estimators; got state from {stateful}"
+            )
+
+    def _single(
+        self, params: Params, data: Data, rngs: PRNGKey
+    ) -> jax.Array:
+        stats: dict[str, Any] = {}
+        keys = jax.random.split(rngs, len(self.estimators))
+        for (name, estimator), key in zip(self.estimators.items(), keys):
+            if isinstance(estimator, Estimator):
+                part, _ = estimator.evaluate_single_walker(
+                    params, data, stats, self._states.get(name), key
+                )
+            else:
+                part, _ = estimator(
+                    params, data, stats, self._states.get(name), key
+                )
+            stats.update(part)
+        if "total_energy" in stats:
+            return stats["total_energy"]
+        components = [
+            value for key, value in stats.items() if key.startswith("energy:")
+        ]
+        if not components:
+            raise ValueError("Physical estimator pipeline produced no energy values")
+        return sum(components[1:], start=components[0])
+
+    def __call__(
+        self, stacked_params: Params, replica_data: Data, rngs: PRNGKey
+    ) -> jax.Array:
+        """Return ``E_local[r, s]`` using flattened, optionally chunked pairs."""
+        m = self.spec.n_states
+        replica_indices = jnp.repeat(jnp.arange(m), m)
+        state_indices = jnp.tile(jnp.arange(m), m)
+        pair_params = jax.tree.map(lambda x: x[state_indices], stacked_params)
+        pair_data = dataclasses.replace(
+            replica_data,
+            **{
+                name: replica_data[name][replica_indices]
+                for name in self.spec.replica_fields
+            },
+        )
+        pair_axes = dataclasses.replace(
+            pair_data,
+            **{
+                name: 0 if name in self.spec.replica_fields else None
+                for name in pair_data.field_names
+            },
+        )
+        keys = jax.random.split(rngs, m * m)
+        values = chunked_vmap(
+            self._single,
+            in_axes=(0, pair_axes, 0),
+            chunk_size=self.pair_chunk_size,
+        )(pair_params, pair_data, keys)
+        return values.reshape(m, m)
+
+
+@configurable_dataclass
+class RayleighMatrixEstimator(PerWalkerEstimator):
+    """Estimate the determinant-state local Rayleigh matrix per walker."""
+
+    matrix_dtype: str = "complex128"
+    pair_chunk_size: int | None = None
+    condition_warning: float = 1e10
+    solve_residual_warning: float = 1e-6
+    max_imag_eigenvalue_warning: float = 1e-6
+    f_component_logpsi_matrix: Any = runtime_dep()
+    f_cross_local_energy: Any = runtime_dep()
+
+    def init(self, data: Data, rngs: PRNGKey) -> None:
+        if hasattr(self.f_cross_local_energy, "init"):
+            self.f_cross_local_energy.init(data, rngs)
+        return None
+
+    def evaluate_single_walker(
+        self,
+        params: Params,
+        data: Data,
+        prev_walker_stats: Mapping[str, Any],
+        state: None,
+        rngs: PRNGKey,
+    ) -> tuple[dict[str, Any], None]:
+        del prev_walker_stats
+        logs = self.f_component_logpsi_matrix(params, data)
+        phi, _ = row_scaled_matrix(logs)
+        dtype = jnp.dtype(self.matrix_dtype)
+        phi = phi.astype(dtype)
+        local_energy = self.f_cross_local_energy(params, data, rngs).astype(dtype)
+        phi_h = phi * local_energy
+        rayleigh = rayleigh_solve(phi, phi_h)
+        residual = solve_residual(phi, rayleigh, phi_h)
+        sigma_min, sigma_max, condition = singular_value_diagnostics(phi)
+        trace = jnp.trace(rayleigh)
+        return {
+            "local_rayleigh": rayleigh,
+            "subspace_energy": jnp.real(trace),
+            "subspace_energy_imag": jnp.imag(trace),
+            "rayleigh_solve_residual": residual,
+            "rayleigh_solve_residual_warning": (
+                ~jnp.isfinite(residual) | (residual > self.solve_residual_warning)
+            ),
+            "amplitude_sigma_min": sigma_min,
+            "amplitude_sigma_max": sigma_max,
+            "amplitude_condition": condition,
+            "amplitude_condition_warning": (
+                ~jnp.isfinite(condition) | (condition > self.condition_warning)
+            ),
+            "rayleigh_finite": jnp.all(jnp.isfinite(rayleigh)),
+        }, state
+
+    def reduce(self, walker_stats: Mapping[str, Any]) -> dict[str, Any]:
+        local_rayleigh = walker_stats["local_rayleigh"]
+        rayleigh_mean = parallel_jax.pmean(jnp.nanmean(local_rayleigh, axis=0))
+        rayleigh_var = parallel_jax.pmean(complex_variance(local_rayleigh, axis=0))
+        scalar_stats = {
+            key: value
+            for key, value in walker_stats.items()
+            if key != "local_rayleigh"
+        }
+        reduced = mean_reduce(scalar_stats)
+        eigenvalues, eigenvectors = jnp.linalg.eig(rayleigh_mean)
+        order = jnp.argsort(jnp.real(eigenvalues))
+        eigenvalues = eigenvalues[order]
+        eigenvectors = eigenvectors[:, order]
+        max_ritz_imag = jnp.max(jnp.abs(jnp.imag(eigenvalues)))
+        return {
+            **reduced,
+            "rayleigh_mean": rayleigh_mean,
+            "local_rayleigh_variance": rayleigh_var,
+            "ritz_energies": jnp.real(eigenvalues),
+            "ritz_energies_imag": jnp.imag(eigenvalues),
+            "ritz_vectors": eigenvectors,
+            "max_ritz_imag": max_ritz_imag,
+            "max_ritz_imag_warning": (
+                max_ritz_imag > self.max_imag_eigenvalue_warning
+            ),
+        }

--- a/src/jaqmc/estimator/rayleigh.py
+++ b/src/jaqmc/estimator/rayleigh.py
@@ -175,8 +175,6 @@ class RayleighMatrixEstimator(PerWalkerEstimator):
     matrix_dtype: str = "complex128"
     pair_chunk_size: int | None = None
     condition_warning: float = 1e10
-    condition_hard_limit: float = 1e14
-    min_valid_fraction: float = 0.99
     solve_residual_warning: float = 1e-6
     max_imag_eigenvalue_warning: float = 1e-6
     f_component_logpsi_matrix: Any = runtime_dep()
@@ -202,20 +200,29 @@ class RayleighMatrixEstimator(PerWalkerEstimator):
         phi = phi.astype(dtype)
         local_energy = self.f_cross_local_energy(params, data, rngs).astype(dtype)
         phi_h = phi * local_energy
-        sigma_min, sigma_max, condition = singular_value_diagnostics(phi)
-        matrix_finite = jnp.all(jnp.isfinite(phi)) & jnp.all(jnp.isfinite(phi_h))
-        condition_ok = jnp.isfinite(condition) & (
-            condition < self.condition_hard_limit
+        phi_finite = jnp.all(jnp.isfinite(phi))
+        # Derive the sentinel from ``phi`` so it inherits the same varying-axis
+        # annotation inside shard_map as the SVD branch outputs.
+        nan_real = jnp.real(phi[0, 0]) * 0 + jnp.nan
+        sigma_min, sigma_max, condition = jax.lax.cond(
+            phi_finite,
+            lambda _: singular_value_diagnostics(phi),
+            lambda _: (nan_real, nan_real, nan_real),
+            operand=None,
         )
-        solve_input_valid = matrix_finite & condition_ok
+        matrix_finite = jnp.all(jnp.isfinite(phi)) & jnp.all(jnp.isfinite(phi_h))
         rayleigh = jax.lax.cond(
-            solve_input_valid,
+            matrix_finite,
             lambda _: rayleigh_solve(phi, phi_h),
-            lambda _: jnp.zeros_like(phi_h),
+            lambda _: jnp.full_like(phi_h, jnp.nan),
             operand=None,
         )
         residual = solve_residual(phi, rayleigh, phi_h)
-        rayleigh_valid = solve_input_valid & jnp.all(jnp.isfinite(rayleigh))
+        rayleigh_valid = (
+            matrix_finite
+            & jnp.all(jnp.isfinite(rayleigh))
+            & jnp.isfinite(residual)
+        )
         trace = jnp.trace(rayleigh)
         return {
             "local_rayleigh": rayleigh,
@@ -241,18 +248,17 @@ class RayleighMatrixEstimator(PerWalkerEstimator):
         valid = walker_stats["rayleigh_valid"] & jnp.all(
             jnp.isfinite(local_rayleigh), axis=(-2, -1)
         )
-        mask = valid[:, None, None]
-        safe = jnp.where(mask, local_rayleigh, 0)
         local_count = jnp.sum(valid)
         global_count = parallel_jax.psum(local_count)
-        safe_count = jnp.maximum(global_count, 1)
-        rayleigh_mean = parallel_jax.psum(jnp.sum(safe, axis=0)) / safe_count
+        global_total = parallel_jax.psum(jnp.asarray(valid.shape[0]))
+        rayleigh_mean = (
+            parallel_jax.psum(jnp.sum(local_rayleigh, axis=0)) / global_total
+        )
         second_moment = (
-            parallel_jax.psum(jnp.sum(jnp.where(mask, jnp.abs(safe) ** 2, 0), axis=0))
-            / safe_count
+            parallel_jax.psum(jnp.sum(jnp.abs(local_rayleigh) ** 2, axis=0))
+            / global_total
         )
         rayleigh_var = jnp.maximum(second_moment - jnp.abs(rayleigh_mean) ** 2, 0)
-        global_total = parallel_jax.psum(jnp.asarray(valid.shape[0]))
         valid_fraction = global_count / global_total
         invalid_count = global_total - global_count
 
@@ -260,10 +266,19 @@ class RayleighMatrixEstimator(PerWalkerEstimator):
         for key, value in walker_stats.items():
             if key == "local_rayleigh":
                 continue
-            value_mask = valid.reshape((valid.shape[0],) + (1,) * (value.ndim - 1))
-            masked = jnp.where(value_mask, value, jnp.nan)
-            reduced[key] = parallel_jax.pmean(jnp.nanmean(masked, axis=0))
-        eigenvalues, eigenvectors = jnp.linalg.eig(rayleigh_mean)
+            reduced[key] = (
+                parallel_jax.psum(jnp.sum(value, axis=0)) / global_total
+            )
+        subspace_energy = walker_stats["subspace_energy"]
+        energy_second_moment = (
+            parallel_jax.psum(jnp.sum(subspace_energy**2, axis=0)) / global_total
+        )
+        reduced["subspace_energy_var"] = jnp.maximum(
+            energy_second_moment - reduced["subspace_energy"] ** 2, 0
+        )
+        step_valid = global_count == global_total
+        eig_input = jnp.where(step_valid, rayleigh_mean, jnp.zeros_like(rayleigh_mean))
+        eigenvalues, eigenvectors = jnp.linalg.eig(eig_input)
         order = jnp.argsort(jnp.real(eigenvalues))
         eigenvalues = eigenvalues[order]
         eigenvectors = eigenvectors[:, order]
@@ -274,8 +289,7 @@ class RayleighMatrixEstimator(PerWalkerEstimator):
             "local_rayleigh_variance": rayleigh_var,
             "rayleigh_valid_fraction": valid_fraction,
             "rayleigh_invalid_count": invalid_count,
-            "training_step_valid": (global_count > 0)
-            & (valid_fraction >= self.min_valid_fraction),
+            "training_step_valid": step_valid,
             "ritz_energies": jnp.real(eigenvalues),
             "ritz_energies_imag": jnp.imag(eigenvalues),
             "ritz_vectors": eigenvectors,

--- a/src/jaqmc/estimator/rayleigh.py
+++ b/src/jaqmc/estimator/rayleigh.py
@@ -3,8 +3,8 @@
 
 """Rayleigh-matrix estimators built from JaQMC physical-energy components."""
 
-import dataclasses
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any
 
 import jax
@@ -12,19 +12,34 @@ from jax import numpy as jnp
 
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import Data
-from jaqmc.estimator.base import Estimator, PerWalkerEstimator, mean_reduce
+from jaqmc.estimator.base import Estimator, PerWalkerEstimator
 from jaqmc.utils import parallel_jax
 from jaqmc.utils.chunked_vmap import chunked_vmap
 from jaqmc.utils.config import configurable_dataclass
 from jaqmc.utils.subspace_linalg import (
-    complex_variance,
     rayleigh_solve,
     row_scaled_matrix,
     singular_value_diagnostics,
     solve_residual,
 )
 from jaqmc.utils.wiring import runtime_dep
-from jaqmc.wavefunction.determinant_state import SubspaceSpec, take_replica
+from jaqmc.wavefunction.determinant_state import (
+    SubspaceSpec,
+    take_replica,
+    take_replica_dynamic,
+)
+
+
+@dataclass(frozen=True)
+class PhysicalEnergyPlan:
+    """Classify native estimators by their replica/state dependence."""
+
+    replica_only: tuple[str, ...] = ("potential",)
+
+    def split(self, estimators: Mapping[str, Any]):
+        replica_only = tuple(name for name in estimators if name in self.replica_only)
+        pair_dependent = tuple(name for name in estimators if name not in replica_only)
+        return replica_only, pair_dependent
 
 
 class CrossLocalEnergyEvaluator:
@@ -36,10 +51,13 @@ class CrossLocalEnergyEvaluator:
         spec: SubspaceSpec,
         *,
         pair_chunk_size: int | None = None,
+        plan: PhysicalEnergyPlan | None = None,
     ):
         self.estimators = dict(estimators)
         self.spec = spec
         self.pair_chunk_size = pair_chunk_size
+        self.plan = plan or PhysicalEnergyPlan()
+        self.replica_only, self.pair_dependent = self.plan.split(self.estimators)
         self._states: dict[str, Any] = {}
 
     def init(self, replica_data: Data, rngs: PRNGKey) -> None:
@@ -59,12 +77,18 @@ class CrossLocalEnergyEvaluator:
                 f"estimators; got state from {stateful}"
             )
 
-    def _single(
-        self, params: Params, data: Data, rngs: PRNGKey
-    ) -> jax.Array:
-        stats: dict[str, Any] = {}
+    def _run_names(
+        self,
+        names: tuple[str, ...],
+        params: Params,
+        data: Data,
+        stats: dict[str, Any],
+        rngs: PRNGKey,
+    ) -> dict[str, Any]:
         keys = jax.random.split(rngs, len(self.estimators))
         for (name, estimator), key in zip(self.estimators.items(), keys):
+            if name not in names:
+                continue
             if isinstance(estimator, Estimator):
                 part, _ = estimator.evaluate_single_walker(
                     params, data, stats, self._states.get(name), key
@@ -74,6 +98,43 @@ class CrossLocalEnergyEvaluator:
                     params, data, stats, self._states.get(name), key
                 )
             stats.update(part)
+        return stats
+
+    def _replica_stats(
+        self, stacked_params: Params, replica_data: Data, replica_index: jax.Array,
+        rngs: PRNGKey,
+    ) -> dict[str, Any]:
+        params = jax.tree.map(
+            lambda x: jax.lax.dynamic_index_in_dim(x, 0, axis=0, keepdims=False),
+            stacked_params,
+        )
+        data = take_replica_dynamic(replica_data, replica_index, self.spec)
+        return self._run_names(self.replica_only, params, data, {}, rngs)
+
+    def _pair_local_energy(
+        self,
+        stacked_params: Params,
+        replica_data: Data,
+        replica_stats: Mapping[str, Any],
+        pair_index: jax.Array,
+        rngs: PRNGKey,
+    ) -> jax.Array:
+        m = self.spec.n_states
+        replica_index, state_index = pair_index // m, pair_index % m
+        params = jax.tree.map(
+            lambda x: jax.lax.dynamic_index_in_dim(
+                x, state_index, axis=0, keepdims=False
+            ),
+            stacked_params,
+        )
+        data = take_replica_dynamic(replica_data, replica_index, self.spec)
+        stats = jax.tree.map(
+            lambda x: jax.lax.dynamic_index_in_dim(
+                x, replica_index, axis=0, keepdims=False
+            ),
+            dict(replica_stats),
+        )
+        stats = self._run_names(self.pair_dependent, params, data, stats, rngs)
         if "total_energy" in stats:
             return stats["total_energy"]
         components = [
@@ -88,29 +149,22 @@ class CrossLocalEnergyEvaluator:
     ) -> jax.Array:
         """Return ``E_local[r, s]`` using flattened, optionally chunked pairs."""
         m = self.spec.n_states
-        replica_indices = jnp.repeat(jnp.arange(m), m)
-        state_indices = jnp.tile(jnp.arange(m), m)
-        pair_params = jax.tree.map(lambda x: x[state_indices], stacked_params)
-        pair_data = dataclasses.replace(
+        replica_rngs, pair_rngs = jax.random.split(rngs)
+        replica_stats = jax.vmap(
+            self._replica_stats, in_axes=(None, None, 0, 0)
+        )(
+            stacked_params,
             replica_data,
-            **{
-                name: replica_data[name][replica_indices]
-                for name in self.spec.replica_fields
-            },
+            jnp.arange(m),
+            jax.random.split(replica_rngs, m),
         )
-        pair_axes = dataclasses.replace(
-            pair_data,
-            **{
-                name: 0 if name in self.spec.replica_fields else None
-                for name in pair_data.field_names
-            },
-        )
-        keys = jax.random.split(rngs, m * m)
+        pair_indices = jnp.arange(m * m)
+        keys = jax.random.split(pair_rngs, m * m)
         values = chunked_vmap(
-            self._single,
-            in_axes=(0, pair_axes, 0),
+            self._pair_local_energy,
+            in_axes=(None, None, None, 0, 0),
             chunk_size=self.pair_chunk_size,
-        )(pair_params, pair_data, keys)
+        )(stacked_params, replica_data, replica_stats, pair_indices, keys)
         return values.reshape(m, m)
 
 
@@ -121,6 +175,8 @@ class RayleighMatrixEstimator(PerWalkerEstimator):
     matrix_dtype: str = "complex128"
     pair_chunk_size: int | None = None
     condition_warning: float = 1e10
+    condition_hard_limit: float = 1e14
+    min_valid_fraction: float = 0.99
     solve_residual_warning: float = 1e-6
     max_imag_eigenvalue_warning: float = 1e-6
     f_component_logpsi_matrix: Any = runtime_dep()
@@ -146,12 +202,24 @@ class RayleighMatrixEstimator(PerWalkerEstimator):
         phi = phi.astype(dtype)
         local_energy = self.f_cross_local_energy(params, data, rngs).astype(dtype)
         phi_h = phi * local_energy
-        rayleigh = rayleigh_solve(phi, phi_h)
-        residual = solve_residual(phi, rayleigh, phi_h)
         sigma_min, sigma_max, condition = singular_value_diagnostics(phi)
+        matrix_finite = jnp.all(jnp.isfinite(phi)) & jnp.all(jnp.isfinite(phi_h))
+        condition_ok = jnp.isfinite(condition) & (
+            condition < self.condition_hard_limit
+        )
+        solve_input_valid = matrix_finite & condition_ok
+        rayleigh = jax.lax.cond(
+            solve_input_valid,
+            lambda _: rayleigh_solve(phi, phi_h),
+            lambda _: jnp.zeros_like(phi_h),
+            operand=None,
+        )
+        residual = solve_residual(phi, rayleigh, phi_h)
+        rayleigh_valid = solve_input_valid & jnp.all(jnp.isfinite(rayleigh))
         trace = jnp.trace(rayleigh)
         return {
             "local_rayleigh": rayleigh,
+            "subspace_local_energy": trace,
             "subspace_energy": jnp.real(trace),
             "subspace_energy_imag": jnp.imag(trace),
             "rayleigh_solve_residual": residual,
@@ -164,19 +232,37 @@ class RayleighMatrixEstimator(PerWalkerEstimator):
             "amplitude_condition_warning": (
                 ~jnp.isfinite(condition) | (condition > self.condition_warning)
             ),
-            "rayleigh_finite": jnp.all(jnp.isfinite(rayleigh)),
+            "rayleigh_finite": rayleigh_valid,
+            "rayleigh_valid": rayleigh_valid,
         }, state
 
     def reduce(self, walker_stats: Mapping[str, Any]) -> dict[str, Any]:
         local_rayleigh = walker_stats["local_rayleigh"]
-        rayleigh_mean = parallel_jax.pmean(jnp.nanmean(local_rayleigh, axis=0))
-        rayleigh_var = parallel_jax.pmean(complex_variance(local_rayleigh, axis=0))
-        scalar_stats = {
-            key: value
-            for key, value in walker_stats.items()
-            if key != "local_rayleigh"
-        }
-        reduced = mean_reduce(scalar_stats)
+        valid = walker_stats["rayleigh_valid"] & jnp.all(
+            jnp.isfinite(local_rayleigh), axis=(-2, -1)
+        )
+        mask = valid[:, None, None]
+        safe = jnp.where(mask, local_rayleigh, 0)
+        local_count = jnp.sum(valid)
+        global_count = parallel_jax.psum(local_count)
+        safe_count = jnp.maximum(global_count, 1)
+        rayleigh_mean = parallel_jax.psum(jnp.sum(safe, axis=0)) / safe_count
+        second_moment = (
+            parallel_jax.psum(jnp.sum(jnp.where(mask, jnp.abs(safe) ** 2, 0), axis=0))
+            / safe_count
+        )
+        rayleigh_var = jnp.maximum(second_moment - jnp.abs(rayleigh_mean) ** 2, 0)
+        global_total = parallel_jax.psum(jnp.asarray(valid.shape[0]))
+        valid_fraction = global_count / global_total
+        invalid_count = global_total - global_count
+
+        reduced = {}
+        for key, value in walker_stats.items():
+            if key == "local_rayleigh":
+                continue
+            value_mask = valid.reshape((valid.shape[0],) + (1,) * (value.ndim - 1))
+            masked = jnp.where(value_mask, value, jnp.nan)
+            reduced[key] = parallel_jax.pmean(jnp.nanmean(masked, axis=0))
         eigenvalues, eigenvectors = jnp.linalg.eig(rayleigh_mean)
         order = jnp.argsort(jnp.real(eigenvalues))
         eigenvalues = eigenvalues[order]
@@ -186,6 +272,10 @@ class RayleighMatrixEstimator(PerWalkerEstimator):
             **reduced,
             "rayleigh_mean": rayleigh_mean,
             "local_rayleigh_variance": rayleigh_var,
+            "rayleigh_valid_fraction": valid_fraction,
+            "rayleigh_invalid_count": invalid_count,
+            "training_step_valid": (global_count > 0)
+            & (valid_fraction >= self.min_valid_fraction),
             "ritz_energies": jnp.real(eigenvalues),
             "ritz_energies_imag": jnp.imag(eigenvalues),
             "ritz_vectors": eigenvectors,

--- a/src/jaqmc/estimator/rayleigh.py
+++ b/src/jaqmc/estimator/rayleigh.py
@@ -3,7 +3,7 @@
 
 """Rayleigh-matrix estimators built from JaQMC physical-energy components."""
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -28,6 +28,53 @@ from jaqmc.wavefunction.determinant_state import (
     take_replica,
     take_replica_dynamic,
 )
+
+
+def grassmann_hamiltonian_statistics(
+    local_rayleigh: jax.Array,
+    *,
+    mean_fn: Callable[[jax.Array], jax.Array] | None = None,
+) -> dict[str, jax.Array]:
+    r"""Compute Grassmann Hamiltonian-variance statistics.
+
+    This is the estimator used by Grassmann VMC to diagnose whether the
+    variational span is invariant under the Hamiltonian.  ``mean_fn`` consumes
+    the leading walker axis; callers may supply a distributed global mean.
+
+    Args:
+        local_rayleigh: Local Rayleigh matrices with shape ``[B, M, M]``.
+        mean_fn: Optional leading-axis mean implementation.
+
+    Returns:
+        The average energy, variance matrix, scalar variance, and standard
+        deviation.  The scalar variance is not clipped; only the square root
+        clips small negative Monte Carlo roundoff.
+    """
+    if local_rayleigh.ndim != 3:
+        raise ValueError(
+            "local_rayleigh must have shape [walkers, states, states]; "
+            f"got {local_rayleigh.shape}."
+        )
+    if local_rayleigh.shape[-2] != local_rayleigh.shape[-1]:
+        raise ValueError("local_rayleigh matrices must be square.")
+    mean = mean_fn or (lambda value: jnp.mean(value, axis=0))
+    local_trace = jnp.trace(local_rayleigh, axis1=-2, axis2=-1)
+    rayleigh_mean = mean(local_rayleigh)
+    trace_mean = mean(local_trace)
+    rayleigh_trace_mean = mean(
+        local_rayleigh * jnp.conj(local_trace)[..., None, None]
+    )
+    variance_matrix = (
+        rayleigh_trace_mean - rayleigh_mean * jnp.conj(trace_mean)
+    )
+    n_states = local_rayleigh.shape[-1]
+    variance = jnp.real(jnp.trace(variance_matrix)) / n_states
+    return {
+        "grassmann_average_energy": jnp.trace(rayleigh_mean) / n_states,
+        "grassmann_hamiltonian_variance_matrix": variance_matrix,
+        "grassmann_hamiltonian_variance": variance,
+        "grassmann_hamiltonian_std": jnp.sqrt(jnp.maximum(variance, 0)),
+    }
 
 
 @dataclass(frozen=True)
@@ -276,6 +323,13 @@ class RayleighMatrixEstimator(PerWalkerEstimator):
         reduced["subspace_energy_var"] = jnp.maximum(
             energy_second_moment - reduced["subspace_energy"] ** 2, 0
         )
+
+        def global_mean(value):
+            return parallel_jax.psum(jnp.sum(value, axis=0)) / global_total
+
+        grassmann_stats = grassmann_hamiltonian_statistics(
+            local_rayleigh, mean_fn=global_mean
+        )
         step_valid = global_count == global_total
         eig_input = jnp.where(step_valid, rayleigh_mean, jnp.zeros_like(rayleigh_mean))
         eigenvalues, eigenvectors = jnp.linalg.eig(eig_input)
@@ -285,6 +339,7 @@ class RayleighMatrixEstimator(PerWalkerEstimator):
         max_ritz_imag = jnp.max(jnp.abs(jnp.imag(eigenvalues)))
         return {
             **reduced,
+            **grassmann_stats,
             "rayleigh_mean": rayleigh_mean,
             "local_rayleigh_variance": rayleigh_var,
             "rayleigh_valid_fraction": valid_fraction,

--- a/src/jaqmc/estimator/streaming_loss_grad.py
+++ b/src/jaqmc/estimator/streaming_loss_grad.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Memory-conservative VMC loss-gradient estimator."""
+
+import dataclasses
+from collections.abc import Mapping
+from functools import partial
+from typing import Any, Literal
+
+import jax
+from jax import numpy as jnp
+
+from jaqmc.array_types import Params, PRNGKey
+from jaqmc.data import BatchedData
+from jaqmc.estimator._loss_grad import vmc_energy_gradient
+from jaqmc.estimator.base import Estimator
+from jaqmc.utils import parallel_jax
+from jaqmc.utils.array import match_first_axis_of
+from jaqmc.utils.clip import clip_observable
+from jaqmc.utils.config import configurable_dataclass
+from jaqmc.utils.func_transform import transform_maybe_complex
+from jaqmc.utils.wiring import runtime_dep
+from jaqmc.wavefunction.base import NumericWavefunctionEvaluate
+
+
+@configurable_dataclass
+class StreamingLossAndGrad(Estimator):
+    """Compute VMC gradients with chunk-local sufficient-statistic reduction.
+
+    Unlike :class:`~jaqmc.estimator.loss_grad.LossAndGrad`, this estimator
+    never materializes a ``[walkers, ...parameters]`` gradient tree. Each
+    chunk's per-walker gradients are reduced immediately inside ``lax.scan``.
+
+    The estimator is wavefunction- and objective-agnostic: ``loss_key`` may
+    name any scalar per-walker objective, including ordinary ground-state VMC.
+    """
+
+    loss_key: str = "total_energy"
+    vmap_chunk_size: int | None = None
+    clip_method: Literal["iqr", "mad", "none"] = "mad"
+    clip_scale: float = 5.0
+    f_log_psi: NumericWavefunctionEvaluate = runtime_dep()
+
+    def evaluate_batch_walkers(
+        self,
+        params: Params,
+        batched_data: BatchedData,
+        prev_walker_stats: Mapping[str, Any],
+        state: None,
+        rngs: PRNGKey,
+    ) -> tuple[dict[str, Any], None]:
+        del rngs
+        loss = prev_walker_stats[self.loss_key]
+        if loss.ndim != 1:
+            raise ValueError(
+                f"Expected one scalar loss per walker, got shape {loss.shape}."
+            )
+        batch_size = batched_data.batch_size
+        if batch_size < 1:
+            raise ValueError("StreamingLossAndGrad requires a non-empty batch.")
+        chunk_size = self.vmap_chunk_size or batch_size
+        if chunk_size < 1:
+            raise ValueError("vmap_chunk_size must be positive or None.")
+        chunk_size = min(chunk_size, batch_size)
+        n_chunks = (batch_size + chunk_size - 1) // chunk_size
+        padded_size = n_chunks * chunk_size
+        pad_size = padded_size - batch_size
+
+        clipped_loss = clip_observable(
+            loss, self.clip_method, scale=self.clip_scale
+        )
+
+        def pad_leaf(x):
+            if pad_size == 0:
+                return x
+            pad_width = ((0, pad_size),) + ((0, 0),) * (x.ndim - 1)
+            return jnp.pad(x, pad_width, mode="edge")
+
+        padded_data = dataclasses.replace(
+            batched_data.data,
+            **{
+                name: jax.tree.map(pad_leaf, batched_data.data[name])
+                for name in batched_data.fields_with_batch
+            },
+        )
+        padded_loss = pad_leaf(clipped_loss)
+        padded_mask = jnp.arange(padded_size) < batch_size
+
+        value_and_grad_f = transform_maybe_complex(
+            self.f_log_psi, jax.value_and_grad
+        )
+        grad_shape = jax.eval_shape(
+            lambda p, d: value_and_grad_f(p, d)[1],
+            params,
+            batched_data.unbatched_example(),
+        )
+        sum_grad = jax.tree.map(
+            lambda x: jnp.zeros(x.shape, x.dtype), grad_shape
+        )
+        sum_grad_loss = jax.tree.map(
+            lambda x: jnp.zeros(x.shape, jnp.real(jnp.zeros((), x.dtype)).dtype),
+            grad_shape,
+        )
+        # Chunk sums vary across data shards even though parameters are shared.
+        # Mark the scan carry accordingly so shard_map VMA stays stable.
+        sum_grad = parallel_jax.pvary(sum_grad)
+        sum_grad_loss = parallel_jax.pvary(sum_grad_loss)
+        vmap_axis = batched_data.vmap_axis
+        vmapped_grad = jax.vmap(value_and_grad_f, in_axes=(None, vmap_axis))
+
+        def scan_body(carry, chunk_index):
+            start = chunk_index * chunk_size
+            chunk_data = dataclasses.replace(
+                padded_data,
+                **{
+                    name: jax.tree.map(
+                        lambda x: jax.lax.dynamic_slice_in_dim(
+                            x, start, chunk_size, axis=0
+                        ),
+                        padded_data[name],
+                    )
+                    for name in batched_data.fields_with_batch
+                },
+            )
+            loss_chunk = jax.lax.dynamic_slice_in_dim(
+                padded_loss, start, chunk_size, axis=0
+            )
+            mask_chunk = jax.lax.dynamic_slice_in_dim(
+                padded_mask, start, chunk_size, axis=0
+            )
+            _, grads = vmapped_grad(parallel_jax.pvary(params), chunk_data)
+            grads = jax.tree.map(
+                lambda x: jnp.where(match_first_axis_of(mask_chunk, x), x, 0),
+                grads,
+            )
+            grad_loss = jax.tree.map(
+                lambda x: jnp.real(
+                    jnp.conj(x) * match_first_axis_of(loss_chunk, x)
+                ).astype(jnp.real(x).dtype),
+                grads,
+            )
+            chunk_sum_grad = jax.tree.map(lambda x: jnp.sum(x, axis=0), grads)
+            chunk_sum_grad_loss = jax.tree.map(
+                lambda x: jnp.sum(x, axis=0), grad_loss
+            )
+            return (
+                jax.tree.map(jnp.add, carry[0], chunk_sum_grad),
+                jax.tree.map(jnp.add, carry[1], chunk_sum_grad_loss),
+            ), None
+
+        (sum_grad, sum_grad_loss), _ = jax.lax.scan(
+            scan_body, (sum_grad, sum_grad_loss), jnp.arange(n_chunks)
+        )
+        return {
+            "sum_grad_logpsi": sum_grad,
+            "sum_grad_logpsi_and_loss": sum_grad_loss,
+            "sum_loss": jnp.sum(loss),
+            "sum_clipped_loss": jnp.sum(clipped_loss),
+            "count": jnp.asarray(batch_size),
+        }, state
+
+    def reduce(self, stats: Mapping[str, Any]) -> dict[str, Any]:
+        """Reduce local sums using global sum/count collectives."""
+        count = parallel_jax.psum(stats["count"])
+        return {
+            "grad_logpsi": jax.tree.map(
+                lambda x: parallel_jax.psum(x) / count,
+                stats["sum_grad_logpsi"],
+            ),
+            "grad_logpsi_and_loss": jax.tree.map(
+                lambda x: parallel_jax.psum(x) / count,
+                stats["sum_grad_logpsi_and_loss"],
+            ),
+            "loss": parallel_jax.psum(stats["sum_loss"]) / count,
+            "clipped_loss": (
+                parallel_jax.psum(stats["sum_clipped_loss"]) / count
+            ),
+        }
+
+    def finalize_stats(
+        self, batch_stats: Mapping[str, Any], state: None
+    ) -> dict[str, Any]:
+        del state
+        batch_mean = partial(jnp.mean, axis=0)
+        grad_logpsi_and_loss = jax.tree.map(
+            batch_mean, batch_stats["grad_logpsi_and_loss"]
+        )
+        grad_logpsi = jax.tree.map(batch_mean, batch_stats["grad_logpsi"])
+        clipped_loss = batch_mean(batch_stats["clipped_loss"])
+        loss = batch_mean(batch_stats["loss"])
+        return {
+            "loss": loss,
+            "grads": vmc_energy_gradient(
+                grad_logpsi, grad_logpsi_and_loss, clipped_loss
+            ),
+        }

--- a/src/jaqmc/optimizer/gvmc_reference_sr.py
+++ b/src/jaqmc/optimizer/gvmc_reference_sr.py
@@ -37,6 +37,17 @@ __all__ = [
 ]
 
 
+def _native_vmc_to_gvmc_gradient(gradient: jax.Array) -> jax.Array:
+    r"""Convert JaQMC's energy-gradient convention to the GVMC force form.
+
+    JaQMC's VMC estimators return ``2 Re[J^H B]`` for real parameters, while
+    the GVMC minimum-SR source equation is written for ``Re[J^H B]``.  Keep
+    this convention conversion at the reference-backend adapter boundary so
+    neither the native estimator nor the generic optimizer contract changes.
+    """
+    return 0.5 * gradient
+
+
 def _sample_matrix(jacobian: jax.Array, lam0: float, lam1: float) -> jax.Array:
     """Build the regularized sample-space matrix used by GVMC."""
     n_samples = jacobian.shape[0]
@@ -126,7 +137,11 @@ class GVMCReferenceSROptimizer:
 
     For production, use :class:`jaqmc.optimizer.sr.SROptimizer`; it evaluates
     the same Grassmann score while adding distributed reductions, chunked Gram
-    construction, mixed precision, and robust stabilization.
+    construction, mixed precision, and robust stabilization.  The native
+    ``OptimizerLike`` gradient supplied to :meth:`update` follows JaQMC's
+    ``2 Re[J^H B]`` VMC convention.  This adapter divides it by two before
+    applying the GVMC source equation, whose reduced gradient is
+    ``Re[J^H B]``.  ``previous_delta`` is therefore stored in GVMC convention.
 
     Args:
         learning_rate: Constant update step used by the GVMC reference code.
@@ -240,7 +255,8 @@ class GVMCReferenceSROptimizer:
             raise RuntimeError(
                 "GVMCReferenceSROptimizer.init must be called before update"
             )
-        gradient, unravel = ravel_pytree(grads)
+        native_gradient, unravel = ravel_pytree(grads)
+        gradient = _native_vmc_to_gvmc_gradient(native_gradient)
         score = self._score_matrix(params, batched_data)
         metric_previous = score @ state.previous_delta
         residual_gradient = (

--- a/src/jaqmc/optimizer/gvmc_reference_sr.py
+++ b/src/jaqmc/optimizer/gvmc_reference_sr.py
@@ -1,0 +1,263 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small-system reference SR backend for determinant-state Grassmann VMC.
+
+The production Grassmann optimizer is JaQMC's existing distributed
+``SROptimizer`` applied to the determinant-state log amplitude.  This module
+implements the sample-space equations used by the accompanying GVMC research
+code as a transparent numerical oracle and A/B backend.  It deliberately does
+not replace or modify JaQMC's SR implementation.  The reference snapshot is
+``cqsl/GVMC@e68e503``; the equations are independently expressed here because
+that repository does not currently declare a software license.
+"""
+
+import math
+from typing import Any, NamedTuple
+
+import jax
+from jax import numpy as jnp
+from jax import scipy as jsp
+from jax.flatten_util import ravel_pytree
+
+from jaqmc.array_types import Params
+from jaqmc.data import BatchedData
+from jaqmc.utils.chunked_vmap import chunked_vmap
+from jaqmc.utils.config import configurable_dataclass
+from jaqmc.utils.func_transform import grad_maybe_complex
+from jaqmc.utils.wiring import runtime_dep
+from jaqmc.wavefunction.base import NumericWavefunctionEvaluate
+
+__all__ = [
+    "GVMCReferenceSROptimizer",
+    "GVMCReferenceSRState",
+    "minsr_solve",
+    "minsr_solve_gradient",
+    "minsr_solve_kacz",
+]
+
+
+def _sample_matrix(jacobian: jax.Array, lam0: float, lam1: float) -> jax.Array:
+    """Build the regularized sample-space matrix used by GVMC."""
+    n_samples = jacobian.shape[0]
+    scale = jnp.linalg.norm(jacobian) ** 2 / n_samples
+    matrix = jacobian @ jnp.conj(jacobian.T)
+    matrix = matrix + scale * (lam1 / n_samples)
+    return matrix + lam0 * jnp.eye(n_samples, dtype=matrix.dtype)
+
+
+def minsr_solve(
+    jacobian: jax.Array,
+    force: jax.Array,
+    *,
+    lam0: float = 1e-4,
+    lam1: float = 1.0,
+) -> jax.Array:
+    r"""Solve the GVMC sample-space minimum-SR equation.
+
+    Computes ``J^H A^-1 force`` with
+    ``A = J J^H + lam1 * ||J||^2 / n^2 + lam0 I``.  The ``lam1`` term is the
+    scalar all-ones shift used by the reference implementation, rather than a
+    second diagonal shift.
+    """
+    if jacobian.ndim != 2:
+        raise ValueError("jacobian must be a rank-2 matrix")
+    if force.shape != (jacobian.shape[0],):
+        raise ValueError(
+            f"force must have shape {(jacobian.shape[0],)}, got {force.shape}"
+        )
+    factor = jsp.linalg.cho_factor(_sample_matrix(jacobian, lam0, lam1))
+    return jnp.conj(jacobian.T) @ jsp.linalg.cho_solve(factor, force)
+
+
+def minsr_solve_kacz(
+    jacobian: jax.Array,
+    force: jax.Array,
+    previous_delta: jax.Array,
+    *,
+    lam0: float = 1e-4,
+    lam1: float = 1.0,
+    mu: float = 0.99,
+) -> jax.Array:
+    """Apply the GVMC Kaczmarz/SPRING continuation equation."""
+    residual_force = force - mu * (jacobian @ previous_delta)
+    return (
+        minsr_solve(jacobian, residual_force, lam0=lam0, lam1=lam1)
+        + mu * previous_delta
+    )
+
+
+def minsr_solve_gradient(
+    jacobian: jax.Array,
+    gradient: jax.Array,
+    *,
+    lam0: float = 1e-4,
+    lam1: float = 1.0,
+) -> jax.Array:
+    r"""Apply the same minimum-SR solve to an already reduced VMC gradient.
+
+    If ``gradient = J^H force``, the matrix inversion lemma makes this exactly
+    equivalent to :func:`minsr_solve`.  This form preserves JaQMC's native
+    ``OptimizerLike`` contract, whose optimizer receives a parameter-shaped
+    energy gradient rather than the per-walker local-energy force.
+    """
+    if lam0 <= 0:
+        raise ValueError("lam0 must be positive for the gradient-form solve")
+    if gradient.shape != (jacobian.shape[1],):
+        raise ValueError(
+            f"gradient must have shape {(jacobian.shape[1],)}, got {gradient.shape}"
+        )
+    factor = jsp.linalg.cho_factor(_sample_matrix(jacobian, lam0, lam1))
+    projected = jacobian @ gradient
+    correction = jnp.conj(jacobian.T) @ jsp.linalg.cho_solve(factor, projected)
+    return (gradient - correction) / lam0
+
+
+class GVMCReferenceSRState(NamedTuple):
+    """Optimizer state containing the step counter and previous SR direction."""
+
+    counter: jax.Array
+    previous_delta: jax.Array
+
+
+@configurable_dataclass
+class GVMCReferenceSROptimizer:
+    """Source-equation Grassmann SR backend for single-device A/B tests.
+
+    For production, use :class:`jaqmc.optimizer.sr.SROptimizer`; it evaluates
+    the same Grassmann score while adding distributed reductions, chunked Gram
+    construction, mixed precision, and robust stabilization.
+
+    Args:
+        learning_rate: Constant update step used by the GVMC reference code.
+        lam0: Diagonal sample-space regularization.
+        lam1: Centered-score null-direction regularization.
+        mu: Kaczmarz/SPRING continuation coefficient.
+        scale_lr_by_sqrt_n_states: Apply the reference ``1 / sqrt(M)`` scaling.
+        n_states: Optional explicit state count. By default it is inferred from
+            the leading axis shared by every determinant-state parameter leaf.
+        score_chunk_size: Optional chunk size for score evaluation.
+        f_log_psi: Runtime-wired determinant log amplitude.
+    """
+
+    learning_rate: float = 0.1
+    lam0: float = 1e-3
+    lam1: float = 1.0
+    mu: float = 0.9
+    scale_lr_by_sqrt_n_states: bool = True
+    n_states: int | None = None
+    score_chunk_size: int | None = None
+    f_log_psi: NumericWavefunctionEvaluate = runtime_dep()
+
+    def __post_init__(self):
+        if self.learning_rate <= 0:
+            raise ValueError("learning_rate must be positive")
+        if self.lam0 <= 0:
+            raise ValueError("lam0 must be positive")
+        if self.lam1 < 0:
+            raise ValueError("lam1 must be non-negative")
+        if not 0 <= self.mu < 1:
+            raise ValueError("mu must satisfy 0 <= mu < 1")
+        if self.n_states is not None and self.n_states < 1:
+            raise ValueError("n_states must be positive or None")
+        if self.score_chunk_size is not None and self.score_chunk_size < 1:
+            raise ValueError("score_chunk_size must be positive or None")
+
+    def _infer_n_states(self, params: Params) -> int:
+        leaves = jax.tree.leaves(params)
+        leading_sizes = {
+            leaf.shape[0] for leaf in leaves if leaf.ndim > 0
+        }
+        if self.n_states is not None:
+            if leading_sizes != {self.n_states} or any(
+                leaf.ndim == 0 for leaf in leaves
+            ):
+                raise ValueError(
+                    "train.optim.n_states does not match the leading state "
+                    "axis of every parameter leaf."
+                )
+            return self.n_states
+        if len(leading_sizes) != 1:
+            raise ValueError(
+                "Cannot infer n_states: determinant-state parameter leaves do "
+                "not share one leading state axis. Set train.optim.n_states."
+            )
+        return leading_sizes.pop()
+
+    def init(
+        self,
+        params: Params,
+        *,
+        batched_data: BatchedData,
+        **extra: Any,
+    ) -> GVMCReferenceSRState:
+        """Initialize the previous-direction state."""
+        del batched_data, extra
+        if jax.device_count() != 1:
+            raise NotImplementedError(
+                "GVMCReferenceSROptimizer is a single-device numerical oracle; "
+                "use jaqmc.optimizer.sr:SROptimizer for multi-device runs."
+            )
+        flat, _ = ravel_pytree(params)
+        if jnp.iscomplexobj(flat):
+            raise NotImplementedError(
+                "GVMCReferenceSROptimizer currently requires real parameters."
+            )
+        self._resolved_n_states = self._infer_n_states(params)
+        return GVMCReferenceSRState(
+            counter=jnp.asarray(0, dtype=jnp.int32),
+            previous_delta=jnp.zeros_like(flat),
+        )
+
+    def _score_matrix(self, params: Params, batched_data: BatchedData) -> jax.Array:
+        score_fn = grad_maybe_complex(self.f_log_psi)
+        score_tree = chunked_vmap(
+            lambda sample: score_fn(params, sample),
+            in_axes=(batched_data.vmap_axis,),
+            out_axes=0,
+            chunk_size=self.score_chunk_size,
+        )(batched_data.data)
+        score = jax.vmap(lambda tree: ravel_pytree(tree)[0])(score_tree)
+        score = (score - jnp.mean(score, axis=0, keepdims=True)) / math.sqrt(
+            batched_data.batch_size
+        )
+        if jnp.iscomplexobj(score):
+            score = jnp.concatenate((jnp.real(score), jnp.imag(score)), axis=0)
+        return score
+
+    def update(
+        self,
+        grads: Params,
+        state: GVMCReferenceSRState,
+        params: Params,
+        *,
+        batched_data: BatchedData,
+        **extra: Any,
+    ) -> tuple[Params, GVMCReferenceSRState]:
+        """Return a reference Grassmann-SR parameter update."""
+        del extra
+        if not hasattr(self, "_resolved_n_states"):
+            raise RuntimeError(
+                "GVMCReferenceSROptimizer.init must be called before update"
+            )
+        gradient, unravel = ravel_pytree(grads)
+        score = self._score_matrix(params, batched_data)
+        metric_previous = score @ state.previous_delta
+        residual_gradient = (
+            gradient
+            - self.mu * (jnp.conj(score.T) @ metric_previous)
+        )
+        delta = minsr_solve_gradient(
+            score,
+            residual_gradient,
+            lam0=self.lam0,
+            lam1=self.lam1,
+        ) + self.mu * state.previous_delta
+        scale = self.learning_rate
+        if self.scale_lr_by_sqrt_n_states:
+            scale /= math.sqrt(self._resolved_n_states)
+        updates = unravel(-scale * delta)
+        return updates, GVMCReferenceSRState(
+            counter=state.counter + 1,
+            previous_delta=delta,
+        )

--- a/src/jaqmc/optimizer/gvmc_reference_sr.py
+++ b/src/jaqmc/optimizer/gvmc_reference_sr.py
@@ -49,7 +49,7 @@ def _native_vmc_to_gvmc_gradient(gradient: jax.Array) -> jax.Array:
 
 
 def _sample_matrix(jacobian: jax.Array, lam0: float, lam1: float) -> jax.Array:
-    """Build the regularized sample-space matrix used by GVMC."""
+    """Build GVMC's matrix; ``lam1`` shifts all entries, not the diagonal."""
     n_samples = jacobian.shape[0]
     scale = jnp.linalg.norm(jacobian) ** 2 / n_samples
     matrix = jacobian @ jnp.conj(jacobian.T)
@@ -148,7 +148,6 @@ class GVMCReferenceSROptimizer:
         lam0: Diagonal sample-space regularization.
         lam1: Centered-score null-direction regularization.
         mu: Kaczmarz/SPRING continuation coefficient.
-        scale_lr_by_sqrt_n_states: Apply the reference ``1 / sqrt(M)`` scaling.
         n_states: Optional explicit state count. By default it is inferred from
             the leading axis shared by every determinant-state parameter leaf.
         score_chunk_size: Optional chunk size for score evaluation.
@@ -159,7 +158,6 @@ class GVMCReferenceSROptimizer:
     lam0: float = 1e-3
     lam1: float = 1.0
     mu: float = 0.9
-    scale_lr_by_sqrt_n_states: bool = True
     n_states: int | None = None
     score_chunk_size: int | None = None
     f_log_psi: NumericWavefunctionEvaluate = runtime_dep()
@@ -269,10 +267,10 @@ class GVMCReferenceSROptimizer:
             lam0=self.lam0,
             lam1=self.lam1,
         ) + self.mu * state.previous_delta
-        scale = self.learning_rate
-        if self.scale_lr_by_sqrt_n_states:
-            scale /= math.sqrt(self._resolved_n_states)
-        updates = unravel(-scale * delta)
+        # Match cqsl/GVMC's actual parameter update.  Its lr / sqrt(M)
+        # quantity is used only for an auxiliary displacement diagnostic and
+        # is not applied to params.
+        updates = unravel(-self.learning_rate * delta)
         return updates, GVMCReferenceSRState(
             counter=state.counter + 1,
             previous_delta=delta,

--- a/src/jaqmc/optimizer/sr/sr.py
+++ b/src/jaqmc/optimizer/sr/sr.py
@@ -71,7 +71,7 @@ class SROptimizer:
     learning_rate: Any = module_config(Standard, direct_value_type=float)
     max_norm: Any = module_config(
         "fixed",
-        direct_value_type=float | Literal["fixed"],
+        direct_value_type=float | Literal["fixed"] | None,
         module_import_base="jaqmc.optimizer",
     )
     damping: Any = module_config(
@@ -80,14 +80,18 @@ class SROptimizer:
     max_cond_num: float | None = 1e7
     robust_gamma: Any = module_config(
         "sqrt",
-        direct_value_type=float | Literal["sqrt"],
+        direct_value_type=float | Literal["sqrt"] | None,
         module_import_base="jaqmc.optimizer",
     )
     spring_mu: Any = module_config(
-        0.9, direct_value_type=float, module_import_base="jaqmc.optimizer"
+        0.9,
+        direct_value_type=float | None,
+        module_import_base="jaqmc.optimizer",
     )
     march_beta: Any = module_config(
-        0.995, direct_value_type=float, module_import_base="jaqmc.optimizer"
+        0.995,
+        direct_value_type=float | None,
+        module_import_base="jaqmc.optimizer",
     )
     march_mode: Literal["var", "diff"] = "var"
     eps: float = 1e-8

--- a/src/jaqmc/sampler/__init__.py
+++ b/src/jaqmc/sampler/__init__.py
@@ -17,5 +17,12 @@ the chaining logics are handled in `DataGenerator`s instead of the samplers them
 """
 
 from .base import SamplePlan, SamplerInit, SamplerLike, SamplerStep
+from .determinant import DeterminantMCMCSampler
 
-__all__ = ["SamplePlan", "SamplerInit", "SamplerLike", "SamplerStep"]
+__all__ = [
+    "DeterminantMCMCSampler",
+    "SamplePlan",
+    "SamplerInit",
+    "SamplerLike",
+    "SamplerStep",
+]

--- a/src/jaqmc/sampler/determinant.py
+++ b/src/jaqmc/sampler/determinant.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Replica-row Metropolis sampler for determinant-state wavefunctions."""
+
+from typing import Literal
+
+import jax
+from jax import numpy as jnp
+
+from jaqmc.utils.array import match_first_axis_of
+from jaqmc.utils.config import configurable_dataclass
+
+from .mcmc import MCMCSampler
+
+
+@configurable_dataclass
+class DeterminantMCMCSampler(MCMCSampler):
+    """Reuse JaQMC MH adaptation while moving one physical replica per proposal.
+
+    The initial implementation deliberately uses a full determinant recomputation
+    for proposal scoring. It keeps the sampler contract identical to
+    :class:`MCMCSampler`; a cached rank-one backend can be added without changing
+    workflow or wavefunction interfaces.
+    """
+
+    n_states: int = 1
+    update_mode: Literal["full"] = "full"
+
+    def __post_init__(self):
+        if self.n_states < 1:
+            raise ValueError("n_states must be positive")
+        if self.update_mode != "full":
+            raise ValueError("Only the correctness-first 'full' update is supported")
+        self._physical_proposal = self.sampling_proposal
+        self.sampling_proposal = self._single_replica_proposal
+
+    def _single_replica_proposal(self, rngs, x, stddev):
+        if self.n_states == 1:
+            return self._physical_proposal(rngs, x, stddev)
+        leaves, treedef = jax.tree.flatten(x)
+        if not leaves:
+            return x
+        batch_size = leaves[0].shape[0]
+        rngs, index_key = jax.random.split(rngs)
+        replica_index = jax.random.randint(
+            index_key, (batch_size,), 0, self.n_states
+        )
+        proposed_all = self._physical_proposal(rngs, x, stddev)
+        proposed_leaves = jax.tree.leaves(proposed_all)
+        proposed = []
+        for leaf, proposal in zip(leaves, proposed_leaves):
+            if leaf.ndim < 2 or leaf.shape[1] != self.n_states:
+                raise ValueError(
+                    "Determinant sampler fields must have shape [batch, states, ...]"
+                )
+            replica_axis = jnp.arange(self.n_states)[None, :]
+            mask = replica_axis == replica_index[:, None]
+            mask = match_first_axis_of(mask, leaf)
+            proposed.append(jnp.where(mask, proposal, leaf))
+        return jax.tree.unflatten(treedef, proposed)

--- a/src/jaqmc/sampler/determinant.py
+++ b/src/jaqmc/sampler/determinant.py
@@ -8,7 +8,6 @@ from typing import Literal
 import jax
 from jax import numpy as jnp
 
-from jaqmc.utils.array import match_first_axis_of
 from jaqmc.utils.config import configurable_dataclass
 
 from .mcmc import MCMCSampler
@@ -46,16 +45,23 @@ class DeterminantMCMCSampler(MCMCSampler):
         replica_index = jax.random.randint(
             index_key, (batch_size,), 0, self.n_states
         )
-        proposed_all = self._physical_proposal(rngs, x, stddev)
-        proposed_leaves = jax.tree.leaves(proposed_all)
-        proposed = []
-        for leaf, proposal in zip(leaves, proposed_leaves):
+        selected = []
+        for leaf in leaves:
             if leaf.ndim < 2 or leaf.shape[1] != self.n_states:
                 raise ValueError(
                     "Determinant sampler fields must have shape [batch, states, ...]"
                 )
-            replica_axis = jnp.arange(self.n_states)[None, :]
-            mask = replica_axis == replica_index[:, None]
-            mask = match_first_axis_of(mask, leaf)
-            proposed.append(jnp.where(mask, proposal, leaf))
+            selected.append(
+                jax.vmap(lambda row, index: row[index])(leaf, replica_index)
+            )
+        selected_tree = jax.tree.unflatten(treedef, selected)
+        proposed_selected = self._physical_proposal(rngs, selected_tree, stddev)
+        proposed_leaves = jax.tree.leaves(proposed_selected)
+        proposed = []
+        for leaf, proposal in zip(leaves, proposed_leaves):
+            proposed.append(
+                jax.vmap(lambda row, value, index: row.at[index].set(value))(
+                    leaf, proposal, replica_index
+                )
+            )
         return jax.tree.unflatten(treedef, proposed)

--- a/src/jaqmc/utils/atomic/__init__.py
+++ b/src/jaqmc/utils/atomic/__init__.py
@@ -11,6 +11,11 @@ from .pp import (
     core_electrons_by_pp,
 )
 from .pretrain import make_pretrain_loss
+from .subspace_pretrain import (
+    StateOrbitalReference,
+    make_subspace_pretrain_loss,
+    make_subspace_reference_log_amplitude,
+)
 from .scf import MolecularSCF, PeriodicSCF
 
 __all__ = [
@@ -22,8 +27,11 @@ __all__ = [
     "AtomicSystemConfig",
     "MolecularSCF",
     "PeriodicSCF",
+    "StateOrbitalReference",
     "core_electrons_by_pp",
     "distribute_spins",
     "initialize_electrons_gaussian",
     "make_pretrain_loss",
+    "make_subspace_pretrain_loss",
+    "make_subspace_reference_log_amplitude",
 ]

--- a/src/jaqmc/utils/atomic/pbc_tda.py
+++ b/src/jaqmc/utils/atomic/pbc_tda.py
@@ -1,0 +1,410 @@
+# Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""PySCF PBC-TDA references for determinant-state pretraining.
+
+This module deliberately delegates Hartree--Fock and TDA/CIS calculations to
+PySCF. It only selects distinct dominant single promotions and adapts their
+occupied MO coefficients to JaQMC's existing periodic orbital evaluator.
+"""
+
+import dataclasses
+import logging
+from collections.abc import Sequence
+from typing import Literal
+
+import jax
+import numpy as np
+import pyscf.pbc.scf.kuhf
+from jax import numpy as jnp
+from pyscf.pbc.lib.kpts_helper import get_kconserv_ria
+from pyscf.pbc.tdscf import kuhf as pbc_tda_kuhf
+
+from jaqmc.utils.config import configurable_dataclass
+
+from .scf import PeriodicSCF
+
+logger = logging.getLogger(__name__)
+
+
+@configurable_dataclass
+class PBCTDAReferenceConfig:
+    """Configuration for the KUHF-TDA single-promotion reference adapter."""
+
+    kshift: int = 0
+    oversample: int = 4
+    candidate_topk: int = 8
+    min_selected_weight: float = 1e-4
+    require_converged: bool = True
+    require_same_k: bool = True
+    occupation_tolerance: float = 1e-6
+
+    def __post_init__(self):
+        if self.kshift != 0:
+            raise NotImplementedError(
+                "PBC TDA subspace pretraining v1 supports kshift=0 only."
+            )
+        if not self.require_same_k:
+            raise NotImplementedError(
+                "PBC TDA subspace pretraining v1 requires same-k promotions."
+            )
+        if self.oversample < 0:
+            raise ValueError("pretrain.tda.oversample must be non-negative")
+        if self.candidate_topk < 1:
+            raise ValueError("pretrain.tda.candidate_topk must be positive")
+        if self.min_selected_weight < 0:
+            raise ValueError("pretrain.tda.min_selected_weight must be non-negative")
+        if self.occupation_tolerance <= 0:
+            raise ValueError("pretrain.tda.occupation_tolerance must be positive")
+
+
+@dataclasses.dataclass(frozen=True)
+class PBCSinglePromotion:
+    """One single-determinant proxy selected from a PBC-TDA root."""
+
+    root_index: int
+    excitation_energy: float
+    spin: Literal["alpha", "beta"]
+    k_occ: int
+    k_vir: int
+    occ_local_index: int
+    vir_local_index: int
+    occ_mo_index: int
+    vir_mo_index: int
+    amplitude: complex
+    weight: float
+    largest_weight: float
+    total_weight: float
+    participation_ratio: float
+
+    @property
+    def key(self) -> tuple[str, int, int, int, int]:
+        """Return the determinant-defining promotion identity."""
+        return (
+            self.spin,
+            self.k_occ,
+            self.occ_mo_index,
+            self.k_vir,
+            self.vir_mo_index,
+        )
+
+
+def select_unique_promotions(
+    candidates_by_root: Sequence[Sequence[PBCSinglePromotion]],
+    n_requested: int,
+    *,
+    candidate_topk: int,
+    min_selected_weight: float,
+) -> list[PBCSinglePromotion]:
+    """Greedily assign a distinct high-weight promotion to each low root."""
+    if n_requested < 0:
+        raise ValueError("n_requested must be non-negative")
+    selected: list[PBCSinglePromotion] = []
+    used: dict[tuple[str, int, int, int, int], int] = {}
+    ordered_roots = sorted(
+        (root for root in candidates_by_root if root),
+        key=lambda root: (root[0].excitation_energy, root[0].root_index),
+    )
+    for candidates in ordered_roots:
+        chosen = None
+        for candidate in sorted(candidates, key=lambda item: item.weight, reverse=True)[
+            :candidate_topk
+        ]:
+            if candidate.weight < min_selected_weight:
+                continue
+            if candidate.key in used:
+                logger.info(
+                    "TDA root=%s candidate skipped: promotion already assigned "
+                    "to state=%s",
+                    candidate.root_index,
+                    used[candidate.key],
+                )
+                continue
+            chosen = candidate
+            break
+        if chosen is None:
+            logger.info(
+                "TDA root=%s skipped: no distinct promotion in top-%s above "
+                "weight threshold %.3e",
+                candidates[0].root_index,
+                candidate_topk,
+                min_selected_weight,
+            )
+            continue
+        used[chosen.key] = len(selected) + 1
+        selected.append(chosen)
+        if len(selected) == n_requested:
+            break
+    if len(selected) != n_requested:
+        raise ValueError(
+            "Unable to select enough distinct TDA promotions: requested "
+            f"{n_requested}, found {len(selected)}. Increase oversample or "
+            "candidate_topk, or inspect the TDA roots."
+        )
+    return selected
+
+
+def _validate_occupations(mo_occ, tolerance: float) -> None:
+    for spin_occ in mo_occ:
+        for k_occ in spin_occ:
+            occ = np.asarray(k_occ)
+            binary = np.isclose(occ, 0.0, atol=tolerance) | np.isclose(
+                occ, 1.0, atol=tolerance
+            )
+            if not np.all(binary):
+                raise NotImplementedError(
+                    "PBC TDA subspace pretraining requires integer KUHF "
+                    "occupations (approximately 0 or 1)."
+                )
+
+
+def _root_candidates(
+    *,
+    root_index: int,
+    excitation_energy: float,
+    amplitudes,
+    mo_occ,
+    kconserv: np.ndarray,
+) -> list[PBCSinglePromotion]:
+    raw = []
+    for spin_index, (spin, spin_amplitudes) in enumerate(
+        (("alpha", amplitudes[0]), ("beta", amplitudes[1]))
+    ):
+        for k_occ, x_ia in enumerate(spin_amplitudes):
+            k_vir = int(kconserv[k_occ])
+            occ_abs = np.flatnonzero(np.asarray(mo_occ[spin_index][k_occ]) > 0.9)
+            vir_abs = np.flatnonzero(np.asarray(mo_occ[spin_index][k_vir]) < 0.1)
+            x_ia = np.asarray(x_ia)
+            if x_ia.shape != (len(occ_abs), len(vir_abs)):
+                raise ValueError(
+                    "Unexpected PySCF TDA amplitude shape for "
+                    f"spin={spin}, k={k_occ}: {x_ia.shape}, expected "
+                    f"{(len(occ_abs), len(vir_abs))}."
+                )
+            for occ_local, vir_local in np.ndindex(x_ia.shape):
+                amplitude = complex(x_ia[occ_local, vir_local])
+                raw.append(
+                    (
+                        spin,
+                        k_occ,
+                        k_vir,
+                        occ_local,
+                        vir_local,
+                        int(occ_abs[occ_local]),
+                        int(vir_abs[vir_local]),
+                        amplitude,
+                        float(abs(amplitude) ** 2),
+                    )
+                )
+
+    total_weight = float(sum(item[-1] for item in raw))
+    largest_weight = float(max((item[-1] for item in raw), default=0.0))
+    if total_weight > 0:
+        normalized = np.asarray([item[-1] / total_weight for item in raw])
+        participation_ratio = float(1.0 / np.sum(normalized**2))
+    else:
+        participation_ratio = float("inf")
+    return [
+        PBCSinglePromotion(
+            root_index=root_index,
+            excitation_energy=float(excitation_energy),
+            spin=item[0],
+            k_occ=item[1],
+            k_vir=item[2],
+            occ_local_index=item[3],
+            vir_local_index=item[4],
+            occ_mo_index=item[5],
+            vir_mo_index=item[6],
+            amplitude=item[7],
+            weight=item[8],
+            largest_weight=largest_weight,
+            total_weight=total_weight,
+            participation_ratio=participation_ratio,
+        )
+        for item in raw
+    ]
+
+
+def run_pbc_tda_promotions(
+    mean_field,
+    n_requested: int,
+    config: PBCTDAReferenceConfig,
+) -> list[PBCSinglePromotion]:
+    """Run PySCF KUHF-TDA and select distinct dominant promotions."""
+    if n_requested < 0:
+        raise ValueError("n_requested must be non-negative")
+    if n_requested == 0:
+        return []
+    if not isinstance(mean_field, pyscf.pbc.scf.kuhf.KUHF):
+        raise NotImplementedError(
+            "PBC TDA subspace pretraining v1 supports KUHF only."
+        )
+    if not bool(mean_field.converged):
+        raise RuntimeError("KUHF must converge before PBC TDA pretraining.")
+    _validate_occupations(mean_field.mo_occ, config.occupation_tolerance)
+    nkpts = len(mean_field.kpts)
+    if config.kshift >= nkpts:
+        raise ValueError(
+            f"pretrain.tda.kshift={config.kshift} is outside nkpts={nkpts}"
+        )
+    kconserv = np.asarray(get_kconserv_ria(mean_field.cell, mean_field.kpts))[
+        config.kshift
+    ]
+    same_k = np.array_equal(kconserv, np.arange(nkpts))
+    if config.require_same_k and not same_k:
+        raise ValueError(
+            "PBC TDA subspace pretraining v1 requires same-k/q=0 promotions."
+        )
+
+    n_roots = n_requested + config.oversample
+    td = pbc_tda_kuhf.TDA(mean_field, kshift_lst=[config.kshift])
+    td.nstates = n_roots
+    td.kernel()
+    converged = np.asarray(td.converged[0], dtype=bool)
+    energies = np.asarray(td.e[0])
+    roots = td.xy[0]
+    logger.info(
+        "PBC TDA: hf=%s, nkpts=%s, requested_states=%s, requested_roots=%s, "
+        "returned_roots=%s, converged_roots=%s, kshift=%s, same_k=%s",
+        type(mean_field).__name__,
+        nkpts,
+        n_requested + 1,
+        n_roots,
+        len(roots),
+        int(np.sum(converged)),
+        config.kshift,
+        same_k,
+    )
+    candidates_by_root = []
+    for root_index, (energy, root_xy) in enumerate(zip(energies, roots)):
+        is_converged = root_index < len(converged) and bool(converged[root_index])
+        if config.require_converged and not is_converged:
+            logger.info("TDA root=%s skipped: not converged", root_index)
+            continue
+        amplitudes, _ = root_xy
+        candidates_by_root.append(
+            _root_candidates(
+                root_index=root_index,
+                excitation_energy=float(energy),
+                amplitudes=amplitudes,
+                mo_occ=mean_field.mo_occ,
+                kconserv=kconserv,
+            )
+        )
+    return select_unique_promotions(
+        candidates_by_root,
+        n_requested,
+        candidate_topk=config.candidate_topk,
+        min_selected_weight=config.min_selected_weight,
+    )
+
+
+class PeriodicStateOrbitalReference:
+    """Lazy ground plus TDA-selected periodic single-determinant references."""
+
+    def __init__(
+        self,
+        scf: PeriodicSCF,
+        n_states: int,
+        config: PBCTDAReferenceConfig,
+    ):
+        if n_states < 1:
+            raise ValueError("n_states must be positive")
+        self.scf = scf
+        self.n_states = n_states
+        self.config = config
+        self.promotions: tuple[PBCSinglePromotion, ...] = ()
+        self._state_coeffs: tuple[list[jax.Array], list[jax.Array]] | None = None
+
+    def prepare(self) -> None:
+        """Run TDA after SCF and build state-stacked occupied coefficients."""
+        if self._state_coeffs is not None:
+            return
+        ground = self.scf.get_occupied_mo_coeffs()
+        promotions = run_pbc_tda_promotions(
+            self.scf.mean_field, self.n_states - 1, self.config
+        )
+        state_coeffs = []
+        for state_index in range(self.n_states):
+            coeffs = (
+                [np.array(value, copy=True) for value in ground[0]],
+                [np.array(value, copy=True) for value in ground[1]],
+            )
+            if state_index:
+                promotion = promotions[state_index - 1]
+                spin_index = 0 if promotion.spin == "alpha" else 1
+                coeffs[spin_index][promotion.k_occ][
+                    :, promotion.occ_local_index
+                ] = np.asarray(
+                    self.scf.mean_field.mo_coeff[spin_index][promotion.k_vir]
+                )[:, promotion.vir_mo_index]
+            state_coeffs.append(coeffs)
+
+        self._state_coeffs = (
+            [
+                jnp.asarray(np.stack([state[0][k] for state in state_coeffs]))
+                for k in range(len(ground[0]))
+            ],
+            [
+                jnp.asarray(np.stack([state[1][k] for state in state_coeffs]))
+                for k in range(len(ground[1]))
+            ],
+        )
+        self.promotions = tuple(promotions)
+        logger.info("Subspace pretrain reference: state=0, reference=KUHF ground")
+        for state_index, promotion in enumerate(promotions, start=1):
+            logger.info(
+                "Subspace pretrain reference: state=%s, tda_root=%s, omega=%.8g, "
+                "spin=%s, k_occ=%s, k_vir=%s, occ_local=%s, vir_local=%s, "
+                "occ_mo=%s, vir_mo=%s, weight=%.6g, participation_ratio=%.6g",
+                state_index,
+                promotion.root_index,
+                promotion.excitation_energy,
+                promotion.spin,
+                promotion.k_occ,
+                promotion.k_vir,
+                promotion.occ_local_index,
+                promotion.vir_local_index,
+                promotion.occ_mo_index,
+                promotion.vir_mo_index,
+                promotion.weight,
+                promotion.participation_ratio,
+            )
+            if promotion.weight < 0.1 or promotion.participation_ratio > 3:
+                logger.warning(
+                    "TDA root=%s is strongly multi-configurational; its "
+                    "single-determinant pretrain target is only a weak proxy.",
+                    promotion.root_index,
+                )
+
+    def _coeffs_for_state(
+        self, state_index: jax.Array
+    ) -> tuple[list[jax.Array], list[jax.Array]]:
+        if self._state_coeffs is None:
+            raise RuntimeError("PeriodicStateOrbitalReference.prepare() was not called.")
+        return (
+            [value[state_index] for value in self._state_coeffs[0]],
+            [value[state_index] for value in self._state_coeffs[1]],
+        )
+
+    def eval_orbitals(
+        self,
+        state_index: jax.Array,
+        pos: jnp.ndarray,
+        nspins: tuple[int, int],
+    ) -> tuple[jnp.ndarray, jnp.ndarray]:
+        """Evaluate one state's occupied orbitals with native PBC machinery."""
+        return self.scf.eval_orbitals_from_coeffs(
+            pos, nspins, self._coeffs_for_state(state_index)
+        )
+
+    def eval_slater(
+        self,
+        state_index: jax.Array,
+        pos: jnp.ndarray,
+        nspins: tuple[int, int],
+    ) -> jnp.ndarray:
+        """Evaluate one state's complex Slater log-amplitude."""
+        return self.scf.eval_slater_from_coeffs(
+            pos, nspins, self._coeffs_for_state(state_index)
+        )

--- a/src/jaqmc/utils/atomic/scf.py
+++ b/src/jaqmc/utils/atomic/scf.py
@@ -565,6 +565,17 @@ class PeriodicSCF:
     def eval_orbitals(
         self, pos: jnp.ndarray, nspins: tuple[int, int]
     ) -> tuple[jnp.ndarray, jnp.ndarray]:
+        """Evaluate occupied orbitals using the SCF ground-state coefficients."""
+        return self.eval_orbitals_from_coeffs(
+            pos, nspins, self.get_occupied_mo_coeffs()
+        )
+
+    def eval_orbitals_from_coeffs(
+        self,
+        pos: jnp.ndarray,
+        nspins: tuple[int, int],
+        mo_coeffs: tuple[list[jnp.ndarray], list[jnp.ndarray]],
+    ) -> tuple[jnp.ndarray, jnp.ndarray]:
         r"""Evaluate occupied orbital matrices for the Slater determinant.
 
         This method produces dense orbital matrices by evaluating all electrons
@@ -583,17 +594,15 @@ class PeriodicSCF:
         Args:
             pos: Electron positions with shape ``(..., nelec, 3)``.
             nspins: Tuple of ``(n_alpha, n_beta)`` electrons.
+            mo_coeffs: Spin-separated occupied MO coefficients, one matrix per
+                k-point. This has the same layout as ``self._mo_coeff`` but may
+                represent a state-specific occupied subspace.
 
         Returns:
             Tuple of ``(alpha_matrix, beta_matrix)`` orbital matrices with
             shapes ``(..., n_alpha, n_alpha)`` and ``(..., n_beta, n_beta)``.
 
-        Raises:
-            RuntimeError: If Hartree-Fock calculation has not been performed.
         """
-        if self._mo_coeff is None:
-            raise RuntimeError("Mean-field calculation has not been run.")
-
         n_alpha, n_beta = nspins
         leading_dims = pos.shape[:-2]
         pos_flat = jnp.reshape(pos, [-1, 3])  # (batch*nelec, 3)
@@ -628,8 +637,8 @@ class PeriodicSCF:
             # Concatenate along orbital axis: (batch, n_spin, total_orbs)
             return jnp.concatenate(mo_list, axis=-1)
 
-        alpha_mos = build_orbital_matrix(aos, slice(0, n_alpha), self._mo_coeff[0])
-        beta_mos = build_orbital_matrix(aos, slice(n_alpha, nelec), self._mo_coeff[1])
+        alpha_mos = build_orbital_matrix(aos, slice(0, n_alpha), mo_coeffs[0])
+        beta_mos = build_orbital_matrix(aos, slice(n_alpha, nelec), mo_coeffs[1])
 
         # Reshape to output format: (..., n_spin, n_spin)
         # Handle zero-electron cases explicitly to avoid reshape issues with -1
@@ -657,9 +666,30 @@ class PeriodicSCF:
         Returns:
             Log value of Slater determinant (complex).
         """
-        alpha_matrix, beta_matrix = self.eval_orbitals(pos, nspins)
+        return self.eval_slater_from_coeffs(
+            pos, nspins, self.get_occupied_mo_coeffs()
+        )
+
+    def eval_slater_from_coeffs(
+        self,
+        pos: jnp.ndarray,
+        nspins: tuple[int, int],
+        mo_coeffs: tuple[list[jnp.ndarray], list[jnp.ndarray]],
+    ) -> jnp.ndarray:
+        """Evaluate a Slater log-amplitude from supplied occupied MOs."""
+        alpha_matrix, beta_matrix = self.eval_orbitals_from_coeffs(
+            pos, nspins, mo_coeffs
+        )
         sign, logdet = _eval_slater_from_orbitals(alpha_matrix, beta_matrix)
         return logdet + jnp.log(sign)
+
+    def get_occupied_mo_coeffs(
+        self,
+    ) -> tuple[list[jnp.ndarray], list[jnp.ndarray]]:
+        """Return native occupied MO coefficients after periodic SCF."""
+        if self._mo_coeff is None:
+            raise RuntimeError("Mean-field calculation has not been run.")
+        return self._mo_coeff
 
     def get_orbital_kpoints(self) -> jnp.ndarray:
         """Get k-point assignment for each orbital in the wavefunction.

--- a/src/jaqmc/utils/atomic/subspace_pretrain.py
+++ b/src/jaqmc/utils/atomic/subspace_pretrain.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""State-aware adapters for native JaQMC orbital pretraining."""
+
+from collections.abc import Mapping
+from typing import Any, Protocol
+
+import jax
+from jax import numpy as jnp
+
+from jaqmc.array_types import Params, PRNGKey
+from jaqmc.data import Data
+from jaqmc.estimator import FunctionEstimator
+from jaqmc.estimator.base import Estimator
+from jaqmc.utils import parallel_jax
+from jaqmc.utils.subspace_linalg import stable_complex_logdet
+from jaqmc.wavefunction.base import NumericWavefunctionEvaluate
+from jaqmc.wavefunction.determinant_state import SubspaceSpec, take_replica_dynamic
+
+
+class StateOrbitalReference(Protocol):
+    """Reference that evaluates state-indexed orbitals and Slater amplitudes."""
+
+    n_states: int
+
+    def eval_orbitals(
+        self,
+        state_index: jax.Array,
+        pos: jnp.ndarray,
+        nspins: tuple[int, int],
+    ) -> tuple[jnp.ndarray, jnp.ndarray]: ...
+
+    def eval_slater(
+        self,
+        state_index: jax.Array,
+        pos: jnp.ndarray,
+        nspins: tuple[int, int],
+    ) -> jnp.ndarray: ...
+
+
+def make_subspace_pretrain_loss(
+    orbitals_fn: NumericWavefunctionEvaluate,
+    orbital_ref: StateOrbitalReference,
+    spec: SubspaceSpec,
+    nspins: tuple[int, int],
+    *,
+    full_det: bool,
+) -> Estimator:
+    """Match each component NN to its diagonal replica orbital reference.
+
+    The loss evaluates state ``s`` only on replica ``s``. Consequently neural
+    forward/gradient work scales as ``O(M)`` rather than ``O(M**2)``.
+    """
+    if not full_det:
+        raise NotImplementedError(
+            "Subspace TDA pretraining v1 supports full_det wavefunctions only."
+        )
+    if orbital_ref.n_states != spec.n_states:
+        raise ValueError(
+            "State reference and subspace sizes differ: "
+            f"{orbital_ref.n_states} != {spec.n_states}."
+        )
+    states = jnp.arange(spec.n_states)
+
+    def one_state_loss(params_s, state_index, determinant_data):
+        physical_data = take_replica_dynamic(
+            determinant_data, state_index, spec
+        )
+        target_alpha, target_beta = orbital_ref.eval_orbitals(
+            state_index, physical_data.electrons, nspins
+        )
+        predicted = orbitals_fn(params_s, physical_data)
+        na = target_alpha.shape[-2]
+        nb = target_beta.shape[-2]
+        target = jnp.block(
+            [
+                [
+                    target_alpha,
+                    jnp.zeros((na, nb), dtype=target_alpha.dtype),
+                ],
+                [
+                    jnp.zeros((nb, na), dtype=target_beta.dtype),
+                    target_beta,
+                ],
+            ]
+        )
+        return jnp.mean(jnp.abs(predicted - target) ** 2)
+
+    def loss_fn(stacked_params: Params, determinant_data: Data) -> jnp.ndarray:
+        losses = jax.vmap(one_state_loss, in_axes=(0, 0, None))(
+            stacked_params, states, determinant_data
+        )
+        return jnp.mean(losses)
+
+    loss_and_grad_fn = jax.value_and_grad(loss_fn, argnums=0)
+
+    def evaluate(
+        params: Params,
+        data: Data,
+        prev_walker_stats: Mapping[str, Any],
+        state: None,
+        rngs: PRNGKey,
+    ) -> tuple[dict[str, Any], None]:
+        del prev_walker_stats, rngs
+        loss, grads = loss_and_grad_fn(parallel_jax.pvary(params), data)
+        return {"loss": loss, "grads": grads}, state
+
+    return FunctionEstimator(evaluate)
+
+
+def make_subspace_reference_log_amplitude(
+    orbital_ref: StateOrbitalReference,
+    spec: SubspaceSpec,
+    nspins: tuple[int, int],
+):
+    """Build the determinant-state HF/TDA reference sampling amplitude."""
+    if orbital_ref.n_states != spec.n_states:
+        raise ValueError(
+            "State reference and subspace sizes differ: "
+            f"{orbital_ref.n_states} != {spec.n_states}."
+        )
+    states = jnp.arange(spec.n_states)
+
+    def one_replica(electrons):
+        return jax.vmap(
+            lambda state_index: orbital_ref.eval_slater(
+                state_index, electrons, nspins
+            )
+        )(states)
+
+    def reference_log_amplitude(data: Data) -> jnp.ndarray:
+        log_matrix = jax.vmap(one_replica)(data.electrons)
+        return jnp.real(stable_complex_logdet(log_matrix))
+
+    return reference_log_amplitude

--- a/src/jaqmc/utils/parallel_jax.py
+++ b/src/jaqmc/utils/parallel_jax.py
@@ -115,6 +115,18 @@ def pmean[ValueT](x: ValueT) -> ValueT:
         return x
 
 
+def psum[ValueT](x: ValueT) -> ValueT:
+    """Sum ``x`` across devices along the batch axis.
+
+    Outside a ``shard_map`` context this is the identity, matching
+    :func:`pmean`'s convenient single-device behavior.
+    """
+    try:
+        return jax.lax.psum(x, axis_name=BATCH_AXIS_NAME)
+    except NameError:
+        return x
+
+
 def all_gather(x):
     """Gather ``x`` from every device along the batch axis and tile the result.
 

--- a/src/jaqmc/utils/subspace_linalg.py
+++ b/src/jaqmc/utils/subspace_linalg.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Numerically stable small-matrix operations for variational subspaces."""
+
+import jax
+from jax import numpy as jnp
+
+
+def row_scaled_matrix(log_amplitudes: jax.Array) -> tuple[jax.Array, jax.Array]:
+    """Exponentiate a log-amplitude matrix after removing per-row scales."""
+    row_shift = jax.lax.stop_gradient(
+        jnp.max(jnp.real(log_amplitudes), axis=-1)
+    )
+    return jnp.exp(log_amplitudes - row_shift[:, None]), row_shift
+
+
+def stable_complex_logdet(log_amplitudes: jax.Array) -> jax.Array:
+    """Return ``log(det(exp(log_amplitudes)))`` without amplitude overflow."""
+    scaled, row_shift = row_scaled_matrix(log_amplitudes)
+    phase, logabsdet = jnp.linalg.slogdet(scaled)
+    return jnp.sum(row_shift) + logabsdet + 1j * jnp.angle(phase)
+
+
+def rayleigh_solve(phi: jax.Array, phi_h: jax.Array) -> jax.Array:
+    """Solve the local Rayleigh system ``phi @ R = phi_h``."""
+    return jnp.linalg.solve(phi, phi_h)
+
+
+def solve_residual(a: jax.Array, x: jax.Array, b: jax.Array) -> jax.Array:
+    """Return the relative Frobenius residual of ``a @ x = b``."""
+    tiny = jnp.finfo(jnp.real(b).dtype).tiny
+    return jnp.linalg.norm(a @ x - b) / jnp.maximum(jnp.linalg.norm(b), tiny)
+
+
+def complex_variance(x: jax.Array, axis=0) -> jax.Array:
+    """Return ``E[|x-E[x]|^2]`` for real or complex samples."""
+    centered = x - jnp.nanmean(x, axis=axis, keepdims=True)
+    return jnp.nanmean(jnp.abs(centered) ** 2, axis=axis)
+
+
+def matrix_condition_proxy(matrix: jax.Array) -> jax.Array:
+    """Return the singular-value condition number of a small matrix."""
+    singular_values = jnp.linalg.svd(matrix, compute_uv=False)
+    return singular_values[0] / singular_values[-1]
+
+
+def singular_value_diagnostics(
+    matrix: jax.Array,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Return minimum/maximum singular values and their condition ratio."""
+    singular_values = jnp.linalg.svd(matrix, compute_uv=False)
+    sigma_max = singular_values[0]
+    sigma_min = singular_values[-1]
+    return sigma_min, sigma_max, sigma_max / sigma_min
+
+
+def hermitianized_rayleigh(g: jax.Array, gh: jax.Array) -> jax.Array:
+    """Map a generalized Hermitian eigenproblem to an ordinary one."""
+    g = (g + g.conj().T) / 2
+    gh = (gh + gh.conj().T) / 2
+    chol = jnp.linalg.cholesky(g)
+    left_solved = jnp.linalg.solve(chol, gh)
+    result = jnp.linalg.solve(chol, left_solved.conj().T).conj().T
+    return (result + result.conj().T) / 2
+
+
+def generalized_ritz(g: jax.Array, gh: jax.Array) -> tuple[jax.Array, jax.Array]:
+    """Solve ``GH c = G c e`` for positive-definite overlap ``G``."""
+    effective = hermitianized_rayleigh(g, gh)
+    values, orthonormal_vectors = jnp.linalg.eigh(effective)
+    chol = jnp.linalg.cholesky((g + g.conj().T) / 2)
+    vectors = jnp.linalg.solve(chol.conj().T, orthonormal_vectors)
+    return values, vectors

--- a/src/jaqmc/wavefunction/__init__.py
+++ b/src/jaqmc/wavefunction/__init__.py
@@ -8,6 +8,12 @@ from .base import (
     WavefunctionInit,
     WavefunctionLike,
 )
+from .determinant_state import (
+    DeterminantStateWavefunction,
+    IndependentStateBundle,
+    SubspaceSpec,
+    take_replica,
+)
 
 __all__ = [
     "NumericWavefunctionEvaluate",
@@ -15,4 +21,8 @@ __all__ = [
     "WavefunctionEvaluate",
     "WavefunctionInit",
     "WavefunctionLike",
+    "DeterminantStateWavefunction",
+    "IndependentStateBundle",
+    "SubspaceSpec",
+    "take_replica",
 ]

--- a/src/jaqmc/wavefunction/__init__.py
+++ b/src/jaqmc/wavefunction/__init__.py
@@ -9,10 +9,12 @@ from .base import (
     WavefunctionLike,
 )
 from .determinant_state import (
+    CheckpointStateBundle,
     DeterminantStateWavefunction,
     IndependentStateBundle,
     SubspaceSpec,
     take_replica,
+    take_replica_dynamic,
 )
 
 __all__ = [
@@ -22,7 +24,9 @@ __all__ = [
     "WavefunctionInit",
     "WavefunctionLike",
     "DeterminantStateWavefunction",
+    "CheckpointStateBundle",
     "IndependentStateBundle",
     "SubspaceSpec",
     "take_replica",
+    "take_replica_dynamic",
 ]

--- a/src/jaqmc/wavefunction/determinant_state.py
+++ b/src/jaqmc/wavefunction/determinant_state.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Determinant-state adapters for variational subspace Monte Carlo."""
+
+import dataclasses
+from dataclasses import dataclass
+from typing import Protocol
+
+import jax
+from jax import numpy as jnp
+
+from jaqmc.array_types import Params, PRNGKey
+from jaqmc.data import Data
+from jaqmc.utils.subspace_linalg import row_scaled_matrix, stable_complex_logdet
+from jaqmc.wavefunction.base import WavefunctionLike
+
+
+@dataclass(frozen=True)
+class SubspaceSpec:
+    """Describe the state/replica axis embedded in one physical walker."""
+
+    n_states: int
+    replica_fields: tuple[str, ...] = ("electrons",)
+
+    def __post_init__(self):
+        if self.n_states < 1:
+            raise ValueError("n_states must be positive")
+        if not self.replica_fields:
+            raise ValueError("replica_fields must not be empty")
+
+
+def take_replica(data: Data, replica_index: int, spec: SubspaceSpec) -> Data:
+    """Remove the replica axis from selected fields of one determinant walker."""
+    missing = set(spec.replica_fields) - set(data.field_names)
+    if missing:
+        raise KeyError(f"Replica fields are absent from data: {sorted(missing)}")
+    return dataclasses.replace(
+        data,
+        **{name: data[name][replica_index] for name in spec.replica_fields},
+    )
+
+
+class IndependentStateBundle:
+    """Evaluate one JaQMC ansatz architecture with independent state parameters."""
+
+    def __init__(self, base_wavefunction: WavefunctionLike, spec: SubspaceSpec):
+        self.base_wavefunction = base_wavefunction
+        self.spec = spec
+
+    def init_params(self, physical_data: Data, rngs: PRNGKey) -> Params:
+        """Initialize independent parameters and stack every PyTree leaf."""
+        # Preserve exact native initialization semantics for the M=1
+        # regression path.  Splitting a single key would otherwise produce a
+        # statistically equivalent, but different, initial wavefunction.
+        keys = (
+            jnp.expand_dims(rngs, 0)
+            if self.spec.n_states == 1
+            else jax.random.split(rngs, self.spec.n_states)
+        )
+        params = [
+            self.base_wavefunction.init_params(physical_data, key) for key in keys
+        ]
+        return jax.tree.map(lambda *xs: jnp.stack(xs), *params)
+
+    def phase_logpsi_all_states(
+        self, stacked_params: Params, physical_data: Data
+    ) -> tuple[jax.Array, jax.Array]:
+        """Return component phases and log amplitudes with shape ``[M]``."""
+        return jax.vmap(self.base_wavefunction.phase_logpsi, in_axes=(0, None))(
+            stacked_params, physical_data
+        )
+
+    def complex_logpsi_all_states(
+        self, stacked_params: Params, physical_data: Data
+    ) -> jax.Array:
+        """Return phase-aware complex log amplitudes with shape ``[M]``."""
+        phase, logabs = self.phase_logpsi_all_states(stacked_params, physical_data)
+        phase = phase.astype(jnp.result_type(phase, 1j))
+        return logabs + 1j * jnp.angle(phase)
+
+    def logpsi_matrix(self, stacked_params: Params, replica_data: Data) -> jax.Array:
+        """Return ``L[r, s] = log(psi_s(R_r))`` with shape ``[M, M]``."""
+        physical_axis = dataclasses.replace(
+            replica_data,
+            **{
+                name: 0 if name in self.spec.replica_fields else None
+                for name in replica_data.field_names
+            },
+        )
+        return jax.vmap(
+            self.complex_logpsi_all_states, in_axes=(None, physical_axis)
+        )(stacked_params, replica_data)
+
+
+class StateBundleLike(Protocol):
+    """Internal adapter contract used by the determinant wrapper."""
+
+    spec: SubspaceSpec
+
+    def init_params(self, physical_data: Data, rngs: PRNGKey) -> Params: ...
+
+    def complex_logpsi_all_states(
+        self, stacked_params: Params, physical_data: Data
+    ) -> jax.Array: ...
+
+    def logpsi_matrix(
+        self, stacked_params: Params, replica_data: Data
+    ) -> jax.Array: ...
+
+
+class DeterminantStateWavefunction:
+    """Wavefunction whose amplitude is a determinant of component states."""
+
+    def __init__(
+        self,
+        base_wavefunction: WavefunctionLike,
+        spec: SubspaceSpec,
+        *,
+        state_bundle: StateBundleLike | None = None,
+    ):
+        self.base_wavefunction = base_wavefunction
+        self.spec = spec
+        self.bundle = state_bundle or IndependentStateBundle(base_wavefunction, spec)
+        if self.bundle.spec != spec:
+            raise ValueError("state_bundle.spec must match determinant spec")
+
+    def init_params(self, data: Data, rngs: PRNGKey) -> Params:
+        physical_data = take_replica(data, 0, self.spec)
+        return self.bundle.init_params(physical_data, rngs)
+
+    def component_logpsi_matrix(self, params: Params, data: Data) -> jax.Array:
+        return self.bundle.logpsi_matrix(params, data)
+
+    def component_amplitude_row(
+        self, params: Params, data: Data
+    ) -> tuple[jax.Array, jax.Array]:
+        """Return a scaled component row and its removed real log scale."""
+        logs = self.bundle.complex_logpsi_all_states(params, data)
+        shift = jax.lax.stop_gradient(jnp.max(jnp.real(logs)))
+        return jnp.exp(logs - shift), shift
+
+    def stable_amplitude_matrix(
+        self, params: Params, data: Data
+    ) -> tuple[jax.Array, jax.Array]:
+        return row_scaled_matrix(self.component_logpsi_matrix(params, data))
+
+    def logpsi(self, params: Params, data: Data) -> jax.Array:
+        return stable_complex_logdet(self.component_logpsi_matrix(params, data))
+
+    def phase_logpsi(
+        self, params: Params, data: Data
+    ) -> tuple[jax.Array, jax.Array]:
+        logpsi = self.logpsi(params, data)
+        return jnp.exp(1j * jnp.imag(logpsi)), jnp.real(logpsi)
+
+    def evaluate(self, params: Params, data: Data) -> dict[str, jax.Array]:
+        return {"logpsi": self.logpsi(params, data)}

--- a/src/jaqmc/wavefunction/determinant_state.py
+++ b/src/jaqmc/wavefunction/determinant_state.py
@@ -12,6 +12,7 @@ from jax import numpy as jnp
 
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import Data
+from jaqmc.utils.checkpoint import NumPyCheckpointManager
 from jaqmc.utils.subspace_linalg import row_scaled_matrix, stable_complex_logdet
 from jaqmc.wavefunction.base import WavefunctionLike
 
@@ -38,6 +39,27 @@ def take_replica(data: Data, replica_index: int, spec: SubspaceSpec) -> Data:
     return dataclasses.replace(
         data,
         **{name: data[name][replica_index] for name in spec.replica_fields},
+    )
+
+
+def take_replica_dynamic(
+    data: Data, replica_index: jax.Array, spec: SubspaceSpec
+) -> Data:
+    """Select one replica with a traced index without expanding replica data."""
+    missing = set(spec.replica_fields) - set(data.field_names)
+    if missing:
+        raise KeyError(f"Replica fields are absent from data: {sorted(missing)}")
+    return dataclasses.replace(
+        data,
+        **{
+            name: jax.tree.map(
+                lambda x: jax.lax.dynamic_index_in_dim(
+                    x, replica_index, axis=0, keepdims=False
+                ),
+                data[name],
+            )
+            for name in spec.replica_fields
+        },
     )
 
 
@@ -91,6 +113,47 @@ class IndependentStateBundle:
         return jax.vmap(
             self.complex_logpsi_all_states, in_axes=(None, physical_axis)
         )(stacked_params, replica_data)
+
+
+class CheckpointStateBundle(IndependentStateBundle):
+    """Initialize independent states from native JaQMC checkpoints."""
+
+    def __init__(
+        self,
+        base_wavefunction: WavefunctionLike,
+        spec: SubspaceSpec,
+        checkpoint_paths: tuple[str, ...] | list[str],
+    ):
+        super().__init__(base_wavefunction, spec)
+        self.checkpoint_paths = tuple(checkpoint_paths)
+        if len(self.checkpoint_paths) != spec.n_states:
+            raise ValueError(
+                "subspace.initialization.checkpoints must contain exactly "
+                f"n_states={spec.n_states} paths; got {len(self.checkpoint_paths)}"
+            )
+
+    def init_params(self, physical_data: Data, rngs: PRNGKey) -> Params:
+        template = self.base_wavefunction.init_params(physical_data, rngs)
+        template_def = jax.tree.structure(template)
+        template_shapes = jax.tree.map(jnp.shape, template)
+        loaded = []
+        for checkpoint_path in self.checkpoint_paths:
+            manager = NumPyCheckpointManager(
+                checkpoint_path, checkpoint_path, prefix="train"
+            )
+            _, restored = manager.restore({"params": template}, strict=True)
+            params = restored["params"]
+            if jax.tree.structure(params) != template_def:
+                raise ValueError(
+                    f"Checkpoint parameter PyTree does not match: {checkpoint_path}"
+                )
+            shapes = jax.tree.map(jnp.shape, params)
+            if jax.tree.leaves(shapes) != jax.tree.leaves(template_shapes):
+                raise ValueError(
+                    f"Checkpoint parameter shapes do not match: {checkpoint_path}"
+                )
+            loaded.append(params)
+        return jax.tree.map(lambda *xs: jnp.stack(xs), *loaded)
 
 
 class StateBundleLike(Protocol):

--- a/src/jaqmc/workflow/__init__.py
+++ b/src/jaqmc/workflow/__init__.py
@@ -3,10 +3,13 @@
 
 from .base import Workflow, WorkflowConfig, init_batched_data
 from .evaluation import EvaluationWorkflow
+from .subspace_vmc import SubspaceConfig, SubspaceVMCWorkflow
 from .vmc import VMCWorkflow
 
 __all__ = [
     "EvaluationWorkflow",
+    "SubspaceConfig",
+    "SubspaceVMCWorkflow",
     "VMCWorkflow",
     "Workflow",
     "WorkflowConfig",

--- a/src/jaqmc/workflow/stage/vmc.py
+++ b/src/jaqmc/workflow/stage/vmc.py
@@ -257,6 +257,7 @@ class VMCWorkStage(SamplingWorkStage):
         grads = final_stats.pop("grads", None)
         if grads is None:
             raise ValueError("None of the estimators provides `grads` stats.")
+        final_stats["grad_norm"] = optax.tree.norm(grads)
         apply_update = self.should_apply_update(final_stats)
 
         def update(_):
@@ -267,17 +268,26 @@ class VMCWorkStage(SamplingWorkStage):
                 batched_data=data,
                 rngs=opt_rngs,
             )
-            return optax.apply_updates(state.params, updates), opt_state
+            return (
+                optax.apply_updates(state.params, updates),
+                opt_state,
+                optax.tree.norm(updates),
+            )
 
         if apply_update is None:
-            params, opt_state = update(None)
+            params, opt_state, update_norm = update(None)
         else:
-            params, opt_state = jax.lax.cond(
+            params, opt_state, update_norm = jax.lax.cond(
                 apply_update,
                 update,
-                lambda _: (state.params, state.opt_state),
+                lambda _: (
+                    state.params,
+                    state.opt_state,
+                    jnp.zeros_like(final_stats["grad_norm"]),
+                ),
                 operand=None,
             )
+        final_stats["update_norm"] = update_norm
         new_state = replace(
             state,
             params=params,

--- a/src/jaqmc/workflow/stage/vmc.py
+++ b/src/jaqmc/workflow/stage/vmc.py
@@ -257,14 +257,27 @@ class VMCWorkStage(SamplingWorkStage):
         grads = final_stats.pop("grads", None)
         if grads is None:
             raise ValueError("None of the estimators provides `grads` stats.")
-        updates, opt_state = self.optimizer.update(
-            grads,
-            state.opt_state,
-            params=state.params,
-            batched_data=data,
-            rngs=opt_rngs,
-        )
-        params = optax.apply_updates(state.params, updates)
+        apply_update = self.should_apply_update(final_stats)
+
+        def update(_):
+            updates, opt_state = self.optimizer.update(
+                grads,
+                state.opt_state,
+                params=state.params,
+                batched_data=data,
+                rngs=opt_rngs,
+            )
+            return optax.apply_updates(state.params, updates), opt_state
+
+        if apply_update is None:
+            params, opt_state = update(None)
+        else:
+            params, opt_state = jax.lax.cond(
+                apply_update,
+                update,
+                lambda _: (state.params, state.opt_state),
+                operand=None,
+            )
         new_state = replace(
             state,
             params=params,
@@ -274,6 +287,17 @@ class VMCWorkStage(SamplingWorkStage):
             opt_state=opt_state,
         )
         return new_state, {**final_stats, **sampler_stats}
+
+    def should_apply_update(
+        self, final_stats: dict[str, Any]
+    ) -> jax.Array | None:
+        """Return an optional runtime gate for the optimizer update.
+
+        ``None`` preserves the native unconditional update path. Subclasses
+        may return a scalar boolean array to gate the update with ``lax.cond``.
+        """
+        del final_stats
+        return None
 
     def _has_nan(self, stats: dict[str, Any]) -> bool:
         if not self.config.stop_on_nan:

--- a/src/jaqmc/workflow/stage/vmc.py
+++ b/src/jaqmc/workflow/stage/vmc.py
@@ -258,56 +258,23 @@ class VMCWorkStage(SamplingWorkStage):
         if grads is None:
             raise ValueError("None of the estimators provides `grads` stats.")
         final_stats["grad_norm"] = optax.tree.norm(grads)
-        apply_update = self.should_apply_update(final_stats)
-
-        def update(_):
-            updates, opt_state = self.optimizer.update(
-                grads,
-                state.opt_state,
-                params=state.params,
-                batched_data=data,
-                rngs=opt_rngs,
-            )
-            return (
-                optax.apply_updates(state.params, updates),
-                opt_state,
-                optax.tree.norm(updates),
-            )
-
-        if apply_update is None:
-            params, opt_state, update_norm = update(None)
-        else:
-            params, opt_state, update_norm = jax.lax.cond(
-                apply_update,
-                update,
-                lambda _: (
-                    state.params,
-                    state.opt_state,
-                    jnp.zeros_like(final_stats["grad_norm"]),
-                ),
-                operand=None,
-            )
-        final_stats["update_norm"] = update_norm
+        updates, opt_state = self.optimizer.update(
+            grads,
+            state.opt_state,
+            params=state.params,
+            batched_data=data,
+            rngs=opt_rngs,
+        )
+        final_stats["update_norm"] = optax.tree.norm(updates)
         new_state = replace(
             state,
-            params=params,
+            params=optax.apply_updates(state.params, updates),
             batched_data=data,
             sampler_state=sampler_state,
             estimator_state=estimator_state,
             opt_state=opt_state,
         )
         return new_state, {**final_stats, **sampler_stats}
-
-    def should_apply_update(
-        self, final_stats: dict[str, Any]
-    ) -> jax.Array | None:
-        """Return an optional runtime gate for the optimizer update.
-
-        ``None`` preserves the native unconditional update path. Subclasses
-        may return a scalar boolean array to gate the update with ``lax.cond``.
-        """
-        del final_stats
-        return None
 
     def _has_nan(self, stats: dict[str, Any]) -> bool:
         if not self.config.stop_on_nan:

--- a/src/jaqmc/workflow/subspace_vmc.py
+++ b/src/jaqmc/workflow/subspace_vmc.py
@@ -1,0 +1,203 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""JaQMC-native assembly of determinant-state variational training."""
+
+from collections.abc import Callable, Mapping
+from dataclasses import replace
+from typing import Any
+
+import jax
+from jax import numpy as jnp
+
+from jaqmc.array_types import PRNGKey
+from jaqmc.data import BatchedData
+from jaqmc.estimator import CrossLocalEnergyEvaluator, EstimatorLike
+from jaqmc.estimator.loss_grad import LossAndGrad
+from jaqmc.estimator.rayleigh import RayleighMatrixEstimator
+from jaqmc.optimizer.kfac import KFACOptimizer
+from jaqmc.sampler.determinant import DeterminantMCMCSampler
+from jaqmc.utils.config import ConfigManager, configurable_dataclass
+from jaqmc.utils.wiring import wire
+from jaqmc.wavefunction.determinant_state import (
+    DeterminantStateWavefunction,
+    SubspaceSpec,
+)
+from jaqmc.workflow.stage.vmc import VMCWorkStage
+from jaqmc.workflow.vmc import VMCWorkflow
+
+
+@configurable_dataclass
+class SubspaceConfig:
+    """Configuration shared by molecule and solid subspace workflows."""
+
+    n_states: int = 2
+    condition_warning: float = 1e10
+    solve_residual_warning: float = 1e-6
+    max_imag_eigenvalue_warning: float = 1e-6
+
+    def __post_init__(self):
+        if self.n_states < 1:
+            raise ValueError("subspace.n_states must be positive")
+
+
+def replicate_walker_replicas(
+    batched_data: BatchedData, spec: SubspaceSpec
+) -> BatchedData:
+    """Repeat batched fields along a new replica axis.
+
+    This shape helper is useful in tests and adapters but must not initialize a
+    determinant chain: identical replica rows produce a singular amplitude
+    matrix.  Use :func:`make_subspace_data_init` for workflow initialization.
+    """
+    missing = set(spec.replica_fields) - set(batched_data.fields_with_batch)
+    if missing:
+        raise ValueError(
+            "Replica fields must already carry the walker batch axis: "
+            f"{sorted(missing)}"
+        )
+    data = replace(
+        batched_data.data,
+        **{
+            name: jax.tree.map(
+                lambda x: jnp.repeat(x[:, None], spec.n_states, axis=1),
+                batched_data.data[name],
+            )
+            for name in spec.replica_fields
+        },
+    )
+    return replace(batched_data, data=data)
+
+
+def make_subspace_data_init(
+    physical_data_init: Callable[[int, PRNGKey], BatchedData], spec: SubspaceSpec
+):
+    """Initialize independent physical configurations and group them by walker.
+
+    Repeating one configuration across replicas makes the initial amplitude
+    matrix singular.  Requesting ``B*M`` native samples keeps initialization
+    owned by the app while introducing only a reshape in this adapter.
+    """
+
+    def data_init(size: int, rngs: PRNGKey) -> BatchedData:
+        physical = physical_data_init(size * spec.n_states, rngs)
+        physical.check()
+        if extra := set(physical.fields_with_batch) - set(spec.replica_fields):
+            raise ValueError(
+                "All native batched fields must be listed in replica_fields; "
+                f"missing {sorted(extra)}"
+            )
+        data = replace(
+            physical.data,
+            **{
+                name: jax.tree.map(
+                    lambda x: x.reshape(size, spec.n_states, *x.shape[1:]),
+                    physical.data[name],
+                )
+                for name in physical.fields_with_batch
+                if name in spec.replica_fields
+            },
+        )
+        result = replace(physical, data=data)
+        result.check()
+        return result
+
+    return data_init
+
+
+class SubspaceVMCWorkflow(VMCWorkflow):
+    """Base workflow that reuses JaQMC's VMC stage, gradients, and optimizers."""
+
+    config_namespace = "subspace_train"
+
+    @classmethod
+    def default_preset(cls) -> dict[str, Any]:
+        fields = (
+            "pmove:.2f,energy=subspace_energy:.4f,"
+            "variance=subspace_energy_var:.4f,max_imag=max_ritz_imag:.2e"
+        )
+        return {
+            "train": {
+                "run": {"iterations": 200_000},
+                "writers": {"console": {"fields": fields}},
+            }
+        }
+
+    def __init__(self, cfg: ConfigManager) -> None:
+        super().__init__(cfg)
+        # Read leaves separately so the ``subspace`` namespace can also hold
+        # nested sampler/evaluation configuration without dataclass decoding
+        # treating those sections as unknown SubspaceConfig fields.
+        self.subspace = SubspaceConfig(
+            n_states=cfg.get("subspace.n_states", 2),
+            condition_warning=cfg.get(
+                "subspace.diagnostics.condition_warning", 1e10
+            ),
+            solve_residual_warning=cfg.get(
+                "subspace.diagnostics.solve_residual_warning", 1e-6
+            ),
+            max_imag_eigenvalue_warning=cfg.get(
+                "subspace.diagnostics.max_imag_eigenvalue_warning", 1e-6
+            ),
+        )
+        self.spec = SubspaceSpec(self.subspace.n_states)
+
+    def configure_subspace(
+        self,
+        *,
+        base_wavefunction,
+        physical_data_init: Callable[[int, PRNGKey], BatchedData],
+        physical_energy_estimators: Mapping[str, EstimatorLike],
+        physical_proposal=None,
+    ) -> None:
+        """Assemble the native VMC stage around app-provided physical pieces."""
+        self.base_wavefunction = base_wavefunction
+        self.wf = DeterminantStateWavefunction(base_wavefunction, self.spec)
+        self.data_init = make_subspace_data_init(physical_data_init, self.spec)
+
+        sampler_default = DeterminantMCMCSampler(
+            n_states=self.spec.n_states,
+            initial_width=0.02,
+            **(
+                {"sampling_proposal": physical_proposal}
+                if physical_proposal is not None
+                else {}
+            ),
+        )
+        sampler = self.cfg.get("subspace.sampling", sampler_default)
+        rayleigh = self.cfg.get_module(
+            "subspace.evaluation",
+            RayleighMatrixEstimator,
+        )
+        rayleigh.condition_warning = self.subspace.condition_warning
+        rayleigh.solve_residual_warning = self.subspace.solve_residual_warning
+        rayleigh.max_imag_eigenvalue_warning = (
+            self.subspace.max_imag_eigenvalue_warning
+        )
+        cross_energy = CrossLocalEnergyEvaluator(
+            physical_energy_estimators,
+            self.spec,
+            pair_chunk_size=rayleigh.pair_chunk_size,
+        )
+        wire(
+            rayleigh,
+            f_component_logpsi_matrix=self.wf.component_logpsi_matrix,
+            f_cross_local_energy=cross_energy,
+        )
+
+        train = VMCWorkStage.builder(self.cfg.scoped("train"), self.wf)
+        train.configure_sample_plan(self.wf.logpsi, {"electrons": sampler})
+        train.configure_optimizer(default=KFACOptimizer, f_log_psi=self.wf.logpsi)
+        train.configure_estimators(rayleigh=rayleigh)
+        train.configure_loss_grads(
+            LossAndGrad(loss_key="subspace_energy"), f_log_psi=self.wf.logpsi
+        )
+        self.train_stage = train.build()
+
+
+def energy_estimators_only(
+    estimators: Mapping[str, EstimatorLike],
+) -> dict[str, EstimatorLike]:
+    """Keep the ordered physical energy pipeline and discard unrelated observables."""
+    names = ("potential", "kinetic", "ecp", "ph", "total")
+    return {name: estimators[name] for name in names if name in estimators}

--- a/src/jaqmc/workflow/subspace_vmc.py
+++ b/src/jaqmc/workflow/subspace_vmc.py
@@ -21,6 +21,12 @@ from jaqmc.estimator import (
 from jaqmc.estimator.rayleigh import RayleighMatrixEstimator
 from jaqmc.optimizer.optax import adam
 from jaqmc.sampler.determinant import DeterminantMCMCSampler
+from jaqmc.utils.atomic.pretrain import make_pretrain_log_amplitude
+from jaqmc.utils.atomic.subspace_pretrain import (
+    StateOrbitalReference,
+    make_subspace_pretrain_loss,
+    make_subspace_reference_log_amplitude,
+)
 from jaqmc.utils.config import ConfigManager, configurable_dataclass
 from jaqmc.utils.wiring import wire
 from jaqmc.wavefunction.determinant_state import (
@@ -192,6 +198,7 @@ class SubspaceVMCWorkflow(VMCWorkflow):
             ),
         )
         sampler = self.cfg.get("subspace.sampling", sampler_default)
+        self.subspace_sampler = sampler
         rayleigh = self.cfg.get_module(
             "subspace.evaluation",
             RayleighMatrixEstimator,
@@ -249,6 +256,50 @@ class SubspaceVMCWorkflow(VMCWorkflow):
             writers=native_stage.writers,
             optimizer=native_stage.optimizer,
         )
+
+    def configure_subspace_pretrain(
+        self,
+        *,
+        orbital_reference: StateOrbitalReference,
+        nspins: tuple[int, int],
+        full_det: bool,
+        ref_fraction: float,
+    ) -> None:
+        """Configure native determinant-state orbital pretraining.
+
+        The pretrain and energy stages share the determinant wavefunction and
+        sampler type, allowing :class:`VMCWorkflow` to transfer parameters,
+        walkers, and sampler state without an adapter.
+        """
+        if self.initialization_mode == "checkpoints":
+            raise ValueError(
+                "TDA pretrain and checkpoint initialization are mutually "
+                "exclusive in v1."
+            )
+        loss_estimator = make_subspace_pretrain_loss(
+            orbitals_fn=self.base_wavefunction.orbitals,
+            orbital_ref=orbital_reference,
+            spec=self.spec,
+            nspins=nspins,
+            full_det=full_det,
+        )
+        reference_log_amplitude = make_subspace_reference_log_amplitude(
+            orbital_reference, self.spec, nspins
+        )
+        f_log_amplitude = make_pretrain_log_amplitude(
+            self.wf.logpsi,
+            reference_log_amplitude,
+            ref_fraction=ref_fraction,
+        )
+        pretrain = VMCWorkStage.builder(
+            self.cfg.scoped("pretrain"), self.wf, name="pretrain"
+        )
+        pretrain.configure_sample_plan(
+            f_log_amplitude, {"electrons": self.subspace_sampler}
+        )
+        pretrain.configure_optimizer(default=adam, f_log_psi=self.wf.logpsi)
+        pretrain.configure_estimators(grads=loss_estimator)
+        self.pretrain_stage = pretrain.build()
 
 
 class SubspaceVMCWorkStage(VMCWorkStage):

--- a/src/jaqmc/workflow/subspace_vmc.py
+++ b/src/jaqmc/workflow/subspace_vmc.py
@@ -13,8 +13,11 @@ from jax import numpy as jnp
 
 from jaqmc.array_types import PRNGKey
 from jaqmc.data import BatchedData
-from jaqmc.estimator import CrossLocalEnergyEvaluator, EstimatorLike
-from jaqmc.estimator.loss_grad import StreamingLossAndGrad
+from jaqmc.estimator import (
+    CrossLocalEnergyEvaluator,
+    EstimatorLike,
+    StreamingLossAndGrad,
+)
 from jaqmc.estimator.rayleigh import RayleighMatrixEstimator
 from jaqmc.optimizer.optax import adam
 from jaqmc.sampler.determinant import DeterminantMCMCSampler
@@ -122,7 +125,8 @@ class SubspaceVMCWorkflow(VMCWorkflow):
             "sigma_min=amplitude_sigma_min:.2e,"
             "condition=amplitude_condition:.2e,"
             "residual=rayleigh_solve_residual:.2e,"
-            "max_imag=max_ritz_imag:.2e"
+            "max_imag=max_ritz_imag:.2e,"
+            "grad_norm=grad_norm:.2e,update_norm=update_norm:.2e"
         )
         return {
             "train": {
@@ -217,12 +221,17 @@ class SubspaceVMCWorkflow(VMCWorkflow):
             raise TypeError("train.grads estimator must expose a loss_key field")
         grads.loss_key = "subspace_local_energy"
         train.configure_loss_grads(grads, f_log_psi=self.wf.logpsi)
+        device_count = jax.device_count()
+        local_batch = self.config.batch_size // device_count
         logger.info(
-            "Subspace chunking: n_states=%s, determinant_batch=%s, "
+            "Subspace chunking: n_states=%s, global_batch=%s, "
+            "local_batch=%s, devices=%s, "
             "rayleigh_walkers=%s, cross_pairs=%s, gradient_walkers=%s, "
             "matrix_dtype=%s, optimizer=%s, objective=%s",
             self.spec.n_states,
             self.config.batch_size,
+            local_batch,
+            device_count,
             rayleigh.vmap_chunk_size,
             rayleigh.pair_chunk_size,
             getattr(grads, "vmap_chunk_size", None),

--- a/src/jaqmc/workflow/subspace_vmc.py
+++ b/src/jaqmc/workflow/subspace_vmc.py
@@ -3,6 +3,7 @@
 
 """JaQMC-native assembly of determinant-state variational training."""
 
+import logging
 from collections.abc import Callable, Mapping
 from dataclasses import replace
 from typing import Any
@@ -13,7 +14,7 @@ from jax import numpy as jnp
 from jaqmc.array_types import PRNGKey
 from jaqmc.data import BatchedData
 from jaqmc.estimator import CrossLocalEnergyEvaluator, EstimatorLike
-from jaqmc.estimator.loss_grad import LossAndGrad
+from jaqmc.estimator.loss_grad import StreamingLossAndGrad
 from jaqmc.estimator.rayleigh import RayleighMatrixEstimator
 from jaqmc.optimizer.optax import adam
 from jaqmc.sampler.determinant import DeterminantMCMCSampler
@@ -26,6 +27,8 @@ from jaqmc.wavefunction.determinant_state import (
 )
 from jaqmc.workflow.stage.vmc import VMCWorkStage
 from jaqmc.workflow.vmc import VMCWorkflow
+
+logger = logging.getLogger(__name__)
 
 
 @configurable_dataclass
@@ -209,9 +212,23 @@ class SubspaceVMCWorkflow(VMCWorkflow):
         train.configure_sample_plan(self.wf.logpsi, {"electrons": sampler})
         train.configure_optimizer(default=adam, f_log_psi=self.wf.logpsi)
         train.configure_estimators(rayleigh=rayleigh)
-        train.configure_loss_grads(
-            LossAndGrad(loss_key="subspace_local_energy"),
-            f_log_psi=self.wf.logpsi,
+        grads = train.cfg.get("grads", StreamingLossAndGrad)
+        if not hasattr(grads, "loss_key"):
+            raise TypeError("train.grads estimator must expose a loss_key field")
+        grads.loss_key = "subspace_local_energy"
+        train.configure_loss_grads(grads, f_log_psi=self.wf.logpsi)
+        logger.info(
+            "Subspace chunking: n_states=%s, determinant_batch=%s, "
+            "rayleigh_walkers=%s, cross_pairs=%s, gradient_walkers=%s, "
+            "matrix_dtype=%s, optimizer=%s, objective=%s",
+            self.spec.n_states,
+            self.config.batch_size,
+            rayleigh.vmap_chunk_size,
+            rayleigh.pair_chunk_size,
+            getattr(grads, "vmap_chunk_size", None),
+            rayleigh.matrix_dtype,
+            type(train.optimizer).__name__,
+            grads.loss_key,
         )
         native_stage = train.build()
         self.train_stage = SubspaceVMCWorkStage(
@@ -226,20 +243,10 @@ class SubspaceVMCWorkflow(VMCWorkflow):
 
 
 class SubspaceVMCWorkStage(VMCWorkStage):
-    """Native VMC stage with rollback-before-abort for invalid subspace steps."""
+    """Native VMC stage that skips updates for invalid Rayleigh steps."""
 
-    def compute_step(self, state, rngs):
-        updated, stats = super().compute_step(state, rngs)
-        valid = stats.get("training_step_valid", jnp.array(True))
-        params = jax.tree.map(
-            lambda new, old: jnp.where(valid, new, old), updated.params, state.params
-        )
-        opt_state = jax.tree.map(
-            lambda new, old: jnp.where(valid, new, old),
-            updated.opt_state,
-            state.opt_state,
-        )
-        return replace(updated, params=params, opt_state=opt_state), stats
+    def should_apply_update(self, final_stats: dict[str, Any]) -> jax.Array:
+        return jnp.asarray(final_stats.get("training_step_valid", True))
 
     def _has_nan(self, stats: dict[str, Any]) -> bool:
         if "training_step_valid" in stats and not bool(

--- a/src/jaqmc/workflow/subspace_vmc.py
+++ b/src/jaqmc/workflow/subspace_vmc.py
@@ -20,6 +20,7 @@ from jaqmc.sampler.determinant import DeterminantMCMCSampler
 from jaqmc.utils.config import ConfigManager, configurable_dataclass
 from jaqmc.utils.wiring import wire
 from jaqmc.wavefunction.determinant_state import (
+    CheckpointStateBundle,
     DeterminantStateWavefunction,
     SubspaceSpec,
 )
@@ -35,6 +36,8 @@ class SubspaceConfig:
     condition_warning: float = 1e10
     solve_residual_warning: float = 1e-6
     max_imag_eigenvalue_warning: float = 1e-6
+    condition_hard_limit: float = 1e14
+    min_valid_fraction: float = 0.99
 
     def __post_init__(self):
         if self.n_states < 1:
@@ -139,8 +142,22 @@ class SubspaceVMCWorkflow(VMCWorkflow):
             max_imag_eigenvalue_warning=cfg.get(
                 "subspace.diagnostics.max_imag_eigenvalue_warning", 1e-6
             ),
+            condition_hard_limit=cfg.get(
+                "subspace.diagnostics.condition_hard_limit", 1e14
+            ),
+            min_valid_fraction=cfg.get(
+                "subspace.diagnostics.min_valid_fraction", 0.99
+            ),
         )
         self.spec = SubspaceSpec(self.subspace.n_states)
+        self.initialization_mode = cfg.get("subspace.initialization.mode", "random")
+        self.initialization_checkpoints = cfg.get(
+            "subspace.initialization.checkpoints", []
+        )
+        if self.initialization_mode not in ("random", "checkpoints"):
+            raise ValueError(
+                "subspace.initialization.mode must be 'random' or 'checkpoints'"
+            )
 
     def configure_subspace(
         self,
@@ -152,7 +169,14 @@ class SubspaceVMCWorkflow(VMCWorkflow):
     ) -> None:
         """Assemble the native VMC stage around app-provided physical pieces."""
         self.base_wavefunction = base_wavefunction
-        self.wf = DeterminantStateWavefunction(base_wavefunction, self.spec)
+        state_bundle = None
+        if self.initialization_mode == "checkpoints":
+            state_bundle = CheckpointStateBundle(
+                base_wavefunction, self.spec, self.initialization_checkpoints
+            )
+        self.wf = DeterminantStateWavefunction(
+            base_wavefunction, self.spec, state_bundle=state_bundle
+        )
         self.data_init = make_subspace_data_init(physical_data_init, self.spec)
 
         sampler_default = DeterminantMCMCSampler(
@@ -174,6 +198,8 @@ class SubspaceVMCWorkflow(VMCWorkflow):
         rayleigh.max_imag_eigenvalue_warning = (
             self.subspace.max_imag_eigenvalue_warning
         )
+        rayleigh.condition_hard_limit = self.subspace.condition_hard_limit
+        rayleigh.min_valid_fraction = self.subspace.min_valid_fraction
         cross_energy = CrossLocalEnergyEvaluator(
             physical_energy_estimators,
             self.spec,
@@ -190,9 +216,45 @@ class SubspaceVMCWorkflow(VMCWorkflow):
         train.configure_optimizer(default=KFACOptimizer, f_log_psi=self.wf.logpsi)
         train.configure_estimators(rayleigh=rayleigh)
         train.configure_loss_grads(
-            LossAndGrad(loss_key="subspace_energy"), f_log_psi=self.wf.logpsi
+            LossAndGrad(
+                loss_key="subspace_local_energy", validity_key="rayleigh_valid"
+            ),
+            f_log_psi=self.wf.logpsi,
         )
-        self.train_stage = train.build()
+        native_stage = train.build()
+        self.train_stage = SubspaceVMCWorkStage(
+            config=native_stage.config,
+            name=native_stage.name,
+            wavefunction=native_stage.wavefunction,
+            sample_plan=native_stage.sample_plan,
+            estimators=native_stage.estimators,
+            writers=native_stage.writers,
+            optimizer=native_stage.optimizer,
+        )
+
+
+class SubspaceVMCWorkStage(VMCWorkStage):
+    """Native VMC stage with rollback-before-abort for invalid subspace steps."""
+
+    def compute_step(self, state, rngs):
+        updated, stats = super().compute_step(state, rngs)
+        valid = stats.get("training_step_valid", jnp.array(True))
+        params = jax.tree.map(
+            lambda new, old: jnp.where(valid, new, old), updated.params, state.params
+        )
+        opt_state = jax.tree.map(
+            lambda new, old: jnp.where(valid, new, old),
+            updated.opt_state,
+            state.opt_state,
+        )
+        return replace(updated, params=params, opt_state=opt_state), stats
+
+    def _has_nan(self, stats: dict[str, Any]) -> bool:
+        if "training_step_valid" in stats and not bool(
+            jnp.asarray(stats["training_step_valid"])
+        ):
+            return True
+        return super()._has_nan(stats)
 
 
 def energy_estimators_only(

--- a/src/jaqmc/workflow/subspace_vmc.py
+++ b/src/jaqmc/workflow/subspace_vmc.py
@@ -15,7 +15,7 @@ from jaqmc.data import BatchedData
 from jaqmc.estimator import CrossLocalEnergyEvaluator, EstimatorLike
 from jaqmc.estimator.loss_grad import LossAndGrad
 from jaqmc.estimator.rayleigh import RayleighMatrixEstimator
-from jaqmc.optimizer.kfac import KFACOptimizer
+from jaqmc.optimizer.optax import adam
 from jaqmc.sampler.determinant import DeterminantMCMCSampler
 from jaqmc.utils.config import ConfigManager, configurable_dataclass
 from jaqmc.utils.wiring import wire
@@ -36,8 +36,6 @@ class SubspaceConfig:
     condition_warning: float = 1e10
     solve_residual_warning: float = 1e-6
     max_imag_eigenvalue_warning: float = 1e-6
-    condition_hard_limit: float = 1e14
-    min_valid_fraction: float = 0.99
 
     def __post_init__(self):
         if self.n_states < 1:
@@ -117,7 +115,11 @@ class SubspaceVMCWorkflow(VMCWorkflow):
     def default_preset(cls) -> dict[str, Any]:
         fields = (
             "pmove:.2f,energy=subspace_energy:.4f,"
-            "variance=subspace_energy_var:.4f,max_imag=max_ritz_imag:.2e"
+            "variance=subspace_energy_var:.4f,imag=subspace_energy_imag:.2e,"
+            "sigma_min=amplitude_sigma_min:.2e,"
+            "condition=amplitude_condition:.2e,"
+            "residual=rayleigh_solve_residual:.2e,"
+            "max_imag=max_ritz_imag:.2e"
         )
         return {
             "train": {
@@ -141,12 +143,6 @@ class SubspaceVMCWorkflow(VMCWorkflow):
             ),
             max_imag_eigenvalue_warning=cfg.get(
                 "subspace.diagnostics.max_imag_eigenvalue_warning", 1e-6
-            ),
-            condition_hard_limit=cfg.get(
-                "subspace.diagnostics.condition_hard_limit", 1e14
-            ),
-            min_valid_fraction=cfg.get(
-                "subspace.diagnostics.min_valid_fraction", 0.99
             ),
         )
         self.spec = SubspaceSpec(self.subspace.n_states)
@@ -198,8 +194,6 @@ class SubspaceVMCWorkflow(VMCWorkflow):
         rayleigh.max_imag_eigenvalue_warning = (
             self.subspace.max_imag_eigenvalue_warning
         )
-        rayleigh.condition_hard_limit = self.subspace.condition_hard_limit
-        rayleigh.min_valid_fraction = self.subspace.min_valid_fraction
         cross_energy = CrossLocalEnergyEvaluator(
             physical_energy_estimators,
             self.spec,
@@ -213,12 +207,10 @@ class SubspaceVMCWorkflow(VMCWorkflow):
 
         train = VMCWorkStage.builder(self.cfg.scoped("train"), self.wf)
         train.configure_sample_plan(self.wf.logpsi, {"electrons": sampler})
-        train.configure_optimizer(default=KFACOptimizer, f_log_psi=self.wf.logpsi)
+        train.configure_optimizer(default=adam, f_log_psi=self.wf.logpsi)
         train.configure_estimators(rayleigh=rayleigh)
         train.configure_loss_grads(
-            LossAndGrad(
-                loss_key="subspace_local_energy", validity_key="rayleigh_valid"
-            ),
+            LossAndGrad(loss_key="subspace_local_energy"),
             f_log_psi=self.wf.logpsi,
         )
         native_stage = train.build()

--- a/src/jaqmc/workflow/subspace_vmc.py
+++ b/src/jaqmc/workflow/subspace_vmc.py
@@ -6,9 +6,11 @@
 import logging
 from collections.abc import Callable, Mapping
 from dataclasses import replace
+from operator import itemgetter
 from typing import Any
 
 import jax
+import optax
 from jax import numpy as jnp
 
 from jaqmc.array_types import PRNGKey
@@ -304,29 +306,65 @@ class SubspaceVMCWorkflow(VMCWorkflow):
 
 
 class SubspaceVMCWorkStage(VMCWorkStage):
-    """Native VMC stage that skips updates for invalid Rayleigh steps."""
+    """Native VMC stage that gates invalid Rayleigh steps before optimization."""
 
     def compute_step(self, state, rngs):
-        """Run the native step and roll back only an invalid optimizer update."""
-        new_state, stats = super().compute_step(state, rngs)
-        valid = jnp.asarray(stats.get("training_step_valid", True))
-        new_state = replace(
-            new_state,
-            params=jax.tree.map(
-                lambda new, old: jnp.where(valid, new, old),
-                new_state.params,
-                state.params,
-            ),
-            opt_state=jax.tree.map(
-                lambda new, old: jnp.where(valid, new, old),
-                new_state.opt_state,
+        """Sample and estimate first, then bypass the optimizer if invalid."""
+        sampler_rngs, est_rngs, opt_rngs = jax.random.split(rngs, 3)
+        data, sampler_stats, sampler_state = self.sample_plan.step(
+            state.params, state.batched_data, state.sampler_state, sampler_rngs
+        )
+        step_stats, estimator_state = self.estimators.evaluate(
+            state.params, data, state.estimator_state, est_rngs
+        )
+        batched = jax.tree.map(itemgetter(None), step_stats)
+        final_stats = self.estimators.finalize_stats(batched, estimator_state)
+        grads = final_stats.pop("grads", None)
+        if grads is None:
+            raise ValueError("None of the estimators provides `grads` stats.")
+        grad_norm = optax.tree.norm(grads)
+        final_stats["grad_norm"] = grad_norm
+        valid = jnp.asarray(final_stats.get("training_step_valid", True))
+
+        def apply_optimizer(_):
+            updates, opt_state = self.optimizer.update(
+                grads,
                 state.opt_state,
-            ),
+                params=state.params,
+                batched_data=data,
+                rngs=opt_rngs,
+            )
+            return (
+                optax.apply_updates(state.params, updates),
+                opt_state,
+                optax.tree.norm(updates),
+            )
+
+        def preserve_state(_):
+            return state.params, state.opt_state, jnp.zeros_like(grad_norm)
+
+        try:
+            concrete_valid = bool(valid)
+        except jax.errors.TracerBoolConversionError:
+            params, opt_state, update_norm = jax.lax.cond(
+                valid, apply_optimizer, preserve_state, operand=None
+            )
+        else:
+            if concrete_valid:
+                params, opt_state, update_norm = apply_optimizer(None)
+            else:
+                params, opt_state, update_norm = preserve_state(None)
+
+        final_stats["update_norm"] = update_norm
+        new_state = replace(
+            state,
+            params=params,
+            batched_data=data,
+            sampler_state=sampler_state,
+            estimator_state=estimator_state,
+            opt_state=opt_state,
         )
-        stats["update_norm"] = jnp.where(
-            valid, stats["update_norm"], jnp.zeros_like(stats["update_norm"])
-        )
-        return new_state, stats
+        return new_state, {**final_stats, **sampler_stats}
 
     def _has_nan(self, stats: dict[str, Any]) -> bool:
         if "training_step_valid" in stats and not bool(

--- a/src/jaqmc/workflow/subspace_vmc.py
+++ b/src/jaqmc/workflow/subspace_vmc.py
@@ -128,6 +128,7 @@ class SubspaceVMCWorkflow(VMCWorkflow):
         fields = (
             "pmove:.2f,energy=subspace_energy:.4f,"
             "variance=subspace_energy_var:.4f,imag=subspace_energy_imag:.2e,"
+            "grass_var=grassmann_hamiltonian_variance:.3e,"
             "sigma_min=amplitude_sigma_min:.2e,"
             "condition=amplitude_condition:.2e,"
             "residual=rayleigh_solve_residual:.2e,"
@@ -305,8 +306,27 @@ class SubspaceVMCWorkflow(VMCWorkflow):
 class SubspaceVMCWorkStage(VMCWorkStage):
     """Native VMC stage that skips updates for invalid Rayleigh steps."""
 
-    def should_apply_update(self, final_stats: dict[str, Any]) -> jax.Array:
-        return jnp.asarray(final_stats.get("training_step_valid", True))
+    def compute_step(self, state, rngs):
+        """Run the native step and roll back only an invalid optimizer update."""
+        new_state, stats = super().compute_step(state, rngs)
+        valid = jnp.asarray(stats.get("training_step_valid", True))
+        new_state = replace(
+            new_state,
+            params=jax.tree.map(
+                lambda new, old: jnp.where(valid, new, old),
+                new_state.params,
+                state.params,
+            ),
+            opt_state=jax.tree.map(
+                lambda new, old: jnp.where(valid, new, old),
+                new_state.opt_state,
+                state.opt_state,
+            ),
+        )
+        stats["update_norm"] = jnp.where(
+            valid, stats["update_norm"], jnp.zeros_like(stats["update_norm"])
+        )
+        return new_state, stats
 
     def _has_nan(self, stats: dict[str, Any]) -> bool:
         if "training_step_valid" in stats and not bool(

--- a/tests/cli_dry_run_test.py
+++ b/tests/cli_dry_run_test.py
@@ -408,7 +408,12 @@ def test_solid_subspace_train_help_is_exposed() -> None:
 
 
 @pytest.mark.parametrize(
-    "config_name", ["hchain_subspace_smoke.yml", "h24_subspace_smoke.yml"]
+    "config_name",
+    [
+        "hchain_subspace_smoke.yml",
+        "hchain_subspace_tda_pretrain_smoke.yml",
+        "h24_subspace_smoke.yml",
+    ],
 )
 def test_solid_subspace_smoke_yaml_dry_run(config_name: str) -> None:
     smoke_config = (
@@ -444,6 +449,27 @@ def test_solid_subspace_h24_overlay_dry_run(hardware_name: str) -> None:
             str(configs / "workflows" / "subspace_smoke.yml"),
             "--yml",
             str(configs / "hardware" / hardware_name),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+
+
+def test_solid_subspace_h24_tda_pretrain_overlay_dry_run() -> None:
+    root = Path(__file__).resolve().parents[1]
+    configs = root / "configs"
+    result = CliRunner().invoke(
+        cli,
+        [
+            "solid",
+            "subspace-train",
+            "--yml",
+            str(configs / "systems" / "h24_base.yml"),
+            "--yml",
+            str(configs / "workflows" / "subspace_tda_pretrain_smoke.yml"),
+            "--yml",
+            str(configs / "hardware" / "single_v100.yml"),
             "--dry-run",
         ],
     )

--- a/tests/cli_dry_run_test.py
+++ b/tests/cli_dry_run_test.py
@@ -400,6 +400,29 @@ def test_cli_command_dry_run(
     assert result.exit_code == 0, f"command: {case.command}\noutput:\n{result.output}"
 
 
+def test_solid_subspace_train_help_is_exposed() -> None:
+    result = CliRunner().invoke(cli, ["solid", "subspace-train", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "solid-state low-energy subspace" in result.output
+
+
+def test_solid_subspace_smoke_yaml_dry_run() -> None:
+    smoke_config = (
+        Path(__file__).resolve().parents[1]
+        / "examples"
+        / "solid"
+        / "hchain_subspace_smoke.yml"
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["solid", "subspace-train", "--yml", str(smoke_config), "--dry-run"],
+    )
+
+    assert result.exit_code == 0, result.output
+
+
 def test_cli_verbose_config_dotlist(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level("INFO", logger="jaqmc.utils.config")
 

--- a/tests/cli_dry_run_test.py
+++ b/tests/cli_dry_run_test.py
@@ -426,6 +426,31 @@ def test_solid_subspace_smoke_yaml_dry_run(config_name: str) -> None:
     assert result.exit_code == 0, result.output
 
 
+@pytest.mark.parametrize(
+    "hardware_name",
+    ["single_v100.yml", "multi_v100_2gpu.yml", "multi_v100_4gpu.yml"],
+)
+def test_solid_subspace_h24_overlay_dry_run(hardware_name: str) -> None:
+    root = Path(__file__).resolve().parents[1]
+    configs = root / "configs"
+    result = CliRunner().invoke(
+        cli,
+        [
+            "solid",
+            "subspace-train",
+            "--yml",
+            str(configs / "systems" / "h24_base.yml"),
+            "--yml",
+            str(configs / "workflows" / "subspace_smoke.yml"),
+            "--yml",
+            str(configs / "hardware" / hardware_name),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+
+
 def test_cli_verbose_config_dotlist(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level("INFO", logger="jaqmc.utils.config")
 

--- a/tests/cli_dry_run_test.py
+++ b/tests/cli_dry_run_test.py
@@ -407,12 +407,15 @@ def test_solid_subspace_train_help_is_exposed() -> None:
     assert "solid-state low-energy subspace" in result.output
 
 
-def test_solid_subspace_smoke_yaml_dry_run() -> None:
+@pytest.mark.parametrize(
+    "config_name", ["hchain_subspace_smoke.yml", "h24_subspace_smoke.yml"]
+)
+def test_solid_subspace_smoke_yaml_dry_run(config_name: str) -> None:
     smoke_config = (
         Path(__file__).resolve().parents[1]
         / "examples"
         / "solid"
-        / "hchain_subspace_smoke.yml"
+        / config_name
     )
 
     result = CliRunner().invoke(

--- a/tests/cli_dry_run_test.py
+++ b/tests/cli_dry_run_test.py
@@ -477,6 +477,30 @@ def test_solid_subspace_h24_tda_pretrain_overlay_dry_run() -> None:
     assert result.exit_code == 0, result.output
 
 
+@pytest.mark.parametrize(
+    "optimizer_config",
+    ["subspace_grassmann_sr.yml", "subspace_gvmc_reference_sr.yml"],
+)
+def test_solid_subspace_grassmann_optimizer_overlay_dry_run(
+    optimizer_config: str,
+) -> None:
+    root = Path(__file__).resolve().parents[1]
+    result = CliRunner().invoke(
+        cli,
+        [
+            "solid",
+            "subspace-train",
+            "--yml",
+            str(root / "examples" / "solid" / "hchain_subspace_smoke.yml"),
+            "--yml",
+            str(root / "configs" / "workflows" / optimizer_config),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+
+
 def test_cli_verbose_config_dotlist(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level("INFO", logger="jaqmc.utils.config")
 

--- a/tests/estimator/loss_grad_test.py
+++ b/tests/estimator/loss_grad_test.py
@@ -1,14 +1,16 @@
 # Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
 # SPDX-License-Identifier: Apache-2.0
 
-import numpy as np
-import yaml
 import jax
+import numpy as np
+import pytest
+import yaml
 from jax import lax
 from jax import numpy as jnp
 
 from jaqmc.app.hall import HallTrainWorkflow
-from jaqmc.estimator.loss_grad import LossAndGrad
+from jaqmc.data import BatchedData, Data
+from jaqmc.estimator.loss_grad import LossAndGrad, StreamingLossAndGrad
 from jaqmc.utils.clip import clip_observable
 from jaqmc.utils.config import ConfigManager
 
@@ -75,6 +77,61 @@ def test_loss_and_grad_reduce_uses_selected_clip_method(monkeypatch):
         reduced["grad_logpsi_and_loss"]["w"],
         jnp.mean(grads["w"] * expected_clipped),
     )
+    assert not any(key.endswith("_var") for key in reduced)
+
+
+class GradientData(Data):
+    x: jax.Array
+
+
+@pytest.mark.parametrize("clip_method", ["none", "mad", "iqr"])
+@pytest.mark.parametrize("complex_output", [False, True])
+def test_streaming_loss_grad_matches_reference(
+    monkeypatch, clip_method, complex_output
+):
+    _mock_all_gather_identity(monkeypatch)
+    data = BatchedData(GradientData(x=jnp.array([0.2, -0.4, 0.7, 1.1, -0.8])), ["x"])
+    params = {"a": jnp.array(0.6), "b": jnp.array(-0.3)}
+    local_energy = jnp.array(
+        [1.0 + 0.2j, -0.5 + 0.7j, 2.0 - 0.3j, 0.1 + 0.9j, 1.3 - 0.4j]
+    )
+
+    def logpsi(p, one_data):
+        value = p["a"] * one_data.x + p["b"] * one_data.x**2
+        return value + 1j * p["b"] * one_data.x if complex_output else value
+
+    reference = LossAndGrad(
+        loss_key="energy", clip_method=clip_method, f_log_psi=logpsi
+    )
+    streaming = StreamingLossAndGrad(
+        loss_key="energy",
+        vmap_chunk_size=2,
+        clip_method=clip_method,
+        f_log_psi=logpsi,
+    )
+    prev_stats = {"energy": local_energy}
+
+    ref_walkers, _ = reference.evaluate_batch_walkers(
+        params, data, prev_stats, None, jax.random.key(0)
+    )
+    ref_reduced = reference.reduce(ref_walkers)
+    ref_final = reference.finalize_stats(
+        jax.tree.map(lambda x: x[None], ref_reduced), None
+    )
+    stream_sums, _ = streaming.evaluate_batch_walkers(
+        params, data, prev_stats, None, jax.random.key(0)
+    )
+    stream_reduced = streaming.reduce(stream_sums)
+    stream_final = streaming.finalize_stats(
+        jax.tree.map(lambda x: x[None], stream_reduced), None
+    )
+
+    np.testing.assert_allclose(stream_final["loss"], ref_final["loss"], rtol=1e-6)
+    for actual, expected in zip(
+        jax.tree.leaves(stream_final["grads"]),
+        jax.tree.leaves(ref_final["grads"]),
+    ):
+        np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)
 
 
 def test_loss_and_grad_keeps_imaginary_local_energy_contribution():

--- a/tests/estimator/loss_grad_test.py
+++ b/tests/estimator/loss_grad_test.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import yaml
+import jax
 from jax import lax
 from jax import numpy as jnp
 
@@ -74,6 +75,44 @@ def test_loss_and_grad_reduce_uses_selected_clip_method(monkeypatch):
         reduced["grad_logpsi_and_loss"]["w"],
         jnp.mean(grads["w"] * expected_clipped),
     )
+
+
+def test_loss_and_grad_keeps_imaginary_local_energy_contribution():
+    estimator = LossAndGrad(clip_method="none")
+    local_energy = jnp.array([1.0 + 2.0j, 3.0 - 1.0j])
+    grad_logpsi = {"w": jnp.array([1.0 + 1.0j, 2.0 - 3.0j])}
+
+    reduced = estimator.reduce(
+        {"loss": local_energy, "grad_logpsi": grad_logpsi}
+    )
+    final = estimator.finalize_stats(
+        jax.tree.map(lambda x: x[None], reduced), None
+    )
+    centered = local_energy - jnp.mean(local_energy)
+    expected = 2 * jnp.mean(jnp.real(jnp.conj(grad_logpsi["w"]) * centered))
+    wrong_real_only = 2 * jnp.mean(
+        jnp.real(jnp.conj(grad_logpsi["w"]) * jnp.real(centered))
+    )
+
+    np.testing.assert_allclose(final["grads"]["w"], expected)
+    assert not np.isclose(float(expected), float(wrong_real_only))
+
+
+def test_loss_and_grad_validity_mask_uses_same_walker_subset():
+    estimator = LossAndGrad(clip_method="none", validity_key="valid")
+    reduced = estimator.reduce(
+        {
+            "loss": jnp.array([1.0, 1000.0, 5.0]),
+            "grad_logpsi": {"w": jnp.array([1.0, 100.0, 3.0])},
+            "loss_valid": jnp.array([True, False, True]),
+        }
+    )
+    final = estimator.finalize_stats(
+        jax.tree.map(lambda x: x[None], reduced), None
+    )
+    expected = 2 * jnp.mean(jnp.array([1.0, 3.0]) * (jnp.array([1.0, 5.0]) - 3.0))
+
+    np.testing.assert_allclose(final["grads"]["w"], expected)
 
 
 def test_loss_and_grad_config_roundtrip_preserves_clip_method():

--- a/tests/estimator/loss_grad_test.py
+++ b/tests/estimator/loss_grad_test.py
@@ -10,7 +10,7 @@ from jax import numpy as jnp
 
 from jaqmc.app.hall import HallTrainWorkflow
 from jaqmc.data import BatchedData, Data
-from jaqmc.estimator.loss_grad import LossAndGrad, StreamingLossAndGrad
+from jaqmc.estimator import LossAndGrad, StreamingLossAndGrad
 from jaqmc.utils.clip import clip_observable
 from jaqmc.utils.config import ConfigManager
 
@@ -86,14 +86,24 @@ class GradientData(Data):
 
 @pytest.mark.parametrize("clip_method", ["none", "mad", "iqr"])
 @pytest.mark.parametrize("complex_output", [False, True])
+@pytest.mark.parametrize("chunk_size", [1, 2, 4, 6])
 def test_streaming_loss_grad_matches_reference(
-    monkeypatch, clip_method, complex_output
+    monkeypatch, clip_method, complex_output, chunk_size
 ):
     _mock_all_gather_identity(monkeypatch)
-    data = BatchedData(GradientData(x=jnp.array([0.2, -0.4, 0.7, 1.1, -0.8])), ["x"])
+    data = BatchedData(
+        GradientData(x=jnp.array([0.2, -0.4, 0.7, 1.1, -0.8, 0.3])), ["x"]
+    )
     params = {"a": jnp.array(0.6), "b": jnp.array(-0.3)}
     local_energy = jnp.array(
-        [1.0 + 0.2j, -0.5 + 0.7j, 2.0 - 0.3j, 0.1 + 0.9j, 1.3 - 0.4j]
+        [
+            1.0 + 0.2j,
+            -0.5 + 0.7j,
+            2.0 - 0.3j,
+            0.1 + 0.9j,
+            1.3 - 0.4j,
+            -0.2 + 0.1j,
+        ]
     )
 
     def logpsi(p, one_data):
@@ -105,7 +115,7 @@ def test_streaming_loss_grad_matches_reference(
     )
     streaming = StreamingLossAndGrad(
         loss_key="energy",
-        vmap_chunk_size=2,
+        vmap_chunk_size=chunk_size,
         clip_method=clip_method,
         f_log_psi=logpsi,
     )

--- a/tests/estimator/loss_grad_test.py
+++ b/tests/estimator/loss_grad_test.py
@@ -13,6 +13,7 @@ from jaqmc.data import BatchedData, Data
 from jaqmc.estimator import LossAndGrad, StreamingLossAndGrad
 from jaqmc.utils.clip import clip_observable
 from jaqmc.utils.config import ConfigManager
+from jaqmc.utils.func_transform import grad_maybe_complex
 
 
 def _mock_all_gather_identity(monkeypatch):
@@ -82,6 +83,47 @@ def test_loss_and_grad_reduce_uses_selected_clip_method(monkeypatch):
 
 class GradientData(Data):
     x: jax.Array
+
+
+def test_native_vmc_gradient_convention_is_two_times_centered_score_force():
+    data = BatchedData(
+        GradientData(x=jnp.array([-1.2, -0.4, 0.1, 0.6, 1.0, 1.7])), ["x"]
+    )
+    params = {"weights": jnp.array([0.3, -0.2], dtype=jnp.float64)}
+    local_energy = jnp.array(
+        [0.8 + 0.1j, -0.4 + 0.7j, 1.3 - 0.2j,
+         -0.1 + 0.5j, 0.6 - 0.8j, -0.7 + 0.2j],
+        dtype=jnp.complex128,
+    )
+
+    def logpsi(p, sample):
+        value = p["weights"][0] * sample.x + p["weights"][1] * sample.x**2
+        return value + 0.2j * p["weights"][0] * sample.x**2
+
+    estimator = StreamingLossAndGrad(
+        loss_key="energy", clip_method="none", f_log_psi=logpsi
+    )
+    sums, _ = estimator.evaluate_batch_walkers(
+        params, data, {"energy": local_energy}, None, jax.random.key(0)
+    )
+    reduced = estimator.reduce(sums)
+    final = estimator.finalize_stats(
+        jax.tree.map(lambda x: x[None], reduced), None
+    )
+
+    scores = jax.vmap(lambda sample: grad_maybe_complex(logpsi)(params, sample))(
+        data.data
+    )["weights"]
+    n_walkers = data.batch_size
+    jacobian = (scores - jnp.mean(scores, axis=0)) / jnp.sqrt(n_walkers)
+    force = (local_energy - jnp.mean(local_energy)) / jnp.sqrt(n_walkers)
+    jacobian = jnp.concatenate((jnp.real(jacobian), jnp.imag(jacobian)), axis=0)
+    force = jnp.concatenate((jnp.real(force), jnp.imag(force)), axis=0)
+    gvmc_gradient = jacobian.T @ force
+
+    np.testing.assert_allclose(
+        final["grads"]["weights"], 2.0 * gvmc_gradient, rtol=1e-11, atol=1e-12
+    )
 
 
 @pytest.mark.parametrize("clip_method", ["none", "mad", "iqr"])

--- a/tests/estimator/rayleigh_test.py
+++ b/tests/estimator/rayleigh_test.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jaqmc.data import Data
+from jaqmc.estimator.rayleigh import (
+    CrossLocalEnergyEvaluator,
+    RayleighMatrixEstimator,
+)
+from jaqmc.estimator.total_energy import TotalEnergy
+from jaqmc.wavefunction.determinant_state import SubspaceSpec
+
+
+class ToyData(Data):
+    electrons: jax.Array
+
+
+def test_rayleigh_estimator_matches_direct_solve():
+    phi = jnp.array([[2.0, 0.5], [0.25, 1.5]], dtype=jnp.complex64)
+    logs = jnp.log(phi)
+    local_energy = jnp.array([[1.0, 2.0], [3.0, 4.0]], dtype=jnp.complex64)
+    estimator = RayleighMatrixEstimator(
+        matrix_dtype="complex64",
+        f_component_logpsi_matrix=lambda params, data: logs,
+        f_cross_local_energy=lambda params, data, rngs: local_energy,
+    )
+
+    stats, state = estimator.evaluate_single_walker(
+        {}, ToyData(electrons=jnp.zeros((2, 1, 1))), {}, None, jax.random.key(0)
+    )
+    expected = jnp.linalg.solve(phi, phi * local_energy)
+
+    assert state is None
+    np.testing.assert_allclose(stats["local_rayleigh"], expected, rtol=1e-6)
+    np.testing.assert_allclose(
+        stats["subspace_energy"], jnp.trace(expected).real, rtol=1e-6
+    )
+    # CUDA complex64 small solves have backend-dependent residuals around
+    # 1e-4; the estimator's production default remains complex128.
+    np.testing.assert_allclose(stats["rayleigh_solve_residual"], 0, atol=5e-4)
+
+
+def test_m1_rayleigh_reduces_to_native_local_energy():
+    estimator = RayleighMatrixEstimator(
+        matrix_dtype="complex64",
+        f_component_logpsi_matrix=lambda params, data: jnp.array([[3.0]]),
+        f_cross_local_energy=lambda params, data, rngs: jnp.array([[1.25]]),
+    )
+
+    stats, _ = estimator.evaluate_single_walker(
+        {}, ToyData(electrons=jnp.zeros((1, 1, 1))), {}, None, jax.random.key(0)
+    )
+
+    np.testing.assert_allclose(stats["local_rayleigh"], [[1.25]], rtol=1e-6)
+    np.testing.assert_allclose(stats["subspace_energy"], 1.25, rtol=1e-6)
+
+
+def test_cross_local_energy_reuses_ordered_native_estimator_pipeline():
+    def component(params, data, prev_stats, state, rngs):
+        del prev_stats, rngs
+        value = params["slope"] * jnp.sum(data.electrons)
+        return {"energy:toy": value}, state
+
+    evaluator = CrossLocalEnergyEvaluator(
+        {"component": component, "total": TotalEnergy()},
+        SubspaceSpec(2),
+        pair_chunk_size=2,
+    )
+    data = ToyData(electrons=jnp.array([[[1.0]], [[3.0]]]))
+    params = {"slope": jnp.array([2.0, 5.0])}
+    evaluator.init(data, jax.random.key(0))
+
+    actual = evaluator(params, data, jax.random.key(1))
+
+    np.testing.assert_allclose(actual, [[2.0, 5.0], [6.0, 15.0]])
+
+
+def test_near_singular_amplitude_matrix_triggers_diagnostic():
+    logs = jnp.log(jnp.array([[1.0, 1.0], [1.0, 1.0]], dtype=jnp.complex64))
+    estimator = RayleighMatrixEstimator(
+        matrix_dtype="complex64",
+        f_component_logpsi_matrix=lambda params, data: logs,
+        f_cross_local_energy=lambda params, data, rngs: jnp.ones((2, 2)),
+    )
+
+    stats, _ = estimator.evaluate_single_walker(
+        {}, ToyData(electrons=jnp.zeros((2, 1, 1))), {}, None, jax.random.key(0)
+    )
+
+    assert stats["amplitude_condition_warning"]
+    assert not stats["rayleigh_finite"]

--- a/tests/estimator/rayleigh_test.py
+++ b/tests/estimator/rayleigh_test.py
@@ -133,7 +133,7 @@ def test_cross_local_energy_dynamic_pair_indexing_scales(n_states, chunk_size):
     np.testing.assert_allclose(actual, expected)
 
 
-def test_reduce_uses_one_whole_walker_mask_for_every_matrix_element():
+def test_numerical_failure_invalidates_the_whole_step_without_filtering():
     estimator = RayleighMatrixEstimator(matrix_dtype="complex64")
     matrices = jnp.array(
         [
@@ -152,12 +152,56 @@ def test_reduce_uses_one_whole_walker_mask_for_every_matrix_element():
 
     reduced = estimator.reduce(stats)
 
-    np.testing.assert_allclose(
-        reduced["rayleigh_mean"], (matrices[0] + matrices[2]) / 2
-    )
+    assert jnp.isnan(reduced["rayleigh_mean"]).any()
     np.testing.assert_allclose(reduced["rayleigh_valid_fraction"], 2 / 3)
     np.testing.assert_allclose(reduced["rayleigh_invalid_count"], 1)
     assert not reduced["training_step_valid"]
+
+
+def test_subspace_energy_variance_uses_all_walkers():
+    estimator = RayleighMatrixEstimator(matrix_dtype="complex64")
+    matrices = jnp.array(
+        [
+            [[1.0, 2.0], [3.0, 4.0]],
+            [[5.0, 6.0], [7.0, 8.0]],
+        ],
+        dtype=jnp.complex64,
+    )
+    stats = {
+        "local_rayleigh": matrices,
+        "subspace_local_energy": jnp.array([5.0, 13.0], dtype=jnp.complex64),
+        "subspace_energy": jnp.array([5.0, 13.0]),
+        "rayleigh_valid": jnp.array([True, True]),
+    }
+
+    reduced = estimator.reduce(stats)
+
+    np.testing.assert_allclose(reduced["subspace_energy"], 9.0)
+    np.testing.assert_allclose(reduced["subspace_energy_var"], 16.0)
+    assert reduced["training_step_valid"]
+
+
+def test_ill_conditioned_finite_solve_remains_a_valid_sample():
+    phi = jnp.array(
+        [[1.0, 1.0], [1.0, 1.0001]], dtype=jnp.complex64
+    )
+    local_energy = jnp.array(
+        [[1.0, 2.0], [3.0, 4.0]], dtype=jnp.complex64
+    )
+    estimator = RayleighMatrixEstimator(
+        matrix_dtype="complex64",
+        condition_warning=1e3,
+        f_component_logpsi_matrix=lambda params, data: jnp.log(phi),
+        f_cross_local_energy=lambda params, data, rngs: local_energy,
+    )
+
+    stats, _ = estimator.evaluate_single_walker(
+        {}, ToyData(electrons=jnp.zeros((2, 1, 1))), {}, None, jax.random.key(0)
+    )
+
+    assert stats["amplitude_condition_warning"]
+    assert stats["rayleigh_valid"]
+    assert jnp.isfinite(stats["rayleigh_solve_residual"])
 
 
 def test_near_singular_amplitude_matrix_triggers_diagnostic():

--- a/tests/estimator/rayleigh_test.py
+++ b/tests/estimator/rayleigh_test.py
@@ -4,6 +4,7 @@
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from jaqmc.data import Data
 from jaqmc.estimator.rayleigh import (
@@ -37,6 +38,9 @@ def test_rayleigh_estimator_matches_direct_solve():
     np.testing.assert_allclose(stats["local_rayleigh"], expected, rtol=1e-6)
     np.testing.assert_allclose(
         stats["subspace_energy"], jnp.trace(expected).real, rtol=1e-6
+    )
+    np.testing.assert_allclose(
+        stats["subspace_local_energy"], jnp.trace(expected), rtol=1e-6
     )
     # CUDA complex64 small solves have backend-dependent residuals around
     # 1e-4; the estimator's production default remains complex128.
@@ -76,6 +80,84 @@ def test_cross_local_energy_reuses_ordered_native_estimator_pipeline():
     actual = evaluator(params, data, jax.random.key(1))
 
     np.testing.assert_allclose(actual, [[2.0, 5.0], [6.0, 15.0]])
+
+
+def test_cross_local_energy_reuses_state_independent_potential():
+    def potential(params, data, prev_stats, state, rngs):
+        del params, prev_stats, rngs
+        return {"energy:potential": jnp.sum(data.electrons)}, state
+
+    def kinetic(params, data, prev_stats, state, rngs):
+        del data, prev_stats, rngs
+        return {"energy:kinetic": params["slope"]}, state
+
+    evaluator = CrossLocalEnergyEvaluator(
+        {"potential": potential, "kinetic": kinetic, "total": TotalEnergy()},
+        SubspaceSpec(2),
+        pair_chunk_size=1,
+    )
+    data = ToyData(electrons=jnp.array([[[1.0]], [[3.0]]]))
+    params = {"slope": jnp.array([2.0, 5.0])}
+    evaluator.init(data, jax.random.key(0))
+
+    actual = evaluator(params, data, jax.random.key(1))
+
+    np.testing.assert_allclose(actual, [[3.0, 6.0], [5.0, 8.0]])
+
+
+@pytest.mark.parametrize("n_states", [2, 4, 8, 16])
+@pytest.mark.parametrize("chunk_size", [1, 2, 4])
+def test_cross_local_energy_dynamic_pair_indexing_scales(n_states, chunk_size):
+    def component(params, data, prev_stats, state, rngs):
+        del prev_stats, rngs
+        return {
+            "total_energy": params["slope"] * jnp.sum(data.electrons)
+        }, state
+
+    evaluator = CrossLocalEnergyEvaluator(
+        {"total": component},
+        SubspaceSpec(n_states),
+        pair_chunk_size=chunk_size,
+    )
+    data = ToyData(
+        electrons=jnp.arange(1, n_states + 1, dtype=float)[:, None, None]
+    )
+    params = {"slope": jnp.arange(1, n_states + 1, dtype=float)}
+    evaluator.init(data, jax.random.key(0))
+
+    actual = jax.jit(evaluator)(params, data, jax.random.key(1))
+    expected = jnp.arange(1, n_states + 1, dtype=float)[:, None] * jnp.arange(
+        1, n_states + 1, dtype=float
+    )[None, :]
+
+    np.testing.assert_allclose(actual, expected)
+
+
+def test_reduce_uses_one_whole_walker_mask_for_every_matrix_element():
+    estimator = RayleighMatrixEstimator(matrix_dtype="complex64")
+    matrices = jnp.array(
+        [
+            [[1.0, 2.0], [3.0, 4.0]],
+            [[10.0, jnp.nan], [30.0, 40.0]],
+            [[5.0, 6.0], [7.0, 8.0]],
+        ],
+        dtype=jnp.complex64,
+    )
+    stats = {
+        "local_rayleigh": matrices,
+        "subspace_local_energy": jnp.array([5.0, jnp.nan, 13.0]),
+        "subspace_energy": jnp.array([5.0, jnp.nan, 13.0]),
+        "rayleigh_valid": jnp.array([True, True, True]),
+    }
+
+    reduced = estimator.reduce(stats)
+
+    np.testing.assert_allclose(
+        reduced["rayleigh_mean"], (matrices[0] + matrices[2]) / 2
+    )
+    np.testing.assert_allclose(reduced["rayleigh_valid_fraction"], 2 / 3)
+    np.testing.assert_allclose(reduced["rayleigh_invalid_count"], 1)
+    assert not reduced["training_step_valid"]
 
 
 def test_near_singular_amplitude_matrix_triggers_diagnostic():

--- a/tests/estimator/rayleigh_test.py
+++ b/tests/estimator/rayleigh_test.py
@@ -10,8 +10,10 @@ from jaqmc.data import Data
 from jaqmc.estimator.rayleigh import (
     CrossLocalEnergyEvaluator,
     RayleighMatrixEstimator,
+    grassmann_hamiltonian_statistics,
 )
 from jaqmc.estimator.total_energy import TotalEnergy
+from jaqmc.utils import parallel_jax
 from jaqmc.wavefunction.determinant_state import SubspaceSpec
 
 
@@ -179,6 +181,133 @@ def test_subspace_energy_variance_uses_all_walkers():
     np.testing.assert_allclose(reduced["subspace_energy"], 9.0)
     np.testing.assert_allclose(reduced["subspace_energy_var"], 16.0)
     assert reduced["training_step_valid"]
+
+
+def test_grassmann_variance_matches_reference_formula_elementwise():
+    local_rayleigh = jnp.array(
+        [
+            [[1.0 + 0.2j, 0.3], [0.1j, 2.0 - 0.1j]],
+            [[1.4 - 0.3j, -0.2j], [0.5, 2.5 + 0.4j]],
+            [[0.8 + 0.1j, 0.7], [-0.3j, 1.7 - 0.2j]],
+        ],
+        dtype=jnp.complex128,
+    )
+    actual = grassmann_hamiltonian_statistics(local_rayleigh)
+
+    mean_rayleigh = jnp.mean(local_rayleigh, axis=0)
+    local_trace = jnp.trace(local_rayleigh, axis1=-2, axis2=-1)
+    expected_matrix = jnp.mean(
+        local_rayleigh * jnp.conj(local_trace)[:, None, None], axis=0
+    ) - mean_rayleigh * jnp.conj(jnp.mean(local_trace))
+    expected_variance = jnp.real(jnp.trace(expected_matrix)) / 2
+
+    np.testing.assert_allclose(
+        actual["grassmann_hamiltonian_variance_matrix"], expected_matrix
+    )
+    np.testing.assert_allclose(
+        actual["grassmann_hamiltonian_variance"], expected_variance
+    )
+    np.testing.assert_allclose(
+        actual["grassmann_average_energy"], jnp.trace(mean_rayleigh) / 2
+    )
+
+
+def test_grassmann_variance_m1_is_local_energy_variance():
+    local_energy = jnp.array([1.0, 2.0, 4.0], dtype=jnp.complex128)
+    stats = grassmann_hamiltonian_statistics(local_energy[:, None, None])
+
+    np.testing.assert_allclose(
+        stats["grassmann_hamiltonian_variance"], jnp.var(local_energy.real)
+    )
+
+
+def test_grassmann_variance_detects_hamiltonian_leakage():
+    invariant = jnp.broadcast_to(
+        jnp.array([[1.0, 0.2], [0.0, 2.0]], dtype=jnp.complex128),
+        (4, 2, 2),
+    )
+    leaking = invariant.at[:, 0, 0].add(jnp.array([-1.0, 0.0, 1.0, 2.0]))
+
+    invariant_stats = grassmann_hamiltonian_statistics(invariant)
+    leaking_stats = grassmann_hamiltonian_statistics(leaking)
+
+    np.testing.assert_allclose(
+        invariant_stats["grassmann_hamiltonian_variance"], 0, atol=1e-12
+    )
+    assert leaking_stats["grassmann_hamiltonian_variance"] > 0
+
+
+def test_rayleigh_reduce_appends_grassmann_fields_without_replacing_old_fields():
+    estimator = RayleighMatrixEstimator(matrix_dtype="complex128")
+    matrices = jnp.array(
+        [
+            [[1.0, 0.2], [0.1, 2.0]],
+            [[1.5, 0.3], [0.0, 2.5]],
+        ],
+        dtype=jnp.complex128,
+    )
+    stats = {
+        "local_rayleigh": matrices,
+        "subspace_local_energy": jnp.trace(matrices, axis1=-2, axis2=-1),
+        "subspace_energy": jnp.real(
+            jnp.trace(matrices, axis1=-2, axis2=-1)
+        ),
+        "rayleigh_valid": jnp.ones(2, dtype=bool),
+    }
+
+    reduced = estimator.reduce(stats)
+
+    for old_key in (
+        "subspace_energy",
+        "subspace_energy_var",
+        "local_rayleigh_variance",
+        "ritz_energies",
+    ):
+        assert old_key in reduced
+    for new_key in (
+        "grassmann_average_energy",
+        "grassmann_hamiltonian_variance",
+        "grassmann_hamiltonian_variance_matrix",
+        "grassmann_hamiltonian_std",
+    ):
+        assert new_key in reduced
+
+
+def test_grassmann_variance_uses_global_multi_device_moments():
+    if jax.local_device_count() < 2:
+        pytest.skip("requires at least two devices")
+    matrices = jnp.array(
+        [
+            [[[1.0, 0.1], [0.0, 2.0]], [[1.5, 0.2], [0.1, 2.2]]],
+            [[[0.5, -0.1], [0.2, 1.7]], [[2.0, 0.3], [0.0, 2.8]]],
+        ],
+        dtype=jnp.complex128,
+    )
+    estimator = RayleighMatrixEstimator(matrix_dtype="complex128")
+
+    def reduce(local_rayleigh):
+        trace = jnp.trace(local_rayleigh, axis1=-2, axis2=-1)
+        return estimator.reduce(
+            {
+                "local_rayleigh": local_rayleigh,
+                "subspace_local_energy": trace,
+                "subspace_energy": jnp.real(trace),
+                "rayleigh_valid": jnp.ones(local_rayleigh.shape[0], dtype=bool),
+            }
+        )
+
+    distributed = jax.pmap(
+        reduce, axis_name=parallel_jax.BATCH_AXIS_NAME
+    )(matrices)
+    expected = grassmann_hamiltonian_statistics(matrices.reshape(-1, 2, 2))
+
+    for key in (
+        "grassmann_average_energy",
+        "grassmann_hamiltonian_variance",
+        "grassmann_hamiltonian_variance_matrix",
+    ):
+        np.testing.assert_allclose(distributed[key][0], expected[key])
+        np.testing.assert_allclose(distributed[key][1], expected[key])
 
 
 def test_ill_conditioned_finite_solve_remains_a_valid_sample():

--- a/tests/estimator/streaming_loss_grad_multi_device_test.py
+++ b/tests/estimator/streaming_loss_grad_multi_device_test.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Multi-device equivalence tests for streaming VMC gradients."""
+
+import jax
+import numpy as np
+import pytest
+from jax import numpy as jnp
+
+from jaqmc.data import BatchedData, Data
+from jaqmc.estimator import LossAndGrad, StreamingLossAndGrad
+from jaqmc.utils import parallel_jax
+
+
+class GradientData(Data):
+    x: jax.Array
+
+
+def _logpsi(params, data):
+    real = params["a"] * data.x + params["b"] * data.x**2
+    return real + 1j * params["b"] * data.x
+
+
+def _finalize(estimator, params, data, loss):
+    walker_stats, _ = estimator.evaluate_batch_walkers(
+        params, data, {"energy": loss}, None, jax.random.key(0)
+    )
+    reduced = estimator.reduce(walker_stats)
+    final = estimator.finalize_stats(
+        jax.tree.map(lambda x: x[None], reduced), None
+    )
+    return reduced, final
+
+
+def test_streaming_loss_grad_matches_global_reference_across_devices():
+    if jax.device_count() < 2:
+        pytest.skip("At least two JAX devices are required")
+
+    device_count = jax.device_count()
+    batch_size = 4 * device_count
+    x = jnp.linspace(-1.2, 1.3, batch_size)
+    loss = jnp.linspace(-0.7, 1.8, batch_size) + 0.2j * x
+    params = {"a": jnp.array(0.6), "b": jnp.array(-0.3)}
+    data = BatchedData(GradientData(x=x), ["x"])
+
+    reference = LossAndGrad(
+        loss_key="energy", clip_method="none", f_log_psi=_logpsi
+    )
+    expected_reduced, expected_final = _finalize(
+        reference, params, data, loss
+    )
+
+    streaming = StreamingLossAndGrad(
+        loss_key="energy",
+        vmap_chunk_size=1,
+        clip_method="none",
+        f_log_psi=_logpsi,
+    )
+
+    def distributed(p, d, local_loss):
+        return _finalize(streaming, p, d, local_loss)
+
+    distributed = parallel_jax.shard_map(
+        distributed,
+        mesh=parallel_jax.make_mesh(),
+        in_specs=(
+            parallel_jax.SHARE_PARTITION,
+            data.partition_spec,
+            parallel_jax.DATA_PARTITION,
+        ),
+        out_specs=parallel_jax.SHARE_PARTITION,
+    )
+    actual_reduced, actual_final = distributed(params, data, loss)
+
+    for key in ("grad_logpsi", "grad_logpsi_and_loss"):
+        for actual, expected in zip(
+            jax.tree.leaves(actual_reduced[key]),
+            jax.tree.leaves(expected_reduced[key]),
+        ):
+            np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)
+    np.testing.assert_allclose(
+        actual_reduced["loss"], expected_reduced["loss"], rtol=1e-6
+    )
+    for actual, expected in zip(
+        jax.tree.leaves(actual_final["grads"]),
+        jax.tree.leaves(expected_final["grads"]),
+    ):
+        np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)

--- a/tests/optimizer/gvmc_reference_sr_test.py
+++ b/tests/optimizer/gvmc_reference_sr_test.py
@@ -4,6 +4,7 @@
 import jax
 import jax.numpy as jnp
 import numpy as np
+import optax
 import pytest
 from jax.flatten_util import ravel_pytree
 
@@ -65,6 +66,46 @@ def test_minsr_kacz_matches_reference_continuation():
     )
 
     np.testing.assert_allclose(actual, expected, rtol=1e-10, atol=1e-12)
+
+
+def test_minsr_and_kacz_match_cqsl_gvmc_golden_vectors():
+    """Anchor cqsl/GVMC@e68e503, including its all-entries lam1 shift."""
+    jacobian = jnp.array(
+        [
+            [0.7, -0.2, 0.4],
+            [-0.1, 0.9, -0.3],
+            [-0.6, -0.7, -0.1],
+            [0.2, 0.5, 0.8],
+        ],
+        dtype=jnp.float64,
+    )
+    force = jnp.array([0.35, -0.15, -0.25, 0.05], dtype=jnp.float64)
+    previous = jnp.array([0.12, -0.08, 0.03], dtype=jnp.float64)
+    expected_minsr = jnp.array(
+        [0.47438583246858684, -0.08512767274722458, 0.02486287395734668]
+    )
+    expected_kacz = jnp.array(
+        [0.4769540823520102, -0.08619417530168463, 0.02372779043486619]
+    )
+
+    actual_minsr = minsr_solve(
+        jacobian, force, lam0=0.017, lam1=0.65
+    )
+    actual_kacz = minsr_solve_kacz(
+        jacobian,
+        force,
+        previous,
+        lam0=0.017,
+        lam1=0.65,
+        mu=0.73,
+    )
+
+    np.testing.assert_allclose(
+        actual_minsr, expected_minsr, rtol=1e-12, atol=1e-13
+    )
+    np.testing.assert_allclose(
+        actual_kacz, expected_kacz, rtol=1e-12, atol=1e-13
+    )
 
 
 def test_gradient_form_is_equivalent_for_centered_force():
@@ -157,7 +198,7 @@ def _streaming_native_gradient(params, data, logpsi, local_trace):
     return final["grads"]
 
 
-def test_reference_optimizer_matches_direct_gvmc_single_step_with_factor_control():
+def test_reference_optimizer_m2_uses_source_lr_with_factor_control():
     params, data, logpsi = _linear_problem()
     local_trace = jnp.array(
         [0.8 + 0.1j, -0.4 + 0.7j, 1.3 - 0.2j, -0.1 + 0.5j,
@@ -189,7 +230,6 @@ def test_reference_optimizer_matches_direct_gvmc_single_step_with_factor_control
         lam0=lam0,
         lam1=lam1,
         mu=0.0,
-        scale_lr_by_sqrt_n_states=False,
         f_log_psi=logpsi,
     )
     state = optimizer.init(params, batched_data=data)
@@ -215,6 +255,8 @@ def test_reference_optimizer_matches_direct_gvmc_single_step_with_factor_control
     np.testing.assert_allclose(fixed_cosine, 1.0, rtol=1e-9)
     np.testing.assert_allclose(new_state.previous_delta, direct, rtol=1e-9)
     np.testing.assert_allclose(flat_updates, -learning_rate * direct, rtol=1e-9)
+    wrong_sqrt_scaled = -learning_rate / np.sqrt(2.0) * direct
+    assert not np.allclose(flat_updates, wrong_sqrt_scaled, rtol=1e-4, atol=1e-6)
 
 
 def test_reference_optimizer_matches_direct_gvmc_kacz_trajectory():
@@ -224,7 +266,6 @@ def test_reference_optimizer_matches_direct_gvmc_kacz_trajectory():
         lam0=3e-3,
         lam1=0.7,
         mu=0.8,
-        scale_lr_by_sqrt_n_states=False,
         f_log_psi=logpsi,
     )
     state = optimizer.init(params, batched_data=data)
@@ -261,6 +302,68 @@ def test_reference_optimizer_matches_direct_gvmc_kacz_trajectory():
         direct_previous = direct
 
 
+def test_reference_optimizer_matches_direct_gvmc_parameter_trajectory():
+    params, data, _ = _linear_problem()
+
+    def logpsi(p, sample):
+        weights = p["weights"]
+        value = jnp.sum((weights + 0.1 * weights**2) * sample.features)
+        phase = jnp.sum((weights + 0.05 * weights**3) * sample.features**2)
+        return value + 0.2j * phase
+
+    learning_rate = 0.02
+    optimizer = GVMCReferenceSROptimizer(
+        learning_rate=learning_rate,
+        lam0=4e-3,
+        lam1=0.6,
+        mu=0.7,
+        f_log_psi=logpsi,
+    )
+    params_direct = params
+    params_backend = params
+    state = optimizer.init(params_backend, batched_data=data)
+    direct_previous = jnp.zeros_like(state.previous_delta)
+    base_trace = jnp.array(
+        [0.7 + 0.2j, -0.3 + 0.6j, 1.1 - 0.4j, -0.2 + 0.3j,
+         0.5 - 0.7j, -0.8 + 0.1j, 0.9 + 0.5j, -0.1 - 0.5j]
+    )
+
+    for step in range(5):
+        local_trace = base_trace + 0.02 * step * jnp.arange(8) ** 2
+        jacobian, force = _reference_score_and_force(
+            params_direct, data, logpsi, local_trace
+        )
+        direct = minsr_solve_kacz(
+            jacobian,
+            force,
+            direct_previous,
+            lam0=optimizer.lam0,
+            lam1=optimizer.lam1,
+            mu=optimizer.mu,
+        )
+        _, unravel = ravel_pytree(params_direct)
+        params_direct = optax.apply_updates(
+            params_direct, unravel(-learning_rate * direct)
+        )
+
+        native_grads = _streaming_native_gradient(
+            params_backend, data, logpsi, local_trace
+        )
+        updates, state = optimizer.update(
+            native_grads, state, params_backend, batched_data=data
+        )
+        params_backend = optax.apply_updates(params_backend, updates)
+
+        np.testing.assert_allclose(
+            state.previous_delta, direct, rtol=1e-9, atol=1e-11
+        )
+        for actual, expected in zip(
+            jax.tree.leaves(params_backend), jax.tree.leaves(params_direct)
+        ):
+            np.testing.assert_allclose(actual, expected, rtol=1e-9, atol=1e-11)
+        direct_previous = direct
+
+
 def test_reference_optimizer_m1_matches_direct_sr_and_keeps_learning_rate():
     params, data, logpsi = _linear_problem(n_states=1)
     local_trace = jnp.array(
@@ -278,7 +381,6 @@ def test_reference_optimizer_m1_matches_direct_sr_and_keeps_learning_rate():
         learning_rate=0.07,
         lam0=1e-2,
         mu=0.0,
-        scale_lr_by_sqrt_n_states=True,
         f_log_psi=logpsi,
     )
     state = optimizer.init(params, batched_data=data)

--- a/tests/optimizer/gvmc_reference_sr_test.py
+++ b/tests/optimizer/gvmc_reference_sr_test.py
@@ -8,12 +8,15 @@ import pytest
 from jax.flatten_util import ravel_pytree
 
 from jaqmc.data import BatchedData, Data
+from jaqmc.estimator import StreamingLossAndGrad
 from jaqmc.optimizer.gvmc_reference_sr import (
     GVMCReferenceSROptimizer,
+    _native_vmc_to_gvmc_gradient,
     minsr_solve,
     minsr_solve_gradient,
     minsr_solve_kacz,
 )
+from jaqmc.utils.func_transform import grad_maybe_complex
 
 
 def _reference_matrix(jacobian, lam0, lam1):
@@ -80,8 +83,212 @@ def test_gradient_form_is_equivalent_for_centered_force():
     np.testing.assert_allclose(from_gradient, direct, rtol=1e-9, atol=1e-11)
 
 
+def test_native_gradient_adapter_removes_vmc_factor_two():
+    native_gradient = jnp.array([2.0, -4.0, 0.5], dtype=jnp.float64)
+
+    np.testing.assert_array_equal(
+        _native_vmc_to_gvmc_gradient(native_gradient),
+        jnp.array([1.0, -2.0, 0.25], dtype=jnp.float64),
+    )
+
+
 class LinearData(Data):
     features: jax.Array
+
+
+def _linear_problem(n_states=2):
+    params = {
+        "weights": jnp.array(
+            [[0.2, -0.1], [0.4, 0.3]], dtype=jnp.float64
+        )[:n_states]
+    }
+    features = jnp.array(
+        [
+            [[1.0, 0.0], [0.0, 1.0]],
+            [[0.5, 1.0], [-0.5, 0.2]],
+            [[-1.0, 0.5], [1.0, -0.3]],
+            [[0.2, -0.7], [0.4, 0.9]],
+            [[0.8, 0.3], [-0.2, -0.6]],
+            [[-0.4, -0.9], [0.7, 0.1]],
+            [[1.1, -0.2], [-0.8, 0.5]],
+            [[-0.6, 0.8], [0.3, -1.0]],
+        ],
+        dtype=jnp.float64,
+    )[:, :n_states]
+    data = BatchedData(LinearData(features=features), ["features"])
+
+    def logpsi(p, sample):
+        value = jnp.sum(p["weights"] * sample.features)
+        phase = jnp.sum(p["weights"] * sample.features**2)
+        return value + 0.2j * phase
+
+    return params, data, logpsi
+
+
+def _reference_score_and_force(params, data, logpsi, local_trace):
+    scores = jax.vmap(lambda sample: grad_maybe_complex(logpsi)(params, sample))(
+        data.data
+    )
+    flat_scores = jax.vmap(lambda tree: ravel_pytree(tree)[0])(scores)
+    scale = jnp.sqrt(data.batch_size)
+    jacobian = (flat_scores - jnp.mean(flat_scores, axis=0)) / scale
+    force = (local_trace - jnp.mean(local_trace)) / scale
+    return (
+        jnp.concatenate((jnp.real(jacobian), jnp.imag(jacobian)), axis=0),
+        jnp.concatenate((jnp.real(force), jnp.imag(force)), axis=0),
+    )
+
+
+def _streaming_native_gradient(params, data, logpsi, local_trace):
+    estimator = StreamingLossAndGrad(
+        loss_key="local_trace", clip_method="none", f_log_psi=logpsi
+    )
+    sums, _ = estimator.evaluate_batch_walkers(
+        params,
+        data,
+        {"local_trace": local_trace},
+        None,
+        jax.random.key(0),
+    )
+    reduced = estimator.reduce(sums)
+    final = estimator.finalize_stats(
+        jax.tree.map(lambda x: x[None], reduced), None
+    )
+    return final["grads"]
+
+
+def test_reference_optimizer_matches_direct_gvmc_single_step_with_factor_control():
+    params, data, logpsi = _linear_problem()
+    local_trace = jnp.array(
+        [0.8 + 0.1j, -0.4 + 0.7j, 1.3 - 0.2j, -0.1 + 0.5j,
+         0.6 - 0.8j, -0.7 + 0.2j, 1.1 + 0.4j, -0.2 - 0.6j],
+        dtype=jnp.complex128,
+    )
+    lam0, lam1, learning_rate = 1e-2, 1.0, 0.1
+    jacobian, force = _reference_score_and_force(
+        params, data, logpsi, local_trace
+    )
+    native_grads = _streaming_native_gradient(
+        params, data, logpsi, local_trace
+    )
+    native_gradient, _ = ravel_pytree(native_grads)
+    gvmc_gradient = jacobian.T @ force
+    direct = minsr_solve(jacobian, force, lam0=lam0, lam1=lam1)
+    legacy = minsr_solve_gradient(
+        jacobian, native_gradient, lam0=lam0, lam1=lam1
+    )
+    fixed = minsr_solve_gradient(
+        jacobian,
+        _native_vmc_to_gvmc_gradient(native_gradient),
+        lam0=lam0,
+        lam1=lam1,
+    )
+
+    optimizer = GVMCReferenceSROptimizer(
+        learning_rate=learning_rate,
+        lam0=lam0,
+        lam1=lam1,
+        mu=0.0,
+        scale_lr_by_sqrt_n_states=False,
+        f_log_psi=logpsi,
+    )
+    state = optimizer.init(params, batched_data=data)
+    updates, new_state = optimizer.update(
+        native_grads, state, params, batched_data=data
+    )
+    flat_updates, _ = ravel_pytree(updates)
+
+    np.testing.assert_allclose(native_gradient, 2.0 * gvmc_gradient, rtol=1e-11)
+    np.testing.assert_allclose(legacy, 2.0 * direct, rtol=1e-9, atol=1e-11)
+    np.testing.assert_allclose(fixed, direct, rtol=1e-9, atol=1e-11)
+    legacy_ratio = jnp.linalg.norm(legacy) / jnp.linalg.norm(direct)
+    fixed_ratio = jnp.linalg.norm(fixed) / jnp.linalg.norm(direct)
+    legacy_cosine = jnp.vdot(legacy, direct) / (
+        jnp.linalg.norm(legacy) * jnp.linalg.norm(direct)
+    )
+    fixed_cosine = jnp.vdot(fixed, direct) / (
+        jnp.linalg.norm(fixed) * jnp.linalg.norm(direct)
+    )
+    np.testing.assert_allclose(legacy_ratio, 2.0, rtol=1e-9)
+    np.testing.assert_allclose(fixed_ratio, 1.0, rtol=1e-9)
+    np.testing.assert_allclose(legacy_cosine, 1.0, rtol=1e-9)
+    np.testing.assert_allclose(fixed_cosine, 1.0, rtol=1e-9)
+    np.testing.assert_allclose(new_state.previous_delta, direct, rtol=1e-9)
+    np.testing.assert_allclose(flat_updates, -learning_rate * direct, rtol=1e-9)
+
+
+def test_reference_optimizer_matches_direct_gvmc_kacz_trajectory():
+    params, data, logpsi = _linear_problem()
+    optimizer = GVMCReferenceSROptimizer(
+        learning_rate=0.1,
+        lam0=3e-3,
+        lam1=0.7,
+        mu=0.8,
+        scale_lr_by_sqrt_n_states=False,
+        f_log_psi=logpsi,
+    )
+    state = optimizer.init(params, batched_data=data)
+    direct_previous = jnp.zeros_like(state.previous_delta)
+    base_trace = jnp.array(
+        [0.8 + 0.1j, -0.4 + 0.7j, 1.3 - 0.2j, -0.1 + 0.5j,
+         0.6 - 0.8j, -0.7 + 0.2j, 1.1 + 0.4j, -0.2 - 0.6j]
+    )
+
+    for step in range(5):
+        local_trace = base_trace + (0.03 * step) * jnp.arange(8) ** 2
+        jacobian, force = _reference_score_and_force(
+            params, data, logpsi, local_trace
+        )
+        direct = minsr_solve_kacz(
+            jacobian,
+            force,
+            direct_previous,
+            lam0=optimizer.lam0,
+            lam1=optimizer.lam1,
+            mu=optimizer.mu,
+        )
+        native_grads = _streaming_native_gradient(
+            params, data, logpsi, local_trace
+        )
+        updates, state = optimizer.update(
+            native_grads, state, params, batched_data=data
+        )
+        flat_updates, _ = ravel_pytree(updates)
+
+        np.testing.assert_allclose(state.previous_delta, direct, rtol=1e-9, atol=1e-11)
+        np.testing.assert_allclose(flat_updates, -0.1 * direct, rtol=1e-9, atol=1e-11)
+        np.testing.assert_array_equal(state.counter, step + 1)
+        direct_previous = direct
+
+
+def test_reference_optimizer_m1_matches_direct_sr_and_keeps_learning_rate():
+    params, data, logpsi = _linear_problem(n_states=1)
+    local_trace = jnp.array(
+        [0.2 + 0.3j, -0.6 + 0.1j, 0.8 - 0.4j, 1.1 + 0.2j,
+         -0.2 - 0.7j, 0.4 + 0.5j, -0.9 + 0.1j, 0.3 - 0.2j]
+    )
+    jacobian, force = _reference_score_and_force(
+        params, data, logpsi, local_trace
+    )
+    direct = minsr_solve(jacobian, force, lam0=1e-2, lam1=1.0)
+    native_grads = _streaming_native_gradient(
+        params, data, logpsi, local_trace
+    )
+    optimizer = GVMCReferenceSROptimizer(
+        learning_rate=0.07,
+        lam0=1e-2,
+        mu=0.0,
+        scale_lr_by_sqrt_n_states=True,
+        f_log_psi=logpsi,
+    )
+    state = optimizer.init(params, batched_data=data)
+    updates, state = optimizer.update(
+        native_grads, state, params, batched_data=data
+    )
+    flat_updates, _ = ravel_pytree(updates)
+
+    np.testing.assert_allclose(state.previous_delta, direct, rtol=1e-9, atol=1e-11)
+    np.testing.assert_allclose(flat_updates, -0.07 * direct, rtol=1e-9, atol=1e-11)
 
 
 def test_reference_optimizer_implements_native_optimizer_protocol():

--- a/tests/optimizer/gvmc_reference_sr_test.py
+++ b/tests/optimizer/gvmc_reference_sr_test.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax.flatten_util import ravel_pytree
+
+from jaqmc.data import BatchedData, Data
+from jaqmc.optimizer.gvmc_reference_sr import (
+    GVMCReferenceSROptimizer,
+    minsr_solve,
+    minsr_solve_gradient,
+    minsr_solve_kacz,
+)
+
+
+def _reference_matrix(jacobian, lam0, lam1):
+    n = jacobian.shape[0]
+    scale = jnp.linalg.norm(jacobian) ** 2 / n
+    return (
+        jacobian @ jnp.conj(jacobian.T)
+        + scale * (lam1 / n)
+        + lam0 * jnp.eye(n)
+    )
+
+
+def test_minsr_solve_matches_gvmc_source_equation():
+    jacobian = jnp.array(
+        [[1.0 + 0.2j, 0.3], [-0.4j, 1.2], [-1.0 + 0.2j, -1.5]],
+        dtype=jnp.complex128,
+    )
+    force = jnp.array([0.4 + 0.1j, -0.2j, -0.4 + 0.1j])
+    lam0, lam1 = 2e-3, 0.7
+
+    actual = minsr_solve(jacobian, force, lam0=lam0, lam1=lam1)
+    expected = jnp.conj(jacobian.T) @ jnp.linalg.solve(
+        _reference_matrix(jacobian, lam0, lam1), force
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-11, atol=1e-12)
+
+
+def test_minsr_kacz_matches_reference_continuation():
+    jacobian = jnp.array(
+        [[0.5, -0.2, 0.4], [1.0, 0.3, -0.1], [-1.5, -0.1, -0.3]],
+        dtype=jnp.float64,
+    )
+    force = jnp.array([0.2, -0.5, 0.3], dtype=jnp.float64)
+    previous = jnp.array([0.1, -0.2, 0.05], dtype=jnp.float64)
+    mu = 0.8
+
+    actual = minsr_solve_kacz(
+        jacobian, force, previous, lam0=1e-3, lam1=1.0, mu=mu
+    )
+    residual = force - mu * jacobian @ previous
+    expected = (
+        jnp.conj(jacobian.T)
+        @ jnp.linalg.solve(_reference_matrix(jacobian, 1e-3, 1.0), residual)
+        + mu * previous
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-10, atol=1e-12)
+
+
+def test_gradient_form_is_equivalent_for_centered_force():
+    key_j, key_b = jax.random.split(jax.random.key(3))
+    jacobian = jax.random.normal(key_j, (6, 4), dtype=jnp.float64)
+    jacobian -= jnp.mean(jacobian, axis=0, keepdims=True)
+    force = jax.random.normal(key_b, (6,), dtype=jnp.float64)
+    force -= jnp.mean(force)
+    gradient = jnp.conj(jacobian.T) @ force
+
+    direct = minsr_solve(jacobian, force, lam0=3e-3, lam1=1.0)
+    from_gradient = minsr_solve_gradient(
+        jacobian, gradient, lam0=3e-3, lam1=1.0
+    )
+
+    np.testing.assert_allclose(from_gradient, direct, rtol=1e-9, atol=1e-11)
+
+
+class LinearData(Data):
+    features: jax.Array
+
+
+def test_reference_optimizer_implements_native_optimizer_protocol():
+    params = {
+        "weights": jnp.array(
+            [[0.2, -0.1], [0.4, 0.3]], dtype=jnp.float64
+        )
+    }
+    data = BatchedData(
+        LinearData(
+            features=jnp.array(
+                [
+                    [[1.0, 0.0], [0.0, 1.0]],
+                    [[0.5, 1.0], [-0.5, 0.2]],
+                    [[-1.0, 0.5], [1.0, -0.3]],
+                    [[0.2, -0.7], [0.4, 0.9]],
+                ],
+                dtype=jnp.float64,
+            )
+        ),
+        ["features"],
+    )
+    grads = {"weights": jnp.array([[0.3, -0.2], [0.1, 0.4]])}
+
+    def logpsi(p, sample):
+        value = jnp.sum(p["weights"] * sample.features)
+        return value + 0.2j * value
+
+    optimizer = GVMCReferenceSROptimizer(
+        learning_rate=0.1,
+        lam0=1e-2,
+        mu=0.0,
+        f_log_psi=logpsi,
+    )
+    state = optimizer.init(params, batched_data=data)
+    updates, new_state = jax.jit(optimizer.update)(
+        grads, state, params, batched_data=data
+    )
+
+    assert jax.tree.structure(updates) == jax.tree.structure(params)
+    assert new_state.counter == 1
+    assert all(
+        np.isfinite(np.asarray(leaf)).all() for leaf in jax.tree.leaves(updates)
+    )
+    flat_update, _ = ravel_pytree(updates)
+    assert jnp.linalg.norm(flat_update) > 0
+
+
+def test_reference_optimizer_rejects_multi_device(monkeypatch):
+    optimizer = GVMCReferenceSROptimizer(f_log_psi=lambda p, d: p["w"].sum())
+    params = {"w": jnp.ones((2, 1))}
+    data = BatchedData(LinearData(features=jnp.ones((2, 2, 1))), ["features"])
+    monkeypatch.setattr(jax, "device_count", lambda: 2)
+
+    with pytest.raises(NotImplementedError, match="single-device"):
+        optimizer.init(params, batched_data=data)

--- a/tests/sampler/determinant_sampler_test.py
+++ b/tests/sampler/determinant_sampler_test.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jaqmc.sampler.determinant import DeterminantMCMCSampler
+from jaqmc.sampler.mcmc import gaussian_proposal
+
+
+def test_proposal_changes_exactly_one_replica_per_walker():
+    sampler = DeterminantMCMCSampler(n_states=3)
+    electrons = jnp.zeros((16, 3, 2, 3))
+
+    proposed = sampler.sampling_proposal(jax.random.key(7), electrons, 0.2)
+    changed = jnp.any(proposed != electrons, axis=(2, 3))
+
+    np.testing.assert_array_equal(changed.sum(axis=1), jnp.ones(16))
+
+
+def test_m1_proposal_matches_native_physical_proposal():
+    def deterministic_proposal(rngs, x, stddev):
+        del rngs
+        return x + stddev
+
+    sampler = DeterminantMCMCSampler(
+        n_states=1, sampling_proposal=deterministic_proposal
+    )
+    electrons = jnp.zeros((4, 1, 2, 3))
+    proposed = sampler.sampling_proposal(jax.random.key(0), electrons, 0.5)
+    np.testing.assert_allclose(proposed, 0.5)
+
+
+def test_m1_random_proposal_has_exact_native_rng_semantics():
+    sampler = DeterminantMCMCSampler(n_states=1)
+    electrons = jnp.zeros((4, 1, 2, 3))
+    key = jax.random.key(3)
+
+    proposed = sampler.sampling_proposal(key, electrons, 0.5)
+    expected = gaussian_proposal(key, electrons, 0.5)
+
+    np.testing.assert_array_equal(proposed, expected)

--- a/tests/sampler/determinant_sampler_test.py
+++ b/tests/sampler/determinant_sampler_test.py
@@ -19,6 +19,22 @@ def test_proposal_changes_exactly_one_replica_per_walker():
     np.testing.assert_array_equal(changed.sum(axis=1), jnp.ones(16))
 
 
+def test_physical_proposal_only_receives_selected_replica_shape():
+    seen_shapes = []
+
+    def proposal(rngs, x, stddev):
+        del rngs
+        seen_shapes.append(x.shape)
+        return x + stddev
+
+    sampler = DeterminantMCMCSampler(n_states=3, sampling_proposal=proposal)
+    electrons = jnp.zeros((5, 3, 2, 3))
+
+    sampler.sampling_proposal(jax.random.key(1), electrons, 0.1)
+
+    assert seen_shapes == [(5, 2, 3)]
+
+
 def test_m1_proposal_matches_native_physical_proposal():
     def deterministic_proposal(rngs, x, stddev):
         del rngs

--- a/tests/utils/atomic/pbc_tda_test.py
+++ b/tests/utils/atomic/pbc_tda_test.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from jaqmc.utils.atomic.pbc_tda import (
+    PBCTDAReferenceConfig,
+    PBCSinglePromotion,
+    PeriodicStateOrbitalReference,
+    run_pbc_tda_promotions,
+    select_unique_promotions,
+)
+
+
+def _promotion(root, energy, key, weight):
+    spin, k_occ, occ_mo, k_vir, vir_mo = key
+    return PBCSinglePromotion(
+        root_index=root,
+        excitation_energy=energy,
+        spin=spin,
+        k_occ=k_occ,
+        k_vir=k_vir,
+        occ_local_index=0,
+        vir_local_index=vir_mo - 1,
+        occ_mo_index=occ_mo,
+        vir_mo_index=vir_mo,
+        amplitude=weight**0.5,
+        weight=weight,
+        largest_weight=weight,
+        total_weight=1.0,
+        participation_ratio=1.0,
+    )
+
+
+def test_unique_promotion_selection_uses_next_candidate_on_duplicate():
+    promotion_a = ("alpha", 0, 0, 0, 1)
+    promotion_b = ("beta", 0, 0, 0, 1)
+    roots = [
+        [_promotion(0, 0.2, promotion_a, 0.8)],
+        [
+            _promotion(1, 0.3, promotion_a, 0.7),
+            _promotion(1, 0.3, promotion_b, 0.2),
+        ],
+    ]
+
+    selected = select_unique_promotions(
+        roots, 2, candidate_topk=2, min_selected_weight=1e-4
+    )
+
+    assert [item.key for item in selected] == [promotion_a, promotion_b]
+
+
+def test_v1_config_rejects_nonzero_kshift_and_non_same_k_mode():
+    with pytest.raises(NotImplementedError, match="kshift=0"):
+        PBCTDAReferenceConfig(kshift=1)
+    with pytest.raises(NotImplementedError, match="same-k"):
+        PBCTDAReferenceConfig(require_same_k=False)
+
+
+def test_state_reference_replaces_only_selected_occupied_column(monkeypatch):
+    ground_alpha = np.array([[1.0], [2.0]])
+    ground_beta = np.array([[3.0], [4.0]])
+    virtual_alpha = np.array([10.0, 20.0])
+    promotion = _promotion(0, 0.5, ("alpha", 0, 0, 0, 1), 0.9)
+
+    class FakeSCF:
+        _mo_coeff = ([jnp.asarray(ground_alpha)], [jnp.asarray(ground_beta)])
+        mean_field = SimpleNamespace(
+            mo_coeff=(
+                [np.column_stack([ground_alpha[:, 0], virtual_alpha])],
+                [np.column_stack([ground_beta[:, 0], [30.0, 40.0]])],
+            )
+        )
+
+        def get_occupied_mo_coeffs(self):
+            return self._mo_coeff
+
+        def eval_orbitals_from_coeffs(self, pos, nspins, coeffs):
+            del pos, nspins
+            return coeffs[0][0], coeffs[1][0]
+
+        def eval_slater_from_coeffs(self, pos, nspins, coeffs):
+            del pos, nspins
+            return jnp.sum(coeffs[0][0]) + jnp.sum(coeffs[1][0])
+
+    monkeypatch.setattr(
+        "jaqmc.utils.atomic.pbc_tda.run_pbc_tda_promotions",
+        lambda mean_field, n_requested, config: [promotion],
+    )
+    reference = PeriodicStateOrbitalReference(
+        FakeSCF(), 2, PBCTDAReferenceConfig()
+    )
+    reference.prepare()
+
+    state0 = reference._coeffs_for_state(jnp.array(0))
+    state1 = reference._coeffs_for_state(jnp.array(1))
+    np.testing.assert_array_equal(state0[0][0], ground_alpha)
+    np.testing.assert_array_equal(state0[1][0], ground_beta)
+    np.testing.assert_array_equal(state1[0][0][:, 0], virtual_alpha)
+    np.testing.assert_array_equal(state1[1][0], ground_beta)
+
+
+def test_m1_state_reference_uses_ground_without_running_tda():
+    ground_alpha = jnp.array([[1.0], [2.0]])
+    ground_beta = jnp.array([[3.0], [4.0]])
+
+    class FakeSCF:
+        mean_field = object()
+
+        def get_occupied_mo_coeffs(self):
+            return [ground_alpha], [ground_beta]
+
+    reference = PeriodicStateOrbitalReference(
+        FakeSCF(), 1, PBCTDAReferenceConfig()
+    )
+    reference.prepare()
+
+    coeffs = reference._coeffs_for_state(jnp.array(0))
+    np.testing.assert_array_equal(coeffs[0][0], ground_alpha)
+    np.testing.assert_array_equal(coeffs[1][0], ground_beta)
+    assert reference.promotions == ()
+
+
+def test_periodic_tda_selector_on_tiny_gamma_h2():
+    from jaqmc.utils.atomic.atom import Atom
+    from jaqmc.utils.atomic.scf import PeriodicSCF
+
+    scf = PeriodicSCF(
+        atoms=[Atom("H", [0.0, 0.0, 0.0]), Atom("H", [1.4, 0.0, 0.0])],
+        nelectrons=(1, 1),
+        basis="sto-3g",
+        lattice_vectors=np.eye(3) * 8.0,
+        kpts=np.zeros((1, 3)),
+        restricted=False,
+        verbose=0,
+    )
+    scf.run()
+    if not scf.mean_field.converged:
+        pytest.skip("Tiny periodic KUHF did not converge on this PySCF backend")
+
+    promotions = run_pbc_tda_promotions(
+        scf.mean_field,
+        1,
+        PBCTDAReferenceConfig(oversample=0, candidate_topk=4),
+    )
+
+    assert len(promotions) == 1
+    promotion = promotions[0]
+    assert promotion.excitation_energy > 0
+    assert np.isfinite(promotion.weight)
+    assert promotion.spin in ("alpha", "beta")
+    assert promotion.k_occ == promotion.k_vir == 0
+    assert promotion.vir_mo_index != promotion.occ_mo_index

--- a/tests/utils/atomic/scf_test.py
+++ b/tests/utils/atomic/scf_test.py
@@ -116,6 +116,19 @@ def test_bloch_periodicity(hydrogen_pbc_scf):
         )
 
 
+def test_periodic_orbital_coeff_adapter_matches_ground_path(hydrogen_pbc_scf):
+    pbc_scf, nspins, *_ = hydrogen_pbc_scf
+    positions = jnp.array([[0.3, 0.4, 0.5]])
+
+    native = pbc_scf.eval_orbitals(positions, nspins)
+    adapted = pbc_scf.eval_orbitals_from_coeffs(
+        positions, nspins, pbc_scf.get_occupied_mo_coeffs()
+    )
+
+    for actual, expected in zip(adapted, native):
+        np.testing.assert_array_equal(actual, expected)
+
+
 def test_density_matches_pyscf_get_rho(hydrogen_pbc_scf):
     """Compare density against PySCF reference (Gamma point only)."""
     import pyscf.pbc.dft

--- a/tests/utils/atomic/subspace_pretrain_test.py
+++ b/tests/utils/atomic/subspace_pretrain_test.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import numpy as np
+from jax import numpy as jnp
+
+from jaqmc.data import Data
+from jaqmc.utils.atomic.subspace_pretrain import (
+    make_subspace_pretrain_loss,
+    make_subspace_reference_log_amplitude,
+)
+from jaqmc.wavefunction.determinant_state import SubspaceSpec
+
+
+class ReplicaData(Data):
+    electrons: jax.Array
+
+
+class MockStateReference:
+    def __init__(self, n_states):
+        self.n_states = n_states
+
+    def eval_orbitals(self, state_index, pos, nspins):
+        del nspins
+        target = pos[0, 0] + state_index
+        return target[None, None], jnp.zeros((0, 0))
+
+    def eval_slater(self, state_index, pos, nspins):
+        del nspins
+        x = pos[0, 0]
+        return 0.1 * x + state_index * (0.2 * x**2 + 0.3)
+
+
+def test_subspace_pretrain_loss_has_finite_statewise_gradients():
+    spec = SubspaceSpec(2)
+    reference = MockStateReference(2)
+    data = ReplicaData(electrons=jnp.array([[[1.0]], [[2.0]]]))
+    params = {"w": jnp.array([0.2, -0.4])}
+
+    def orbitals_fn(params_s, physical_data):
+        value = params_s["w"] * physical_data.electrons[0, 0]
+        return value[None, None]
+
+    estimator = make_subspace_pretrain_loss(
+        orbitals_fn,
+        reference,
+        spec,
+        (1, 0),
+        full_det=True,
+    )
+    stats, _ = estimator.evaluate_single_walker(
+        params, data, {}, None, jax.random.key(0)
+    )
+
+    assert jnp.isscalar(stats["loss"])
+    assert jnp.isfinite(stats["loss"])
+    assert stats["grads"]["w"].shape == (2,)
+    assert jnp.all(jnp.isfinite(stats["grads"]["w"]))
+    assert not np.isclose(stats["grads"]["w"][0], stats["grads"]["w"][1])
+
+
+def test_reference_determinant_log_amplitude_is_replica_permutation_invariant():
+    spec = SubspaceSpec(2)
+    reference = MockStateReference(2)
+    log_amplitude = make_subspace_reference_log_amplitude(
+        reference, spec, (1, 0)
+    )
+    data = ReplicaData(electrons=jnp.array([[[0.4]], [[1.3]]]))
+    swapped = ReplicaData(electrons=data.electrons[::-1])
+
+    actual = log_amplitude(data)
+    permuted = log_amplitude(swapped)
+
+    assert jnp.isfinite(actual)
+    np.testing.assert_allclose(actual, permuted, rtol=1e-6, atol=1e-6)
+
+
+def test_m1_reference_path_is_finite_without_tda_states():
+    spec = SubspaceSpec(1)
+    log_amplitude = make_subspace_reference_log_amplitude(
+        MockStateReference(1), spec, (1, 0)
+    )
+    data = ReplicaData(electrons=jnp.array([[[0.7]]]))
+
+    assert jnp.isfinite(log_amplitude(data))

--- a/tests/utils/subspace_linalg_test.py
+++ b/tests/utils/subspace_linalg_test.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+import jax.numpy as jnp
+import numpy as np
+
+from jaqmc.utils.subspace_linalg import (
+    complex_variance,
+    generalized_ritz,
+    rayleigh_solve,
+    row_scaled_matrix,
+    solve_residual,
+    stable_complex_logdet,
+)
+
+
+def test_row_scaling_and_complex_logdet_are_stable():
+    logs = jnp.array([[1000.0, 999.0], [998.0, 1001.0]], dtype=jnp.complex64)
+    scaled, shifts = row_scaled_matrix(logs)
+    expected = jnp.linalg.slogdet(scaled)
+
+    actual = stable_complex_logdet(logs)
+
+    np.testing.assert_allclose(actual.real, shifts.sum() + expected[1], rtol=1e-6)
+    np.testing.assert_allclose(actual.imag, jnp.angle(expected[0]), atol=1e-6)
+    assert np.isfinite(actual)
+
+
+def test_rayleigh_solve_and_residual():
+    phi = jnp.array([[2.0, 0.5], [0.25, 1.5]], dtype=jnp.complex64)
+    expected = jnp.array([[1.0, 0.2j], [-0.1j, 3.0]], dtype=jnp.complex64)
+    phi_h = phi @ expected
+
+    actual = rayleigh_solve(phi, phi_h)
+
+    # CUDA complex64 small-matrix solves can use lower-precision kernels than
+    # the CPU backend.  Keep this test about dtype-appropriate correctness;
+    # production Rayleigh evaluation defaults to complex128.
+    np.testing.assert_allclose(actual, expected, rtol=5e-4, atol=5e-4)
+    np.testing.assert_allclose(solve_residual(phi, actual, phi_h), 0, atol=5e-4)
+
+
+def test_generalized_ritz_matches_explicit_reference():
+    g = jnp.array([[2.0, 0.2], [0.2, 1.0]])
+    gh = jnp.array([[1.0, 0.1], [0.1, 3.0]])
+
+    values, vectors = generalized_ritz(g, gh)
+    residual = gh @ vectors - g @ vectors * values[None, :]
+
+    np.testing.assert_allclose(residual, 0, atol=2e-6)
+    np.testing.assert_allclose(vectors.T @ g @ vectors, jnp.eye(2), atol=2e-6)
+
+
+def test_complex_variance_uses_absolute_square():
+    samples = jnp.array([1 + 1j, 1 - 1j])
+    np.testing.assert_allclose(complex_variance(samples), 1.0)
+
+
+def test_rayleigh_similarity_preserves_trace_and_spectrum():
+    rayleigh = jnp.array([[1.0, 0.2], [0.3, 2.0]], dtype=jnp.complex64)
+    basis = jnp.array([[1.0, 0.4], [-0.2, 1.0]], dtype=jnp.complex64)
+    transformed = jnp.linalg.solve(basis, rayleigh @ basis)
+
+    np.testing.assert_allclose(
+        jnp.trace(transformed), jnp.trace(rayleigh), atol=5e-4
+    )
+    np.testing.assert_allclose(
+        jnp.sort(jnp.linalg.eigvals(transformed)),
+        jnp.sort(jnp.linalg.eigvals(rayleigh)),
+        atol=5e-4,
+    )

--- a/tests/wavefunction/determinant_state_test.py
+++ b/tests/wavefunction/determinant_state_test.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jaqmc.data import Data
+from jaqmc.wavefunction.determinant_state import (
+    DeterminantStateWavefunction,
+    SubspaceSpec,
+)
+
+
+class ToyData(Data):
+    electrons: jax.Array
+    fixed: jax.Array
+
+
+class ToyWavefunction:
+    def init_params(self, data, rngs):
+        del data
+        return {"slope": jax.random.uniform(rngs, (), minval=0.5, maxval=1.5)}
+
+    def phase_logpsi(self, params, data):
+        value = 1 + params["slope"] * data.electrons.sum()
+        return jnp.sign(value), jnp.log(jnp.abs(value))
+
+
+def test_m1_reduces_to_component_amplitude_and_gradient():
+    wf = DeterminantStateWavefunction(ToyWavefunction(), SubspaceSpec(1))
+    data = ToyData(electrons=jnp.array([[[0.2], [0.3]]]), fixed=jnp.array(1.0))
+    params = {"slope": jnp.array([0.7])}
+    physical = ToyData(electrons=data.electrons[0], fixed=data.fixed)
+    _, expected_logabs = ToyWavefunction().phase_logpsi(
+        {"slope": params["slope"][0]}, physical
+    )
+
+    actual = wf.logpsi(params, data)
+    actual_grad = jax.grad(lambda p: wf.logpsi(p, data).real)(params)
+    expected_grad = jax.grad(
+        lambda p: ToyWavefunction().phase_logpsi(p, physical)[1]
+    )({"slope": params["slope"][0]})
+
+    np.testing.assert_allclose(actual.real, expected_logabs, rtol=1e-6)
+    np.testing.assert_allclose(actual_grad["slope"][0], expected_grad["slope"])
+
+
+def test_m1_initialization_uses_the_native_key_exactly():
+    base = ToyWavefunction()
+    wf = DeterminantStateWavefunction(base, SubspaceSpec(1))
+    physical = ToyData(electrons=jnp.array([[0.2]]), fixed=jnp.array(1.0))
+    replica = ToyData(
+        electrons=physical.electrons[None, ...], fixed=physical.fixed
+    )
+    key = jax.random.key(11)
+
+    native = base.init_params(physical, key)
+    determinant = wf.init_params(replica, key)
+
+    np.testing.assert_array_equal(determinant["slope"][0], native["slope"])
+
+
+def test_component_matrix_matches_explicit_loop_and_permutation_invariance():
+    wf = DeterminantStateWavefunction(ToyWavefunction(), SubspaceSpec(2))
+    data = ToyData(
+        electrons=jnp.array([[[0.1]], [[0.8]]]), fixed=jnp.array(1.0)
+    )
+    params = {"slope": jnp.array([0.4, 1.2])}
+
+    logs = wf.component_logpsi_matrix(params, data)
+    expected = np.empty((2, 2), dtype=np.complex64)
+    for r in range(2):
+        for s in range(2):
+            phase, logabs = ToyWavefunction().phase_logpsi(
+                {"slope": params["slope"][s]},
+                ToyData(electrons=data.electrons[r], fixed=data.fixed),
+            )
+            expected[r, s] = np.asarray(logabs + 1j * jnp.angle(phase + 0j))
+    np.testing.assert_allclose(logs, expected, rtol=1e-6)
+
+    original = wf.logpsi(params, data)
+    permuted_params = {"slope": params["slope"][::-1]}
+    permuted = wf.logpsi(permuted_params, data)
+    np.testing.assert_allclose(original.real, permuted.real, atol=1e-6)
+    np.testing.assert_allclose(
+        jnp.exp(2 * original.real), jnp.exp(2 * permuted.real), rtol=1e-6
+    )

--- a/tests/wavefunction/determinant_state_test.py
+++ b/tests/wavefunction/determinant_state_test.py
@@ -4,12 +4,15 @@
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from jaqmc.data import Data
 from jaqmc.wavefunction.determinant_state import (
+    CheckpointStateBundle,
     DeterminantStateWavefunction,
     SubspaceSpec,
 )
+from jaqmc.utils.checkpoint import NumPyCheckpointManager
 
 
 class ToyData(Data):
@@ -86,3 +89,24 @@ def test_component_matrix_matches_explicit_loop_and_permutation_invariance():
     np.testing.assert_allclose(
         jnp.exp(2 * original.real), jnp.exp(2 * permuted.real), rtol=1e-6
     )
+
+
+def test_checkpoint_state_bundle_loads_and_stacks_native_params(tmp_path):
+    paths = []
+    for index, slope in enumerate((0.4, 1.2)):
+        path = tmp_path / f"state-{index}"
+        NumPyCheckpointManager(path, prefix="train").save(
+            index, {"params": {"slope": jnp.array(slope)}}
+        )
+        paths.append(str(path))
+    physical = ToyData(electrons=jnp.array([[0.2]]), fixed=jnp.array(1.0))
+    bundle = CheckpointStateBundle(ToyWavefunction(), SubspaceSpec(2), paths)
+
+    params = bundle.init_params(physical, jax.random.key(0))
+
+    np.testing.assert_allclose(params["slope"], [0.4, 1.2])
+
+
+def test_checkpoint_state_bundle_requires_one_path_per_state():
+    with pytest.raises(ValueError, match="exactly n_states=2"):
+        CheckpointStateBundle(ToyWavefunction(), SubspaceSpec(2), ["one"])

--- a/tests/wavefunction/grassmann_qgt_test.py
+++ b/tests/wavefunction/grassmann_qgt_test.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from jaqmc.utils.func_transform import grad_maybe_complex
+from jaqmc.utils.subspace_linalg import stable_complex_logdet
+
+
+def _synthetic_logs(theta):
+    n_states = theta.shape[0]
+    rows = jnp.arange(1, n_states + 1, dtype=theta.dtype)[:, None]
+    cols = jnp.arange(1, n_states + 1, dtype=theta.dtype)[None, :]
+    base = 0.07 * rows * cols + 0.03j * (rows - cols)
+    return base + theta[None, :] * (0.2 * rows + 0.05j * rows**2)
+
+
+@pytest.mark.parametrize("n_states", [2, 3])
+def test_logdet_score_matches_gvmc_vjp_identity(n_states):
+    theta = jnp.linspace(-0.3, 0.4, n_states, dtype=jnp.float64)
+    score = grad_maybe_complex(
+        lambda value: stable_complex_logdet(_synthetic_logs(value))
+    )(theta)
+
+    logs = _synthetic_logs(theta)
+    phi = jnp.exp(logs)
+    cotangent = phi * jnp.linalg.inv(phi).T
+    _, vjp = jax.vjp(_synthetic_logs, theta)
+    (score_real,) = vjp(cotangent)
+    (score_imag,) = vjp(-1j * cotangent)
+    reference = jax.lax.complex(score_real, score_imag)
+
+    np.testing.assert_allclose(score, reference, rtol=1e-10, atol=1e-12)
+
+
+@pytest.mark.parametrize("n_states", [2, 3])
+def test_stable_row_scaling_preserves_logdet_score(n_states):
+    theta = jnp.linspace(-0.2, 0.5, n_states, dtype=jnp.float64)
+
+    def direct(value):
+        sign, logabs = jnp.linalg.slogdet(jnp.exp(_synthetic_logs(value)))
+        return logabs + jnp.log(sign)
+
+    stable_score = grad_maybe_complex(
+        lambda value: stable_complex_logdet(_synthetic_logs(value))
+    )(theta)
+    direct_score = grad_maybe_complex(direct)(theta)
+
+    np.testing.assert_allclose(stable_score, direct_score, rtol=1e-10, atol=1e-12)
+
+
+def test_m1_grassmann_qgt_reduces_to_ordinary_score_covariance():
+    theta = jnp.array([0.35], dtype=jnp.float64)
+    samples = jnp.array([-1.0, -0.2, 0.7, 1.5], dtype=jnp.float64)
+
+    def component(value, sample):
+        return value[0] * sample + 0.1j * value[0] * sample**2
+
+    def determinant(value, sample):
+        return stable_complex_logdet(component(value, sample)[None, None])
+
+    component_scores = jax.vmap(
+        lambda sample: grad_maybe_complex(component)(theta, sample)
+    )(samples)
+    determinant_scores = jax.vmap(
+        lambda sample: grad_maybe_complex(determinant)(theta, sample)
+    )(samples)
+    centered = component_scores - jnp.mean(component_scores, axis=0)
+    ordinary_qgt = jnp.real(jnp.conj(centered).T @ centered) / len(samples)
+    det_centered = determinant_scores - jnp.mean(determinant_scores, axis=0)
+    grassmann_qgt = (
+        jnp.real(jnp.conj(det_centered).T @ det_centered) / len(samples)
+    )
+
+    np.testing.assert_allclose(
+        determinant_scores, component_scores, rtol=1e-11, atol=1e-12
+    )
+    np.testing.assert_allclose(grassmann_qgt, ordinary_qgt, rtol=1e-11)

--- a/tests/workflow/subspace_vmc_test.py
+++ b/tests/workflow/subspace_vmc_test.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jaqmc.data import BatchedData, Data
+from jaqmc.utils import parallel_jax
+from jaqmc.utils.config import ConfigManager
+from jaqmc.wavefunction.determinant_state import SubspaceSpec, take_replica
+from jaqmc.workflow.base import init_batched_data
+from jaqmc.workflow.subspace_vmc import (
+    SubspaceVMCWorkflow,
+    make_subspace_data_init,
+    replicate_walker_replicas,
+)
+
+
+class ToyData(Data):
+    electrons: jax.Array
+    atoms: jax.Array
+
+
+def test_replica_axis_is_inside_walker_axis_and_physical_data_is_recoverable():
+    physical = BatchedData(
+        ToyData(electrons=jnp.zeros((5, 2, 3)), atoms=jnp.ones((1, 3))),
+        ["electrons"],
+    )
+    spec = SubspaceSpec(4)
+
+    replica_data = replicate_walker_replicas(physical, spec)
+    one_walker = replica_data.unbatched_example()
+    recovered = take_replica(one_walker, 2, spec)
+
+    assert replica_data.data.electrons.shape == (5, 4, 2, 3)
+    assert replica_data.fields_with_batch == ["electrons"]
+    assert recovered.electrons.shape == (2, 3)
+    np.testing.assert_array_equal(recovered.atoms, physical.data.atoms)
+
+
+def test_subspace_data_init_groups_independent_native_samples():
+    requested_sizes = []
+
+    def physical_data_init(size, rngs):
+        del rngs
+        requested_sizes.append(size)
+        return BatchedData(
+            ToyData(
+                electrons=jnp.arange(size, dtype=float)[:, None, None],
+                atoms=jnp.ones((1, 3)),
+            ),
+            ["electrons"],
+        )
+
+    data_init = make_subspace_data_init(physical_data_init, SubspaceSpec(3))
+    result = data_init(4, jax.random.key(0))
+
+    assert requested_sizes == [12]
+    assert result.data.electrons.shape == (4, 3, 1, 1)
+    np.testing.assert_array_equal(
+        result.data.electrons[:, :, 0, 0], jnp.arange(12).reshape(4, 3)
+    )
+
+
+class ToyWavefunction:
+    def init_params(self, data, rngs):
+        del data
+        return {"slope": jax.random.uniform(rngs, (), minval=0.5, maxval=1.5)}
+
+    def logpsi(self, params, data):
+        return params["slope"] * jnp.sum(data.electrons)
+
+    def phase_logpsi(self, params, data):
+        return jnp.array(1.0), self.logpsi(params, data)
+
+
+def test_workflow_accepts_documented_nested_subspace_config():
+    cfg = ConfigManager(
+        {
+            "workflow": {"batch_size": 4, "save_path": ".tmp/subspace-test"},
+            "subspace": {
+                "n_states": 2,
+                "sampling": {"steps": 3, "initial_width": 0.04},
+                "evaluation": {
+                    "pair_chunk_size": 2,
+                    "matrix_dtype": "complex64",
+                },
+                "diagnostics": {
+                    "condition_warning": 1e8,
+                    "solve_residual_warning": 1e-5,
+                    "max_imag_eigenvalue_warning": 1e-4,
+                },
+            },
+        }
+    )
+
+    def physical_data_init(size, rngs):
+        del rngs
+        return BatchedData(
+            ToyData(
+                electrons=jnp.arange(size, dtype=float)[:, None, None],
+                atoms=jnp.ones((1, 3)),
+            ),
+            ["electrons"],
+        )
+
+    def energy(params, data, prev_stats, state, rngs):
+        del params, data, prev_stats, rngs
+        return {"total_energy": jnp.array(1.0)}, state
+
+    workflow = SubspaceVMCWorkflow(cfg)
+    workflow.configure_subspace(
+        base_wavefunction=ToyWavefunction(),
+        physical_data_init=physical_data_init,
+        physical_energy_estimators={"total": energy},
+    )
+    workflow.prepare(dry_run=True)
+
+    sampler = workflow.train_stage.sample_plan.samplers[("electrons",)]
+    assert sampler.n_states == 2
+    assert sampler.steps == 3
+    assert sampler.initial_width == 0.04
+
+    data = init_batched_data(workflow.data_init, 4, jax.random.key(2))
+    state = workflow.train_stage.create_state(jax.random.key(3), batched_data=data)
+    partition = state.partition()
+    compute = parallel_jax.jit_sharded(
+        workflow.train_stage.compute_step,
+        in_specs=(partition, parallel_jax.DATA_PARTITION),
+        out_specs=(parallel_jax.SHARE_PARTITION, partition),
+        check_vma=False,
+    )
+    rngs = jax.device_put(
+        jax.random.split(jax.random.PRNGKey(4), jax.device_count()).flatten(),
+        parallel_jax.make_sharding(parallel_jax.DATA_PARTITION),
+    )
+    stats, updated = compute(state, rngs)
+
+    assert jnp.isfinite(stats["subspace_energy"])
+    assert all(
+        np.isfinite(np.asarray(x)).all() for x in jax.tree.leaves(updated.params)
+    )

--- a/tests/workflow/subspace_vmc_test.py
+++ b/tests/workflow/subspace_vmc_test.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from jaqmc.data import BatchedData, Data
 from jaqmc.estimator import StreamingLossAndGrad
@@ -77,6 +78,23 @@ class ToyWavefunction:
 
     def phase_logpsi(self, params, data):
         return jnp.array(1.0), self.logpsi(params, data)
+
+    def orbitals(self, params, data):
+        value = params["slope"] * jnp.sum(data.electrons)
+        return value[None, None]
+
+
+class ToyStateReference:
+    n_states = 2
+
+    def eval_orbitals(self, state_index, pos, nspins):
+        del nspins
+        value = jnp.sum(pos) + state_index
+        return value[None, None], jnp.zeros((0, 0))
+
+    def eval_slater(self, state_index, pos, nspins):
+        del nspins
+        return state_index * jnp.sum(pos)
 
 
 def test_workflow_accepts_documented_nested_subspace_config():
@@ -222,3 +240,83 @@ def test_invalid_subspace_step_skips_optimizer_update():
     )
     np.testing.assert_array_equal(stats["update_norm"], 0)
     assert stage._has_nan(stats)
+
+
+def test_subspace_pretrain_reuses_wavefunction_and_determinant_sampler():
+    cfg = ConfigManager(
+        {
+            "workflow": {"batch_size": 2},
+            "subspace": {"n_states": 2},
+            "pretrain": {"run": {"iterations": 1, "burn_in": 0}},
+        }
+    )
+
+    def physical_data_init(size, rngs):
+        del rngs
+        return BatchedData(
+            ToyData(
+                electrons=jnp.ones((size, 1, 1)), atoms=jnp.ones((1, 3))
+            ),
+            ["electrons"],
+        )
+
+    def energy(params, data, prev_stats, state, rngs):
+        del params, data, prev_stats, rngs
+        return {"total_energy": jnp.array(1.0)}, state
+
+    workflow = SubspaceVMCWorkflow(cfg)
+    workflow.configure_subspace(
+        base_wavefunction=ToyWavefunction(),
+        physical_data_init=physical_data_init,
+        physical_energy_estimators={"total": energy},
+    )
+    workflow.configure_subspace_pretrain(
+        orbital_reference=ToyStateReference(),
+        nspins=(1, 0),
+        full_det=True,
+        ref_fraction=1.0,
+    )
+
+    pretrain_sampler = workflow.pretrain_stage.sample_plan.samplers[("electrons",)]
+    train_sampler = workflow.train_stage.sample_plan.samplers[("electrons",)]
+    assert workflow.pretrain_stage.wavefunction is workflow.train_stage.wavefunction
+    assert pretrain_sampler is train_sampler
+
+
+def test_subspace_pretrain_rejects_checkpoint_initialization():
+    cfg = ConfigManager(
+        {
+            "workflow": {"batch_size": 2},
+            "subspace": {
+                "n_states": 2,
+                "initialization": {
+                    "mode": "checkpoints",
+                    "checkpoints": ["state0", "state1"],
+                },
+            },
+        }
+    )
+
+    def physical_data_init(size, rngs):
+        del rngs
+        return BatchedData(
+            ToyData(
+                electrons=jnp.ones((size, 1, 1)), atoms=jnp.ones((1, 3))
+            ),
+            ["electrons"],
+        )
+
+    workflow = SubspaceVMCWorkflow(cfg)
+    workflow.configure_subspace(
+        base_wavefunction=ToyWavefunction(),
+        physical_data_init=physical_data_init,
+        physical_energy_estimators={},
+    )
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        workflow.configure_subspace_pretrain(
+            orbital_reference=ToyStateReference(),
+            nspins=(1, 0),
+            full_det=True,
+            ref_fraction=1.0,
+        )

--- a/tests/workflow/subspace_vmc_test.py
+++ b/tests/workflow/subspace_vmc_test.py
@@ -122,9 +122,11 @@ def test_workflow_accepts_documented_nested_subspace_config():
     workflow.prepare(dry_run=True)
 
     sampler = workflow.train_stage.sample_plan.samplers[("electrons",)]
+    optimizer = workflow.train_stage.optimizer
     assert sampler.n_states == 2
     assert sampler.steps == 3
     assert sampler.initial_width == 0.04
+    assert type(optimizer).__name__ == "adam"
 
     data = init_batched_data(workflow.data_init, 4, jax.random.key(2))
     state = workflow.train_stage.create_state(jax.random.key(3), batched_data=data)
@@ -142,6 +144,7 @@ def test_workflow_accepts_documented_nested_subspace_config():
     updated, stats = compute(state, rngs)
 
     assert jnp.isfinite(stats["subspace_energy"])
+    assert jnp.isfinite(stats["subspace_energy_var"])
     assert all(
         np.isfinite(np.asarray(x)).all() for x in jax.tree.leaves(updated.params)
     )

--- a/tests/workflow/subspace_vmc_test.py
+++ b/tests/workflow/subspace_vmc_test.py
@@ -8,7 +8,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from jaqmc.data import BatchedData, Data
-from jaqmc.estimator.loss_grad import StreamingLossAndGrad
+from jaqmc.estimator import StreamingLossAndGrad
 from jaqmc.utils import parallel_jax
 from jaqmc.utils.config import ConfigManager
 from jaqmc.wavefunction.determinant_state import SubspaceSpec, take_replica
@@ -142,6 +142,12 @@ def test_workflow_accepts_documented_nested_subspace_config():
     assert grads.clip_scale == 7.0
     assert grads.loss_key == "subspace_local_energy"
 
+    console_fields = workflow.default_preset()["train"]["writers"]["console"][
+        "fields"
+    ]
+    assert "grad_norm=grad_norm" in console_fields
+    assert "update_norm=update_norm" in console_fields
+
     data = init_batched_data(workflow.data_init, 4, jax.random.key(2))
     state = workflow.train_stage.create_state(jax.random.key(3), batched_data=data)
     partition = state.partition()
@@ -214,4 +220,5 @@ def test_invalid_subspace_step_skips_optimizer_update():
     np.testing.assert_array_equal(
         updated.opt_state["count"], original.opt_state["count"]
     )
+    np.testing.assert_array_equal(stats["update_norm"], 0)
     assert stage._has_nan(stats)

--- a/tests/workflow/subspace_vmc_test.py
+++ b/tests/workflow/subspace_vmc_test.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
 # SPDX-License-Identifier: Apache-2.0
 
+from dataclasses import dataclass
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -12,9 +14,11 @@ from jaqmc.wavefunction.determinant_state import SubspaceSpec, take_replica
 from jaqmc.workflow.base import init_batched_data
 from jaqmc.workflow.subspace_vmc import (
     SubspaceVMCWorkflow,
+    SubspaceVMCWorkStage,
     make_subspace_data_init,
     replicate_walker_replicas,
 )
+from jaqmc.workflow.stage.vmc import VMCWorkStage
 
 
 class ToyData(Data):
@@ -128,16 +132,48 @@ def test_workflow_accepts_documented_nested_subspace_config():
     compute = parallel_jax.jit_sharded(
         workflow.train_stage.compute_step,
         in_specs=(partition, parallel_jax.DATA_PARTITION),
-        out_specs=(parallel_jax.SHARE_PARTITION, partition),
+        out_specs=(partition, parallel_jax.SHARE_PARTITION),
         check_vma=False,
     )
     rngs = jax.device_put(
         jax.random.split(jax.random.PRNGKey(4), jax.device_count()).flatten(),
         parallel_jax.make_sharding(parallel_jax.DATA_PARTITION),
     )
-    stats, updated = compute(state, rngs)
+    updated, stats = compute(state, rngs)
 
     assert jnp.isfinite(stats["subspace_energy"])
     assert all(
         np.isfinite(np.asarray(x)).all() for x in jax.tree.leaves(updated.params)
     )
+
+
+def test_invalid_subspace_step_rolls_back_params_and_optimizer(monkeypatch):
+    @dataclass
+    class ToyState:
+        params: dict
+        opt_state: dict
+
+    original = ToyState(
+        params={"w": jnp.array(1.0)}, opt_state={"count": jnp.array(2)}
+    )
+
+    def invalid_update(self, state, rngs):
+        del self, rngs
+        return (
+            ToyState(
+                params={"w": jnp.array(jnp.nan)},
+                opt_state={"count": jnp.array(3)},
+            ),
+            {"training_step_valid": jnp.array(False)},
+        )
+
+    monkeypatch.setattr(VMCWorkStage, "compute_step", invalid_update)
+    stage = object.__new__(SubspaceVMCWorkStage)
+
+    updated, stats = stage.compute_step(original, jax.random.key(0))
+
+    np.testing.assert_array_equal(updated.params["w"], original.params["w"])
+    np.testing.assert_array_equal(
+        updated.opt_state["count"], original.opt_state["count"]
+    )
+    assert stage._has_nan(stats)

--- a/tests/workflow/subspace_vmc_test.py
+++ b/tests/workflow/subspace_vmc_test.py
@@ -8,6 +8,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from jaqmc.data import BatchedData, Data
+from jaqmc.estimator.loss_grad import StreamingLossAndGrad
 from jaqmc.utils import parallel_jax
 from jaqmc.utils.config import ConfigManager
 from jaqmc.wavefunction.determinant_state import SubspaceSpec, take_replica
@@ -18,7 +19,6 @@ from jaqmc.workflow.subspace_vmc import (
     make_subspace_data_init,
     replicate_walker_replicas,
 )
-from jaqmc.workflow.stage.vmc import VMCWorkStage
 
 
 class ToyData(Data):
@@ -96,6 +96,14 @@ def test_workflow_accepts_documented_nested_subspace_config():
                     "max_imag_eigenvalue_warning": 1e-4,
                 },
             },
+            "train": {
+                "grads": {
+                    "vmap_chunk_size": 3,
+                    "clip_method": "none",
+                    "clip_scale": 7.0,
+                    "loss_key": "must_be_overridden",
+                }
+            },
         }
     )
 
@@ -123,10 +131,16 @@ def test_workflow_accepts_documented_nested_subspace_config():
 
     sampler = workflow.train_stage.sample_plan.samplers[("electrons",)]
     optimizer = workflow.train_stage.optimizer
+    grads = workflow.train_stage.estimators.estimators["grads"]
     assert sampler.n_states == 2
     assert sampler.steps == 3
     assert sampler.initial_width == 0.04
     assert type(optimizer).__name__ == "adam"
+    assert isinstance(grads, StreamingLossAndGrad)
+    assert grads.vmap_chunk_size == 3
+    assert grads.clip_method == "none"
+    assert grads.clip_scale == 7.0
+    assert grads.loss_key == "subspace_local_energy"
 
     data = init_batched_data(workflow.data_init, 4, jax.random.key(2))
     state = workflow.train_stage.create_state(jax.random.key(3), batched_data=data)
@@ -150,28 +164,49 @@ def test_workflow_accepts_documented_nested_subspace_config():
     )
 
 
-def test_invalid_subspace_step_rolls_back_params_and_optimizer(monkeypatch):
+def test_invalid_subspace_step_skips_optimizer_update():
     @dataclass
     class ToyState:
         params: dict
+        batched_data: object
+        sampler_state: object
+        estimator_state: object
         opt_state: dict
 
     original = ToyState(
-        params={"w": jnp.array(1.0)}, opt_state={"count": jnp.array(2)}
+        params={"w": jnp.array(1.0)},
+        batched_data=object(),
+        sampler_state=None,
+        estimator_state=None,
+        opt_state={"count": jnp.array(2)},
     )
 
-    def invalid_update(self, state, rngs):
-        del self, rngs
-        return (
-            ToyState(
-                params={"w": jnp.array(jnp.nan)},
-                opt_state={"count": jnp.array(3)},
-            ),
-            {"training_step_valid": jnp.array(False)},
-        )
+    class SamplePlan:
+        def step(self, params, data, sampler_state, rngs):
+            del params, rngs
+            return data, {}, sampler_state
 
-    monkeypatch.setattr(VMCWorkStage, "compute_step", invalid_update)
+    class Estimators:
+        def evaluate(self, params, data, estimator_state, rngs):
+            del params, data, rngs
+            return {}, estimator_state
+
+        def finalize_stats(self, stats, estimator_state):
+            del stats, estimator_state
+            return {
+                "grads": {"w": jnp.array(jnp.nan)},
+                "training_step_valid": jnp.array(False),
+            }
+
+    class Optimizer:
+        def update(self, grads, opt_state, **kwargs):
+            del grads, kwargs
+            return {"w": jnp.array(jnp.nan)}, {"count": opt_state["count"] + 1}
+
     stage = object.__new__(SubspaceVMCWorkStage)
+    stage.sample_plan = SamplePlan()
+    stage.estimators = Estimators()
+    stage.optimizer = Optimizer()
 
     updated, stats = stage.compute_step(original, jax.random.key(0))
 

--- a/tests/workflow/subspace_vmc_test.py
+++ b/tests/workflow/subspace_vmc_test.py
@@ -16,6 +16,7 @@ from jaqmc.utils import parallel_jax
 from jaqmc.utils.config import ConfigManager
 from jaqmc.wavefunction.determinant_state import SubspaceSpec, take_replica
 from jaqmc.workflow.base import init_batched_data
+from jaqmc.workflow.stage.vmc import VMCState
 from jaqmc.workflow.subspace_vmc import (
     SubspaceVMCWorkflow,
     SubspaceVMCWorkStage,
@@ -287,6 +288,57 @@ def test_invalid_subspace_step_skips_optimizer_update():
     )
     np.testing.assert_array_equal(stats["update_norm"], 0)
     assert stage._has_nan(stats)
+
+
+def test_invalid_subspace_step_preserves_state_under_jit():
+    data = BatchedData(
+        ToyData(
+            electrons=jnp.ones((2, 1, 1)), atoms=jnp.ones((1, 3))
+        ),
+        ["electrons"],
+    )
+    original = VMCState(
+        params={"w": jnp.array(1.0)},
+        batched_data=data,
+        sampler_state=jnp.array(3),
+        estimator_state=jnp.array(4),
+        opt_state={"count": jnp.array(2)},
+    )
+
+    class SamplePlan:
+        def step(self, params, batched_data, sampler_state, rngs):
+            del params, rngs
+            return batched_data, {"pmove": jnp.array(1.0)}, sampler_state
+
+    class Estimators:
+        def evaluate(self, params, batched_data, estimator_state, rngs):
+            del params, batched_data, rngs
+            return {"dummy": jnp.array(0.0)}, estimator_state
+
+        def finalize_stats(self, stats, estimator_state):
+            del stats, estimator_state
+            return {
+                "grads": {"w": jnp.array(5.0)},
+                "training_step_valid": jnp.array(False),
+            }
+
+    class SentinelOptimizer:
+        def update(self, grads, opt_state, **kwargs):
+            del grads, opt_state, kwargs
+            return {"w": jnp.array(999.0)}, {"count": jnp.array(999)}
+
+    stage = object.__new__(SubspaceVMCWorkStage)
+    stage.sample_plan = SamplePlan()
+    stage.estimators = Estimators()
+    stage.optimizer = SentinelOptimizer()
+
+    updated, stats = jax.jit(stage.compute_step)(original, jax.random.key(0))
+
+    np.testing.assert_array_equal(updated.params["w"], original.params["w"])
+    np.testing.assert_array_equal(
+        updated.opt_state["count"], original.opt_state["count"]
+    )
+    np.testing.assert_array_equal(stats["update_norm"], 0)
 
 
 def test_subspace_pretrain_reuses_wavefunction_and_determinant_sampler():

--- a/tests/workflow/subspace_vmc_test.py
+++ b/tests/workflow/subspace_vmc_test.py
@@ -10,6 +10,8 @@ import pytest
 
 from jaqmc.data import BatchedData, Data
 from jaqmc.estimator import StreamingLossAndGrad
+from jaqmc.optimizer.gvmc_reference_sr import GVMCReferenceSROptimizer
+from jaqmc.optimizer.sr import SROptimizer
 from jaqmc.utils import parallel_jax
 from jaqmc.utils.config import ConfigManager
 from jaqmc.wavefunction.determinant_state import SubspaceSpec, take_replica
@@ -186,6 +188,51 @@ def test_workflow_accepts_documented_nested_subspace_config():
     assert all(
         np.isfinite(np.asarray(x)).all() for x in jax.tree.leaves(updated.params)
     )
+
+
+@pytest.mark.parametrize(
+    ("module", "expected_type"),
+    [
+        ("jaqmc.optimizer.sr:SROptimizer", SROptimizer),
+        (
+            "jaqmc.optimizer.gvmc_reference_sr:GVMCReferenceSROptimizer",
+            GVMCReferenceSROptimizer,
+        ),
+    ],
+)
+def test_subspace_optimizer_is_swappable_through_native_config(
+    module, expected_type
+):
+    cfg = ConfigManager(
+        {
+            "workflow": {"batch_size": 4},
+            "subspace": {"n_states": 2},
+            "train": {
+                "optim": {"module": module},
+                "grads": {"clip_method": "none"},
+            },
+        }
+    )
+
+    def physical_data_init(size, rngs):
+        del rngs
+        return BatchedData(
+            ToyData(
+                electrons=jnp.ones((size, 1, 1)), atoms=jnp.ones((1, 3))
+            ),
+            ["electrons"],
+        )
+
+    workflow = SubspaceVMCWorkflow(cfg)
+    workflow.configure_subspace(
+        base_wavefunction=ToyWavefunction(),
+        physical_data_init=physical_data_init,
+        physical_energy_estimators={},
+    )
+
+    assert isinstance(workflow.train_stage.optimizer, expected_type)
+    grads = workflow.train_stage.estimators.estimators["grads"]
+    assert grads.clip_method == "none"
 
 
 def test_invalid_subspace_step_skips_optimizer_update():

--- a/tests/workflow/subspace_vmc_test.py
+++ b/tests/workflow/subspace_vmc_test.py
@@ -271,8 +271,8 @@ def test_invalid_subspace_step_skips_optimizer_update():
 
     class Optimizer:
         def update(self, grads, opt_state, **kwargs):
-            del grads, kwargs
-            return {"w": jnp.array(jnp.nan)}, {"count": opt_state["count"] + 1}
+            del grads, opt_state, kwargs
+            raise AssertionError("optimizer must not be called")
 
     stage = object.__new__(SubspaceVMCWorkStage)
     stage.sample_plan = SamplePlan()


### PR DESCRIPTION
## Summary

This PR adds variational subspace VMC support to JaQMC for optimizing multiple low-energy states as a determinant-defined subspace.

Main additions include:

- determinant-state wavefunctions and determinant MCMC sampling;
- Rayleigh-matrix and subspace-variance estimators;
- memory-efficient streaming VMC gradients;
- Grassmann natural-gradient optimization using JaQMC SR/SPRING;
- a GVMC-compatible reference minSR/Kaczmarz implementation for numerical validation;
- molecular and solid-state `subspace-train` workflows;
- optional periodic TDA-based subspace initialization;
- unit, multi-device, and regression tests for the subspace, gradient, Rayleigh, and Grassmann-SR paths;
- hydrogen-atom and hydrogen-chain example configurations.

The implementation keeps the production optimization path based on JaQMC's native distributed SR infrastructure, while using the GVMC reference backend only as a small-system correctness oracle.