### PR TITLE
feat: add variational subspace VMC with Grassmann SR

### DIFF
--- a/configs/workflows/subspace_grassmann_sr.yml
+++ b/configs/workflows/subspace_grassmann_sr.yml
@@ -1,0 +1,20 @@
+# Production Grassmann natural-gradient preset.
+# The determinant-state logpsi score is the Grassmann score; use JaQMC's
+# distributed/chunked SR implementation rather than a second QGT backend.
+# For controlled plain-SR A/B tests, JaQMC's native factor-2 gradient means
+# lr_native is approximately lr_gvmc / 2. Robust features break exact scaling.
+train:
+  optim:
+    module: jaqmc.optimizer.sr:SROptimizer
+    learning_rate: 0.05
+    damping: 1.0e-3
+    spring_mu: 0.9
+    march_beta: null
+    max_cond_num: null
+    max_norm: null
+    robust_gamma: null
+    mixed_precision: true
+    score_chunk_size: 64
+    gram_num_chunks: 4
+  grads:
+    clip_method: none

--- a/configs/workflows/subspace_gvmc_reference_sr.yml
+++ b/configs/workflows/subspace_gvmc_reference_sr.yml
@@ -1,0 +1,15 @@
+# Small-system single-device oracle matching the GVMC minSR/Kacz equations.
+# This backend converts JaQMC's factor-2 native gradient at its adapter and
+# applies the configured learning rate directly, as cqsl/GVMC does.
+# For controlled plain-SR comparisons, use lr_native ~= lr_gvmc / 2.
+# Do not use this backend for multi-device or production runs.
+train:
+  optim:
+    module: jaqmc.optimizer.gvmc_reference_sr:GVMCReferenceSROptimizer
+    learning_rate: 0.10
+    lam0: 1.0e-3
+    lam1: 1.0
+    mu: 0.9
+    score_chunk_size: null
+  grads:
+    clip_method: none

--- a/docs/api-reference/estimators.md
+++ b/docs/api-reference/estimators.md
@@ -93,4 +93,13 @@ API reference for built-in estimators. For background, formulas, and configurati
 
 ```{eval-rst}
 .. autoclass:: jaqmc.estimator.loss_grad.LossAndGrad
+.. autoclass:: jaqmc.estimator.streaming_loss_grad.StreamingLossAndGrad
+```
+
+### Variational subspace Rayleigh matrix
+
+```{eval-rst}
+.. autoclass:: jaqmc.estimator.RayleighMatrixEstimator
+   :members:
+.. autofunction:: jaqmc.estimator.grassmann_hamiltonian_statistics
 ```

--- a/docs/api-reference/optimizers.md
+++ b/docs/api-reference/optimizers.md
@@ -23,8 +23,14 @@ For optimizer config keys, see the configuration reference: [Molecule](#train-op
 
 ```{eval-rst}
 .. autoclass:: jaqmc.optimizer.sr.SROptimizer
+.. autoclass:: jaqmc.optimizer.gvmc_reference_sr.GVMCReferenceSROptimizer
 .. autoclass:: jaqmc.optimizer.kfac.kfac.KFACOptimizer
 ```
+
+The GVMC reference backend is intended only for source-equation comparisons on
+one device. Determinant-state production runs should use
+{class}`jaqmc.optimizer.sr.SROptimizer`, which evaluates the same Grassmann
+score with JaQMC's distributed and chunked solver.
 
 ## Optimizers provided by <inv:optax:*:doc#index>
 

--- a/docs/api-reference/samplers.md
+++ b/docs/api-reference/samplers.md
@@ -36,4 +36,8 @@ For sampler config keys, see the configuration reference: [Molecule](#train-samp
    :special-members: __call__
 
 .. autoclass:: jaqmc.sampler.mcmc.MCMCState
+
+.. autoclass:: jaqmc.sampler.DeterminantMCMCSampler
+   :members:
+   :inherited-members:
 ```

--- a/docs/api-reference/wavefunctions.md
+++ b/docs/api-reference/wavefunctions.md
@@ -30,6 +30,15 @@ For architecture-specific options (FermiNet, LapNet, Psiformer, and system-speci
 .. autoclass:: jaqmc.wavefunction.base.LogPsiWFOutput
 ```
 
+## Variational subspace adapters
+
+```{eval-rst}
+.. autoclass:: jaqmc.wavefunction.DeterminantStateWavefunction
+   :members:
+.. autoclass:: jaqmc.wavefunction.IndependentStateBundle
+   :members:
+```
+
 ### Log-determinant output (used by FermiNet / LapNet / Psiformer)
 
 ```{eval-rst}

--- a/docs/api-reference/workflows.md
+++ b/docs/api-reference/workflows.md
@@ -13,6 +13,9 @@ Use the built-in {class}`~jaqmc.workflow.vmc.VMCWorkflow` and {class}`~jaqmc.wor
 
 .. autoclass:: jaqmc.workflow.evaluation.EvaluationWorkflow
    :members: run
+
+.. autoclass:: jaqmc.workflow.SubspaceVMCWorkflow
+   :members:
 ```
 
 ## Workflow configuration

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -19,6 +19,7 @@ Use this section when you already picked a system and want to run, analyze, tune
 - <project:wavefunction.md> — choose and tune built-in wavefunction architectures.
 - <project:optimizers/index.md> — pick and configure optimization methods.
 - <project:sampling.md> — tune MCMC behavior and acceptance.
+- <project:subspace-variational.md> — jointly optimize low-energy variational subspaces.
 - <project:writers.md> — control which statistics are written and where.
 
 ## Physics and Estimators
@@ -42,6 +43,7 @@ wavefunction.md
 estimators/index.md
 optimizers/index.md
 sampling.md
+subspace-variational.md
 periodic-boundaries.md
 writers.md
 multi-device.md

--- a/docs/guide/subspace-variational.md
+++ b/docs/guide/subspace-variational.md
@@ -1,0 +1,195 @@
+# Variational subspaces
+
+JaQMC can jointly optimize a low-energy subspace without changing the physical
+FermiNet, LapNet, or Psiformer implementation.  The extension evaluates one
+native ansatz architecture with independent parameter sets, samples the
+determinant state, and minimizes the real trace of its local Rayleigh matrix.
+For complex wavefunctions the gradient estimator retains the complete complex
+local trace; the real and imaginary parts are split only for reporting.
+
+Use a separate workflow so ordinary ground-state commands and configuration
+remain unchanged:
+
+```console
+jaqmc molecule subspace-train --yml config.yaml
+jaqmc solid subspace-train --yml config.yaml
+```
+
+The determinant walker stores coordinates as `[walkers, states, electrons, 3]`.
+The state/replica axis is never flattened into the physical electron axis, so
+Hamiltonian estimators do not introduce interactions between replicas.  Initial
+replicas are independent samples produced by the app's existing data
+initializer.
+
+## Configuration
+
+The optimizer stays under the native `train.optim` namespace. Adam is the
+correctness-first subspace default; KFAC can be selected explicitly after the
+determinant-state curvature path has been validated for the target network.
+
+```yaml
+subspace:
+  n_states: 2
+
+  initialization:
+    mode: random  # or checkpoints
+    # checkpoints: [/path/to/state0, /path/to/state1]
+
+  sampling:
+    steps: 10
+    initial_width: 0.02
+    update_mode: full
+
+  evaluation:
+    vmap_chunk_size: 1
+    pair_chunk_size: 4
+    matrix_dtype: complex128
+
+  diagnostics:
+    condition_warning: 1.0e10
+    solve_residual_warning: 1.0e-6
+    max_imag_eigenvalue_warning: 1.0e-6
+
+train:
+  optim:
+    module: jaqmc.optimizer.optax:adam
+    learning_rate: 0.0001
+  grads:
+    vmap_chunk_size: 1
+    clip_method: mad
+    clip_scale: 5.0
+```
+
+The three chunk controls apply to different axes:
+
+- `subspace.evaluation.vmap_chunk_size` controls determinant walkers entering
+  the Rayleigh/local-energy estimator concurrently.
+- `subspace.evaluation.pair_chunk_size` controls concurrent $(r,s)$ energy
+  pairs inside one determinant walker.
+- `train.grads.vmap_chunk_size` controls determinant walkers entering the
+  streaming log-determinant gradient calculation.
+
+Parameters and replica data remain in their original $M$-sized containers.
+The streaming gradient estimator reduces each chunk immediately to parameter
+PyTree sufficient statistics instead of reconstructing a
+`[walkers, ...parameters]` tree. State-independent potential energy is
+evaluated $M$ times and reused across state columns. Walker sharding remains
+the existing JaQMC behavior; every device keeps the complete state axis.
+
+This is intentionally walker-axis data parallelism. With a global determinant
+batch of $B$ and $N$ devices, each device receives approximately $B/N$ walkers
+while retaining all $M$ component states. Pair and gradient chunk sizes control
+single-device concurrency and memory; they do not shard the state axis.
+
+With `initialization.mode: checkpoints`, provide exactly `n_states` native
+JaQMC checkpoint files or directories. Parameter PyTree structure and leaf
+shapes are checked before the states are stacked.
+
+## Reused native components
+
+For every replica $R_r$ and component state $s$, the estimator calls the
+already configured physical JaQMC energy pipeline to obtain
+$E_{L,s}(R_r)$.  It then forms
+
+$$
+\Phi^{(H)}_{rs}=\Phi_{rs}E_{L,s}(R_r),\qquad
+R_L=\operatorname{solve}(\Phi,\Phi^{(H)}).
+$$
+
+The reported scalar energy is $\operatorname{Re}\operatorname{Tr}R_L$; the
+gradient uses the full complex $\operatorname{Tr}R_L$ through
+`StreamingLossAndGrad`. The workflow forces this loss key while preserving
+`train.grads` configuration for chunking and clipping. No NetKet runtime or
+second Hamiltonian implementation is used.
+
+## Grassmann optimization
+
+No separate Grassmann wavefunction or QGT implementation is required. For the
+determinant state,
+
+$$
+\partial_\mu\log\det\Phi
+=\operatorname{Tr}(\Phi^{-1}\partial_\mu\Phi),
+$$
+
+so passing `DeterminantStateWavefunction.logpsi` to JaQMC's existing
+`SROptimizer` produces the Grassmann score and metric. The recommended
+production preset is `configs/workflows/subspace_grassmann_sr.yml`; it retains
+JaQMC's chunking, mixed-precision solve, SPRING, and multi-device reductions
+while disabling robustness extensions for a controlled first comparison.
+
+For small, single-device A/B checks,
+`configs/workflows/subspace_gvmc_reference_sr.yml` selects
+`GVMCReferenceSROptimizer`. This backend independently implements the published
+GVMC sample-space minSR and Kaczmarz/SPRING equations from the
+[official accompanying repository](https://github.com/cqsl/GVMC) behind
+JaQMC's unchanged `OptimizerLike` interface. JaQMC supplies the native VMC
+gradient $2\operatorname{Re}(J^\dagger B)$; the reference adapter converts it
+to the GVMC convention $\operatorname{Re}(J^\dagger B)$ before minSR and
+stores its Kaczmarz direction in that convention. This conversion intentionally
+does not change the shared gradient estimator or compensate through the learning
+rate. The configured learning rate is applied directly as $-\eta\delta$, matching
+the actual parameter update in `cqsl/GVMC`. Its source computes an auxiliary
+normalized displacement with $\eta/\sqrt M$, but does not apply that quantity
+to parameters. It is a numerical oracle, not a production backend.
+Both presets set `train.grads.clip_method: none`, matching the unclipped force
+used for the reference algorithm.
+
+For a controlled plain-SR comparison, JaQMC native SR receives the factor-two
+gradient directly, so `learning_rate_native` is approximately
+`learning_rate_gvmc / 2`. This is only an initial A/B scale convention; robust
+SR, adaptive damping, MARCH, or norm clipping need separate comparisons.
+
+The Rayleigh estimator also reports the Grassmann Hamiltonian variance without
+another Hamiltonian evaluation:
+
+$$
+\Sigma_H=\mathbb E[R_LE_L^*]-\mathbb E[R_L]\mathbb E[E_L]^*,\qquad
+\operatorname{Var}_V(H)=\frac1M\operatorname{Re}\operatorname{Tr}\Sigma_H.
+$$
+
+The appended writer fields are `grassmann_average_energy`,
+`grassmann_hamiltonian_variance`,
+`grassmann_hamiltonian_variance_matrix`, and `grassmann_hamiltonian_std`.
+Existing Rayleigh and subspace-energy fields are unchanged. In particular,
+`grassmann_hamiltonian_variance` diagnoses invariance of the entire span and is
+not interchangeable with `subspace_energy_var` or elementwise
+`local_rayleigh_variance`.
+
+## Diagnostics
+
+Monitor `grassmann_hamiltonian_variance`, `amplitude_sigma_min`, `amplitude_condition`,
+`rayleigh_solve_residual`, `max_ritz_imag`, and their warning fields.  A large
+condition number indicates nearly dependent component states, but is diagnostic
+only and does not remove a sample from the Monte Carlo measure. Every finite
+input attempts the Rayleigh solve. `rayleigh_valid` becomes false only for a
+catastrophic numerical failure such as non-finite input, solution, or residual;
+then the optimizer update is skipped before it can change parameters or
+optimizer state, and training aborts through the native checkpoint path. Normal
+gradients use every determinant sample without masked averaging. Training logs
+also include `grad_norm` and `update_norm`; an invalid gated step reports a zero
+update norm.
+
+## Hydrogen example
+
+The public example
+[`examples/atoms/hydrogen_subspace.yml`](../../examples/atoms/hydrogen_subspace.yml)
+targets the $M=5$ span containing the hydrogen 1s state and fourfold $n=2$
+manifold. Its exact sorted Ritz spectrum is
+$[-0.5,-0.125,-0.125,-0.125,-0.125]$ Ha, with Ky-Fan trace $-1.0$ Ha.
+
+Run the example through the molecule workflow:
+
+```console
+jaqmc molecule subspace-train \
+  --yml examples/atoms/hydrogen_subspace.yml
+```
+
+The same core feature is available to periodic systems through
+`jaqmc solid subspace-train`; system-specific research and hardware overlays
+are intentionally kept outside this core contribution.
+
+The current sampler is the correctness-first full-recompute implementation: one
+replica row moves per proposal while the determinant is reevaluated through the
+normal sample-plan log-probability callback.  A cached Sherman--Morrison backend
+can be added later behind the same sampler/wavefunction interfaces.

--- a/examples/atoms/hydrogen_subspace.yml
+++ b/examples/atoms/hydrogen_subspace.yml
@@ -1,0 +1,67 @@
+# Hydrogen determinant-subspace validation.
+#
+# Use:
+#   jaqmc molecule subspace-train \
+#       --yml examples/atoms/hydrogen_subspace.yml
+#
+# This example targets the five-dimensional low-energy hydrogen subspace:
+# 1s + the fourfold n=2 manifold.
+#
+# Exact Ritz spectrum:
+#   [-0.5, -0.125, -0.125, -0.125, -0.125]
+# Exact Ky-Fan trace:
+#   -1.0 Ha
+#
+# Any orthogonal basis spanning the degenerate n=2 subspace is valid; the four
+# corresponding Ritz vectors need not individually equal 2s/2px/2py/2pz.
+
+logging:
+  level: info
+  stream: stdout
+
+jax:
+  enable_x64: true
+
+workflow:
+  seed: 20260903
+  batch_size: 1024
+
+system:
+  module: atom
+  symbol: H
+  electron_init_width: 1.0
+
+wf:
+  module: ferminet
+
+subspace:
+  n_states: 5
+  initialization:
+    mode: random
+  sampling:
+    steps: 20
+    initial_width: 0.02
+    adapt_frequency: 100
+    pmove_range: [0.5, 0.55]
+  evaluation:
+    vmap_chunk_size: 64
+    pair_chunk_size: 5
+    matrix_dtype: complex128
+
+train:
+  run:
+    iterations: 40000
+    burn_in: 100
+    save_time_interval: 1800
+    save_step_interval: 500
+    timing_warmup_steps: 10
+    stop_on_nan: loss
+  optim:
+    module: jaqmc.optimizer.sr:SROptimizer
+    # JaQMC's native VMC gradient uses the factor-two convention; for a plain
+    # SR comparison, this is approximately GVMC reference learning_rate=0.10.
+    learning_rate: 0.05
+  grads:
+    module: jaqmc.estimator.streaming_loss_grad:StreamingLossAndGrad
+    vmap_chunk_size: 64
+    clip_method: none

--- a/src/jaqmc/app/cli.py
+++ b/src/jaqmc/app/cli.py
@@ -158,6 +158,14 @@ def molecule_evaluate(cfg: ConfigManager, dry_run: bool):
     MoleculeEvalWorkflow(cfg)(dry_run)
 
 
+@molecule.add_command
+@make_cli(name="subspace-train", help="Train a molecular low-energy subspace.")
+def molecule_subspace_train(cfg: ConfigManager, dry_run: bool):
+    from .molecule import MoleculeSubspaceTrainWorkflow
+
+    MoleculeSubspaceTrainWorkflow(cfg)(dry_run)
+
+
 # --- solid ---
 
 
@@ -180,6 +188,14 @@ def solid_evaluate(cfg: ConfigManager, dry_run: bool):
     from .solid import SolidEvalWorkflow
 
     SolidEvalWorkflow(cfg)(dry_run)
+
+
+@solid.add_command
+@make_cli(name="subspace-train", help="Train a solid-state low-energy subspace.")
+def solid_subspace_train(cfg: ConfigManager, dry_run: bool):
+    from .solid import SolidSubspaceTrainWorkflow
+
+    SolidSubspaceTrainWorkflow(cfg)(dry_run)
 
 
 # --- electron_gas ---

--- a/src/jaqmc/app/molecule/__init__.py
+++ b/src/jaqmc/app/molecule/__init__.py
@@ -1,6 +1,14 @@
 # Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
 # SPDX-License-Identifier: Apache-2.0
 
-from .workflow import MoleculeEvalWorkflow, MoleculeTrainWorkflow
+from .workflow import (
+    MoleculeEvalWorkflow,
+    MoleculeSubspaceTrainWorkflow,
+    MoleculeTrainWorkflow,
+)
 
-__all__ = ["MoleculeEvalWorkflow", "MoleculeTrainWorkflow"]
+__all__ = [
+    "MoleculeEvalWorkflow",
+    "MoleculeSubspaceTrainWorkflow",
+    "MoleculeTrainWorkflow",
+]

--- a/src/jaqmc/app/molecule/workflow.py
+++ b/src/jaqmc/app/molecule/workflow.py
@@ -25,6 +25,10 @@ from jaqmc.wavefunction import Wavefunction
 from jaqmc.workflow.evaluation import EvaluationWorkflow
 from jaqmc.workflow.stage.evaluation import EvaluationWorkStage
 from jaqmc.workflow.stage.vmc import VMCWorkStage
+from jaqmc.workflow.subspace_vmc import (
+    SubspaceVMCWorkflow,
+    energy_estimators_only,
+)
 from jaqmc.workflow.vmc import VMCWorkflow
 
 from .config import MoleculeConfig, MoleculePretrainReferenceConfig
@@ -117,6 +121,23 @@ class MoleculeEvalWorkflow(EvaluationWorkflow):
         evaluation.configure_estimators(**eval_estimators)
 
         self.evaluation_stage = evaluation.build()
+
+
+class MoleculeSubspaceTrainWorkflow(SubspaceVMCWorkflow):
+    """Jointly optimize a low-energy molecular variational subspace."""
+
+    def __init__(self, cfg: ConfigManager) -> None:
+        super().__init__(cfg)
+        system_config, wf = configure_system(cfg)
+        physical_data_init = partial(data_init, system_config)
+        physical_estimators = make_estimators(
+            cfg, wf, system_config, always_enable_energy=True
+        )
+        self.configure_subspace(
+            base_wavefunction=wf,
+            physical_data_init=physical_data_init,
+            physical_energy_estimators=energy_estimators_only(physical_estimators),
+        )
 
 
 def configure_system(

--- a/src/jaqmc/app/solid/__init__.py
+++ b/src/jaqmc/app/solid/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
 # SPDX-License-Identifier: Apache-2.0
 
-from .workflow import SolidEvalWorkflow, SolidTrainWorkflow
+from .workflow import SolidEvalWorkflow, SolidSubspaceTrainWorkflow, SolidTrainWorkflow
 
-__all__ = ["SolidEvalWorkflow", "SolidTrainWorkflow"]
+__all__ = ["SolidEvalWorkflow", "SolidSubspaceTrainWorkflow", "SolidTrainWorkflow"]

--- a/src/jaqmc/app/solid/workflow.py
+++ b/src/jaqmc/app/solid/workflow.py
@@ -28,6 +28,10 @@ from jaqmc.wavefunction import Wavefunction
 from jaqmc.workflow.evaluation import EvaluationWorkflow
 from jaqmc.workflow.stage.evaluation import EvaluationWorkStage
 from jaqmc.workflow.stage.vmc import VMCWorkStage
+from jaqmc.workflow.subspace_vmc import (
+    SubspaceVMCWorkflow,
+    energy_estimators_only,
+)
 from jaqmc.workflow.vmc import VMCWorkflow
 
 from .config import SolidConfig, SolidPretrainReferenceConfig
@@ -146,6 +150,30 @@ class SolidEvalWorkflow(EvaluationWorkflow):
                 for kpt, alpha, beta in self.scf.get_kpoint_occupancies()
             ),
         )
+        super().run()
+
+
+class SolidSubspaceTrainWorkflow(SubspaceVMCWorkflow):
+    """Jointly optimize a low-energy periodic-solid variational subspace."""
+
+    def __init__(self, cfg: ConfigManager) -> None:
+        super().__init__(cfg)
+        system_config, wf, sampling_proposal = configure_system(cfg)
+        reference_config = cfg.get("reference", SolidPretrainReferenceConfig)
+        self.scf = make_scf(reference_config, system_config)
+        physical_estimators = make_estimators(
+            cfg, wf, system_config, always_enable_energy=True
+        )
+        self.configure_subspace(
+            base_wavefunction=wf,
+            physical_data_init=partial(data_init, system_config),
+            physical_energy_estimators=energy_estimators_only(physical_estimators),
+            physical_proposal=sampling_proposal,
+        )
+
+    def run(self) -> None:
+        self.scf.run()
+        self.base_wavefunction.klist = self.scf.get_orbital_kpoints()
         super().run()
 
 

--- a/src/jaqmc/estimator/__init__.py
+++ b/src/jaqmc/estimator/__init__.py
@@ -9,12 +9,26 @@ from .base import (
     FunctionEstimator,
     PerWalkerEstimator,
 )
+from .loss_grad import LossAndGrad
+from .rayleigh import (
+    CrossLocalEnergyEvaluator,
+    PhysicalEnergyPlan,
+    RayleighMatrixEstimator,
+    grassmann_hamiltonian_statistics,
+)
+from .streaming_loss_grad import StreamingLossAndGrad
 
 __all__ = [
+    "CrossLocalEnergyEvaluator",
     "EstimateFn",
     "Estimator",
     "EstimatorLike",
     "EstimatorPipeline",
     "FunctionEstimator",
+    "LossAndGrad",
     "PerWalkerEstimator",
+    "PhysicalEnergyPlan",
+    "RayleighMatrixEstimator",
+    "StreamingLossAndGrad",
+    "grassmann_hamiltonian_statistics",
 ]

--- a/src/jaqmc/estimator/_loss_grad.py
+++ b/src/jaqmc/estimator/_loss_grad.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared mathematical helpers for VMC loss-gradient estimators."""
+
+import jax
+import optax
+from jax import numpy as jnp
+
+from jaqmc.array_types import Params
+
+
+def vmc_energy_gradient(
+    mean_grad_logpsi: Params,
+    mean_grad_logpsi_loss: Params,
+    mean_clipped_loss: jax.Array,
+) -> Params:
+    r"""Return the real VMC energy gradient from sufficient statistics.
+
+    This helper is shared by the materialized and streaming estimators so
+    complex conjugation, real projection, scaling, and dtype preservation
+    cannot drift between the two implementations.
+    """
+    grads = optax.tree.add(
+        mean_grad_logpsi_loss,
+        optax.tree.real(
+            optax.tree.scale(
+                -mean_clipped_loss,
+                jax.tree.map(jnp.conj, mean_grad_logpsi),
+            )
+        ),
+    )
+    grads = jax.tree.map(
+        lambda grad, log_grad: grad.astype(jnp.real(log_grad).dtype),
+        grads,
+        mean_grad_logpsi,
+    )
+    return optax.tree.scale(2, grads)

--- a/src/jaqmc/estimator/loss_grad.py
+++ b/src/jaqmc/estimator/loss_grad.py
@@ -6,11 +6,11 @@ from functools import partial
 from typing import Any, Literal
 
 import jax
-import optax
 from jax import numpy as jnp
 
 from jaqmc.array_types import Params, PRNGKey
 from jaqmc.data import Data
+from jaqmc.estimator._loss_grad import vmc_energy_gradient
 from jaqmc.estimator.base import PerWalkerEstimator, mean_reduce
 from jaqmc.utils import parallel_jax
 from jaqmc.utils.array import match_first_axis_of
@@ -65,6 +65,7 @@ class LossAndGrad(PerWalkerEstimator):
     loss_key: str = "total_energy"
     clip_method: Literal["iqr", "mad", "none"] = "mad"
     clip_scale: float = 5.0
+    validity_key: str | None = None
     f_log_psi: NumericWavefunctionEvaluate = runtime_dep()
 
     def evaluate_single_walker(
@@ -87,27 +88,38 @@ class LossAndGrad(PerWalkerEstimator):
                 f"{prev_walker_stats[self.loss_key].shape}."
             )
         # We copy over loss stats because we need to do customized reduce
-        return {
+        result = {
             "logpsi": primals,
             "grad_logpsi": grads,
             "loss": prev_walker_stats[self.loss_key],
-        }, state
+        }
+        if self.validity_key is not None:
+            result["loss_valid"] = prev_walker_stats[self.validity_key]
+        return result, state
 
     def reduce(self, walker_stats: Mapping[str, Any]) -> dict[str, Any]:
-        clipped_loss = clip_observable(
-            walker_stats["loss"], self.clip_method, scale=self.clip_scale
-        )
+        loss = walker_stats["loss"]
+        grad_logpsi = walker_stats["grad_logpsi"]
+        if self.validity_key is not None:
+            valid = walker_stats["loss_valid"]
+            loss = jnp.where(valid, loss, jnp.nan)
+            grad_logpsi = jax.tree.map(
+                lambda x: jnp.where(match_first_axis_of(valid, x), x, jnp.nan),
+                grad_logpsi,
+            )
+        clipped_loss = clip_observable(loss, self.clip_method, scale=self.clip_scale)
         grad_logpsi_and_loss = jax.tree.map(
             lambda x: jnp.real(jnp.conj(x) * match_first_axis_of(clipped_loss, x)),
-            walker_stats["grad_logpsi"],
+            grad_logpsi,
         )
         return mean_reduce(
             {
                 "grad_logpsi_and_loss": grad_logpsi_and_loss,
-                "loss": walker_stats["loss"],
+                "loss": loss,
                 "clipped_loss": clipped_loss,
-                "grad_logpsi": walker_stats["grad_logpsi"],
-            }
+                "grad_logpsi": grad_logpsi,
+            },
+            include_variance=False,
         )
 
     def finalize_stats(
@@ -121,8 +133,9 @@ class LossAndGrad(PerWalkerEstimator):
         grad_logpsi = jax.tree.map(batch_mean, batch_stats["grad_logpsi"])
         clipped_loss = batch_mean(batch_stats["clipped_loss"])
         loss = batch_mean(batch_stats["loss"])
-        grads = optax.tree.add(
-            grad_logpsi_and_loss,
-            optax.tree.real(optax.tree.scale(-clipped_loss, grad_logpsi)),
-        )
-        return {"loss": loss, "grads": optax.tree.scale(2, grads)}
+        return {
+            "loss": loss,
+            "grads": vmc_energy_gradient(
+                grad_logpsi, grad_logpsi_and_loss, clipped_loss
+            ),
+        }

--- a/src/jaqmc/estimator/rayleigh.py
+++ b/src/jaqmc/estimator/rayleigh.py
@@ -1,0 +1,356 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rayleigh-matrix estimators built from JaQMC physical-energy components."""
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import jax
+from jax import numpy as jnp
+
+from jaqmc.array_types import Params, PRNGKey
+from jaqmc.data import Data
+from jaqmc.estimator.base import Estimator, PerWalkerEstimator
+from jaqmc.utils import parallel_jax
+from jaqmc.utils.chunked_vmap import chunked_vmap
+from jaqmc.utils.config import configurable_dataclass
+from jaqmc.utils.subspace_linalg import (
+    rayleigh_solve,
+    row_scaled_matrix,
+    singular_value_diagnostics,
+    solve_residual,
+)
+from jaqmc.utils.wiring import runtime_dep
+from jaqmc.wavefunction.determinant_state import (
+    SubspaceSpec,
+    take_replica,
+    take_replica_dynamic,
+)
+
+
+def grassmann_hamiltonian_statistics(
+    local_rayleigh: jax.Array,
+    *,
+    mean_fn: Callable[[jax.Array], jax.Array] | None = None,
+) -> dict[str, jax.Array]:
+    r"""Compute Grassmann Hamiltonian-variance statistics.
+
+    This is the estimator used by Grassmann VMC to diagnose whether the
+    variational span is invariant under the Hamiltonian.  ``mean_fn`` consumes
+    the leading walker axis; callers may supply a distributed global mean.
+
+    Args:
+        local_rayleigh: Local Rayleigh matrices with shape ``[B, M, M]``.
+        mean_fn: Optional leading-axis mean implementation.
+
+    Returns:
+        The average energy, variance matrix, scalar variance, and standard
+        deviation.  The scalar variance is not clipped; only the square root
+        clips small negative Monte Carlo roundoff.
+
+    Raises:
+        ValueError: If the input does not contain square per-walker matrices.
+    """
+    if local_rayleigh.ndim != 3:
+        raise ValueError(
+            "local_rayleigh must have shape [walkers, states, states]; "
+            f"got {local_rayleigh.shape}."
+        )
+    if local_rayleigh.shape[-2] != local_rayleigh.shape[-1]:
+        raise ValueError("local_rayleigh matrices must be square.")
+    mean = mean_fn or (lambda value: jnp.mean(value, axis=0))
+    local_trace = jnp.trace(local_rayleigh, axis1=-2, axis2=-1)
+    rayleigh_mean = mean(local_rayleigh)
+    trace_mean = mean(local_trace)
+    rayleigh_trace_mean = mean(local_rayleigh * jnp.conj(local_trace)[..., None, None])
+    variance_matrix = rayleigh_trace_mean - rayleigh_mean * jnp.conj(trace_mean)
+    n_states = local_rayleigh.shape[-1]
+    variance = jnp.real(jnp.trace(variance_matrix)) / n_states
+    return {
+        "grassmann_average_energy": jnp.trace(rayleigh_mean) / n_states,
+        "grassmann_hamiltonian_variance_matrix": variance_matrix,
+        "grassmann_hamiltonian_variance": variance,
+        "grassmann_hamiltonian_std": jnp.sqrt(jnp.maximum(variance, 0)),
+    }
+
+
+@dataclass(frozen=True)
+class PhysicalEnergyPlan:
+    """Classify native estimators by their replica/state dependence."""
+
+    replica_only: tuple[str, ...] = ("potential",)
+
+    def split(self, estimators: Mapping[str, Any]):
+        replica_only = tuple(name for name in estimators if name in self.replica_only)
+        pair_dependent = tuple(name for name in estimators if name not in replica_only)
+        return replica_only, pair_dependent
+
+
+class CrossLocalEnergyEvaluator:
+    """Apply an existing JaQMC physical-energy pipeline to all ``(r, s)`` pairs."""
+
+    def __init__(
+        self,
+        estimators: Mapping[str, Estimator | Any],
+        spec: SubspaceSpec,
+        *,
+        pair_chunk_size: int | None = None,
+        plan: PhysicalEnergyPlan | None = None,
+    ):
+        self.estimators = dict(estimators)
+        self.spec = spec
+        self.pair_chunk_size = pair_chunk_size
+        self.plan = plan or PhysicalEnergyPlan()
+        self.replica_only, self.pair_dependent = self.plan.split(self.estimators)
+        self._states: dict[str, Any] = {}
+
+    def init(self, replica_data: Data, rngs: PRNGKey) -> None:
+        """Initialize reused physical estimators from one physical replica.
+
+        Raises:
+            ValueError: If a physical estimator returns mutable state.
+        """
+        physical_data = take_replica(replica_data, 0, self.spec)
+        keys = jax.random.split(rngs, len(self.estimators))
+        self._states = {
+            name: estimator.init(physical_data, key)
+            if isinstance(estimator, Estimator)
+            else None
+            for (name, estimator), key in zip(self.estimators.items(), keys)
+        }
+        stateful = [name for name, state in self._states.items() if state is not None]
+        if stateful:
+            raise ValueError(
+                "CrossLocalEnergyEvaluator currently requires stateless physical "
+                f"estimators; got state from {stateful}"
+            )
+
+    def _run_names(
+        self,
+        names: tuple[str, ...],
+        params: Params,
+        data: Data,
+        stats: dict[str, Any],
+        rngs: PRNGKey,
+    ) -> dict[str, Any]:
+        keys = jax.random.split(rngs, len(self.estimators))
+        for (name, estimator), key in zip(self.estimators.items(), keys):
+            if name not in names:
+                continue
+            if isinstance(estimator, PerWalkerEstimator):
+                part, _ = estimator.evaluate_single_walker(
+                    params, data, stats, self._states.get(name), key
+                )
+            elif isinstance(estimator, Estimator):
+                raise TypeError(
+                    "CrossLocalEnergyEvaluator requires per-walker estimators; "
+                    f"{name!r} owns a batched evaluation path."
+                )
+            else:
+                part, _ = estimator(params, data, stats, self._states.get(name), key)
+            stats.update(part)
+        return stats
+
+    def _replica_stats(
+        self,
+        stacked_params: Params,
+        replica_data: Data,
+        replica_index: jax.Array,
+        rngs: PRNGKey,
+    ) -> dict[str, Any]:
+        params = jax.tree.map(
+            lambda x: jax.lax.dynamic_index_in_dim(x, 0, axis=0, keepdims=False),
+            stacked_params,
+        )
+        data = take_replica_dynamic(replica_data, replica_index, self.spec)
+        return self._run_names(self.replica_only, params, data, {}, rngs)
+
+    def _pair_local_energy(
+        self,
+        stacked_params: Params,
+        replica_data: Data,
+        replica_stats: Mapping[str, Any],
+        pair_index: jax.Array,
+        rngs: PRNGKey,
+    ) -> jax.Array:
+        m = self.spec.n_states
+        replica_index, state_index = pair_index // m, pair_index % m
+        params = jax.tree.map(
+            lambda x: jax.lax.dynamic_index_in_dim(
+                x, state_index, axis=0, keepdims=False
+            ),
+            stacked_params,
+        )
+        data = take_replica_dynamic(replica_data, replica_index, self.spec)
+        stats = jax.tree.map(
+            lambda x: jax.lax.dynamic_index_in_dim(
+                x, replica_index, axis=0, keepdims=False
+            ),
+            dict(replica_stats),
+        )
+        stats = self._run_names(self.pair_dependent, params, data, stats, rngs)
+        if "total_energy" in stats:
+            return stats["total_energy"]
+        components = [
+            value for key, value in stats.items() if key.startswith("energy:")
+        ]
+        if not components:
+            raise ValueError("Physical estimator pipeline produced no energy values")
+        return sum(components[1:], start=components[0])
+
+    def __call__(
+        self, stacked_params: Params, replica_data: Data, rngs: PRNGKey
+    ) -> jax.Array:
+        """Return ``E_local[r, s]`` using flattened, optionally chunked pairs."""
+        m = self.spec.n_states
+        replica_rngs, pair_rngs = jax.random.split(rngs)
+        replica_stats = jax.vmap(self._replica_stats, in_axes=(None, None, 0, 0))(
+            stacked_params,
+            replica_data,
+            jnp.arange(m),
+            jax.random.split(replica_rngs, m),
+        )
+        pair_indices = jnp.arange(m * m)
+        keys = jax.random.split(pair_rngs, m * m)
+        values = chunked_vmap(
+            self._pair_local_energy,
+            in_axes=(None, None, None, 0, 0),
+            chunk_size=self.pair_chunk_size,
+        )(stacked_params, replica_data, replica_stats, pair_indices, keys)
+        return values.reshape(m, m)
+
+
+@configurable_dataclass
+class RayleighMatrixEstimator(PerWalkerEstimator):
+    """Estimate the determinant-state local Rayleigh matrix per walker."""
+
+    matrix_dtype: str = "complex128"
+    pair_chunk_size: int | None = None
+    condition_warning: float = 1e10
+    solve_residual_warning: float = 1e-6
+    max_imag_eigenvalue_warning: float = 1e-6
+    f_component_logpsi_matrix: Any = runtime_dep()
+    f_cross_local_energy: Any = runtime_dep()
+
+    def init(self, data: Data, rngs: PRNGKey) -> None:
+        if hasattr(self.f_cross_local_energy, "init"):
+            self.f_cross_local_energy.init(data, rngs)
+        return None
+
+    def evaluate_single_walker(
+        self,
+        params: Params,
+        data: Data,
+        prev_walker_stats: Mapping[str, Any],
+        state: None,
+        rngs: PRNGKey,
+    ) -> tuple[dict[str, Any], None]:
+        del prev_walker_stats
+        logs = self.f_component_logpsi_matrix(params, data)
+        phi, _ = row_scaled_matrix(logs)
+        dtype = jnp.dtype(self.matrix_dtype)
+        phi = phi.astype(dtype)
+        local_energy = self.f_cross_local_energy(params, data, rngs).astype(dtype)
+        phi_h = phi * local_energy
+        phi_finite = jnp.all(jnp.isfinite(phi))
+        # Derive the sentinel from ``phi`` so it inherits the same varying-axis
+        # annotation inside shard_map as the SVD branch outputs.
+        nan_real = jnp.real(phi[0, 0]) * 0 + jnp.nan
+        sigma_min, sigma_max, condition = jax.lax.cond(
+            phi_finite,
+            lambda _: singular_value_diagnostics(phi),
+            lambda _: (nan_real, nan_real, nan_real),
+            operand=None,
+        )
+        matrix_finite = jnp.all(jnp.isfinite(phi)) & jnp.all(jnp.isfinite(phi_h))
+        rayleigh = jax.lax.cond(
+            matrix_finite,
+            lambda _: rayleigh_solve(phi, phi_h),
+            lambda _: jnp.full_like(phi_h, jnp.nan),
+            operand=None,
+        )
+        residual = solve_residual(phi, rayleigh, phi_h)
+        rayleigh_valid = (
+            matrix_finite & jnp.all(jnp.isfinite(rayleigh)) & jnp.isfinite(residual)
+        )
+        trace = jnp.trace(rayleigh)
+        return {
+            "local_rayleigh": rayleigh,
+            "subspace_local_energy": trace,
+            "subspace_energy": jnp.real(trace),
+            "subspace_energy_imag": jnp.imag(trace),
+            "rayleigh_solve_residual": residual,
+            "rayleigh_solve_residual_warning": (
+                ~jnp.isfinite(residual) | (residual > self.solve_residual_warning)
+            ),
+            "amplitude_sigma_min": sigma_min,
+            "amplitude_sigma_max": sigma_max,
+            "amplitude_condition": condition,
+            "amplitude_condition_warning": (
+                ~jnp.isfinite(condition) | (condition > self.condition_warning)
+            ),
+            "rayleigh_finite": rayleigh_valid,
+            "rayleigh_valid": rayleigh_valid,
+        }, state
+
+    def reduce(self, walker_stats: Mapping[str, Any]) -> dict[str, Any]:
+        local_rayleigh = walker_stats["local_rayleigh"]
+        valid = walker_stats["rayleigh_valid"] & jnp.all(
+            jnp.isfinite(local_rayleigh), axis=(-2, -1)
+        )
+        local_count = jnp.sum(valid)
+        global_count = parallel_jax.psum(local_count)
+        global_total = parallel_jax.psum(jnp.asarray(valid.shape[0]))
+        rayleigh_mean = (
+            parallel_jax.psum(jnp.sum(local_rayleigh, axis=0)) / global_total
+        )
+        second_moment = (
+            parallel_jax.psum(jnp.sum(jnp.abs(local_rayleigh) ** 2, axis=0))
+            / global_total
+        )
+        rayleigh_var = jnp.maximum(second_moment - jnp.abs(rayleigh_mean) ** 2, 0)
+        valid_fraction = global_count / global_total
+        invalid_count = global_total - global_count
+
+        reduced = {}
+        for key, value in walker_stats.items():
+            if key == "local_rayleigh":
+                continue
+            reduced[key] = parallel_jax.psum(jnp.sum(value, axis=0)) / global_total
+        subspace_energy = walker_stats["subspace_energy"]
+        energy_second_moment = (
+            parallel_jax.psum(jnp.sum(subspace_energy**2, axis=0)) / global_total
+        )
+        reduced["subspace_energy_var"] = jnp.maximum(
+            energy_second_moment - reduced["subspace_energy"] ** 2, 0
+        )
+
+        def global_mean(value):
+            return parallel_jax.psum(jnp.sum(value, axis=0)) / global_total
+
+        grassmann_stats = grassmann_hamiltonian_statistics(
+            local_rayleigh, mean_fn=global_mean
+        )
+        step_valid = global_count == global_total
+        eig_input = jnp.where(step_valid, rayleigh_mean, jnp.zeros_like(rayleigh_mean))
+        eigenvalues, eigenvectors = jnp.linalg.eig(eig_input)
+        order = jnp.argsort(jnp.real(eigenvalues))
+        eigenvalues = eigenvalues[order]
+        eigenvectors = eigenvectors[:, order]
+        max_ritz_imag = jnp.max(jnp.abs(jnp.imag(eigenvalues)))
+        return {
+            **reduced,
+            **grassmann_stats,
+            "rayleigh_mean": rayleigh_mean,
+            "local_rayleigh_variance": rayleigh_var,
+            "rayleigh_valid_fraction": valid_fraction,
+            "rayleigh_invalid_count": invalid_count,
+            "training_step_valid": step_valid,
+            "ritz_energies": jnp.real(eigenvalues),
+            "ritz_energies_imag": jnp.imag(eigenvalues),
+            "ritz_vectors": eigenvectors,
+            "max_ritz_imag": max_ritz_imag,
+            "max_ritz_imag_warning": (max_ritz_imag > self.max_imag_eigenvalue_warning),
+        }

--- a/src/jaqmc/estimator/streaming_loss_grad.py
+++ b/src/jaqmc/estimator/streaming_loss_grad.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Memory-conservative VMC loss-gradient estimator."""
+
+import dataclasses
+from collections.abc import Mapping
+from functools import partial
+from typing import Any, Literal
+
+import jax
+from jax import numpy as jnp
+
+from jaqmc.array_types import Params, PRNGKey
+from jaqmc.data import BatchedData
+from jaqmc.estimator._loss_grad import vmc_energy_gradient
+from jaqmc.estimator.base import Estimator
+from jaqmc.utils import parallel_jax
+from jaqmc.utils.array import match_first_axis_of
+from jaqmc.utils.clip import clip_observable
+from jaqmc.utils.config import configurable_dataclass
+from jaqmc.utils.func_transform import transform_maybe_complex
+from jaqmc.utils.wiring import runtime_dep
+from jaqmc.wavefunction.base import NumericWavefunctionEvaluate
+
+
+@configurable_dataclass
+class StreamingLossAndGrad(Estimator):
+    """Compute VMC gradients with chunk-local sufficient-statistic reduction.
+
+    Unlike :class:`~jaqmc.estimator.loss_grad.LossAndGrad`, this estimator
+    never materializes a ``[walkers, ...parameters]`` gradient tree. Each
+    chunk's per-walker gradients are reduced immediately inside ``lax.scan``.
+
+    The estimator is wavefunction- and objective-agnostic: ``loss_key`` may
+    name any scalar per-walker objective, including ordinary ground-state VMC.
+    """
+
+    loss_key: str = "total_energy"
+    vmap_chunk_size: int | None = None
+    clip_method: Literal["iqr", "mad", "none"] = "mad"
+    clip_scale: float = 5.0
+    f_log_psi: NumericWavefunctionEvaluate = runtime_dep()
+
+    def evaluate_batch_walkers(
+        self,
+        params: Params,
+        batched_data: BatchedData,
+        prev_walker_stats: Mapping[str, Any],
+        state: None,
+        rngs: PRNGKey,
+    ) -> tuple[dict[str, Any], None]:
+        del rngs
+        loss = prev_walker_stats[self.loss_key]
+        if loss.ndim != 1:
+            raise ValueError(
+                f"Expected one scalar loss per walker, got shape {loss.shape}."
+            )
+        batch_size = batched_data.batch_size
+        if batch_size < 1:
+            raise ValueError("StreamingLossAndGrad requires a non-empty batch.")
+        chunk_size = self.vmap_chunk_size or batch_size
+        if chunk_size < 1:
+            raise ValueError("vmap_chunk_size must be positive or None.")
+        chunk_size = min(chunk_size, batch_size)
+        n_chunks = (batch_size + chunk_size - 1) // chunk_size
+        padded_size = n_chunks * chunk_size
+        pad_size = padded_size - batch_size
+
+        clipped_loss = clip_observable(loss, self.clip_method, scale=self.clip_scale)
+
+        def pad_leaf(x):
+            if pad_size == 0:
+                return x
+            pad_width = ((0, pad_size),) + ((0, 0),) * (x.ndim - 1)
+            return jnp.pad(x, pad_width, mode="edge")
+
+        padded_data = dataclasses.replace(
+            batched_data.data,
+            **{
+                name: jax.tree.map(pad_leaf, batched_data.data[name])
+                for name in batched_data.fields_with_batch
+            },
+        )
+        padded_loss = pad_leaf(clipped_loss)
+        padded_mask = jnp.arange(padded_size) < batch_size
+
+        value_and_grad_f = transform_maybe_complex(self.f_log_psi, jax.value_and_grad)
+        grad_shape = jax.eval_shape(
+            lambda p, d: value_and_grad_f(p, d)[1],
+            params,
+            batched_data.unbatched_example(),
+        )
+        sum_grad = jax.tree.map(lambda x: jnp.zeros(x.shape, x.dtype), grad_shape)
+        sum_grad_loss = jax.tree.map(
+            lambda x: jnp.zeros(x.shape, jnp.real(jnp.zeros((), x.dtype)).dtype),
+            grad_shape,
+        )
+        # Chunk sums vary across data shards even though parameters are shared.
+        # Mark the scan carry accordingly so shard_map VMA stays stable.
+        sum_grad = parallel_jax.pvary(sum_grad)
+        sum_grad_loss = parallel_jax.pvary(sum_grad_loss)
+        vmap_axis = batched_data.vmap_axis
+        vmapped_grad = jax.vmap(value_and_grad_f, in_axes=(None, vmap_axis))
+
+        def scan_body(carry, chunk_index):
+            start = chunk_index * chunk_size
+            chunk_data = dataclasses.replace(
+                padded_data,
+                **{
+                    name: jax.tree.map(
+                        lambda x: jax.lax.dynamic_slice_in_dim(
+                            x, start, chunk_size, axis=0
+                        ),
+                        padded_data[name],
+                    )
+                    for name in batched_data.fields_with_batch
+                },
+            )
+            loss_chunk = jax.lax.dynamic_slice_in_dim(
+                padded_loss, start, chunk_size, axis=0
+            )
+            mask_chunk = jax.lax.dynamic_slice_in_dim(
+                padded_mask, start, chunk_size, axis=0
+            )
+            _, grads = vmapped_grad(parallel_jax.pvary(params), chunk_data)
+            grads = jax.tree.map(
+                lambda x: jnp.where(match_first_axis_of(mask_chunk, x), x, 0),
+                grads,
+            )
+            grad_loss = jax.tree.map(
+                lambda x: jnp.real(
+                    jnp.conj(x) * match_first_axis_of(loss_chunk, x)
+                ).astype(jnp.real(x).dtype),
+                grads,
+            )
+            chunk_sum_grad = jax.tree.map(lambda x: jnp.sum(x, axis=0), grads)
+            chunk_sum_grad_loss = jax.tree.map(lambda x: jnp.sum(x, axis=0), grad_loss)
+            return (
+                jax.tree.map(jnp.add, carry[0], chunk_sum_grad),
+                jax.tree.map(jnp.add, carry[1], chunk_sum_grad_loss),
+            ), None
+
+        (sum_grad, sum_grad_loss), _ = jax.lax.scan(
+            scan_body, (sum_grad, sum_grad_loss), jnp.arange(n_chunks)
+        )
+        return {
+            "sum_grad_logpsi": sum_grad,
+            "sum_grad_logpsi_and_loss": sum_grad_loss,
+            "sum_loss": jnp.sum(loss),
+            "sum_clipped_loss": jnp.sum(clipped_loss),
+            "count": jnp.asarray(batch_size),
+        }, state
+
+    def reduce(self, stats: Mapping[str, Any]) -> dict[str, Any]:
+        """Reduce local sums using global sum/count collectives.
+
+        Returns:
+            Globally normalized gradient and loss sufficient statistics.
+        """
+        count = parallel_jax.psum(stats["count"])
+        return {
+            "grad_logpsi": jax.tree.map(
+                lambda x: parallel_jax.psum(x) / count,
+                stats["sum_grad_logpsi"],
+            ),
+            "grad_logpsi_and_loss": jax.tree.map(
+                lambda x: parallel_jax.psum(x) / count,
+                stats["sum_grad_logpsi_and_loss"],
+            ),
+            "loss": parallel_jax.psum(stats["sum_loss"]) / count,
+            "clipped_loss": (parallel_jax.psum(stats["sum_clipped_loss"]) / count),
+        }
+
+    def finalize_stats(
+        self, batch_stats: Mapping[str, Any], state: None
+    ) -> dict[str, Any]:
+        del state
+        batch_mean = partial(jnp.mean, axis=0)
+        grad_logpsi_and_loss = jax.tree.map(
+            batch_mean, batch_stats["grad_logpsi_and_loss"]
+        )
+        grad_logpsi = jax.tree.map(batch_mean, batch_stats["grad_logpsi"])
+        clipped_loss = batch_mean(batch_stats["clipped_loss"])
+        loss = batch_mean(batch_stats["loss"])
+        return {
+            "loss": loss,
+            "grads": vmc_energy_gradient(
+                grad_logpsi, grad_logpsi_and_loss, clipped_loss
+            ),
+        }

--- a/src/jaqmc/optimizer/gvmc_reference_sr.py
+++ b/src/jaqmc/optimizer/gvmc_reference_sr.py
@@ -1,0 +1,276 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small-system reference SR backend for determinant-state Grassmann VMC.
+
+The production Grassmann optimizer is JaQMC's existing distributed
+``SROptimizer`` applied to the determinant-state log amplitude.  This module
+implements the sample-space equations used by the accompanying GVMC research
+code as a transparent numerical oracle and A/B backend.  It deliberately does
+not replace or modify JaQMC's SR implementation.  The reference snapshot is
+``cqsl/GVMC@e68e503``; the equations are independently expressed here because
+that repository does not currently declare a software license.
+"""
+
+import math
+from typing import Any, NamedTuple
+
+import jax
+from jax import numpy as jnp
+from jax import scipy as jsp
+from jax.flatten_util import ravel_pytree
+
+from jaqmc.array_types import Params
+from jaqmc.data import BatchedData
+from jaqmc.utils.chunked_vmap import chunked_vmap
+from jaqmc.utils.config import configurable_dataclass
+from jaqmc.utils.func_transform import grad_maybe_complex
+from jaqmc.utils.wiring import runtime_dep
+from jaqmc.wavefunction.base import NumericWavefunctionEvaluate
+
+__all__ = [
+    "GVMCReferenceSROptimizer",
+    "GVMCReferenceSRState",
+    "minsr_solve",
+    "minsr_solve_gradient",
+    "minsr_solve_kacz",
+]
+
+
+def _native_vmc_to_gvmc_gradient(gradient: jax.Array) -> jax.Array:
+    r"""Convert JaQMC's energy-gradient convention to the GVMC force form.
+
+    JaQMC's VMC estimators return ``2 Re[J^H B]`` for real parameters, while
+    the GVMC minimum-SR source equation is written for ``Re[J^H B]``.  Keep
+    this convention conversion at the reference-backend adapter boundary so
+    neither the native estimator nor the generic optimizer contract changes.
+
+    Returns:
+        The gradient in the GVMC reference convention.
+    """
+    return 0.5 * gradient
+
+
+def _sample_matrix(jacobian: jax.Array, lam0: float, lam1: float) -> jax.Array:
+    """Build GVMC's matrix; ``lam1`` shifts all entries, not the diagonal.
+
+    Returns:
+        The regularized sample-space matrix.
+    """
+    n_samples = jacobian.shape[0]
+    scale = jnp.linalg.norm(jacobian) ** 2 / n_samples
+    matrix = jacobian @ jnp.conj(jacobian.T)
+    matrix = matrix + scale * (lam1 / n_samples)
+    return matrix + lam0 * jnp.eye(n_samples, dtype=matrix.dtype)
+
+
+def minsr_solve(
+    jacobian: jax.Array,
+    force: jax.Array,
+    *,
+    lam0: float = 1e-4,
+    lam1: float = 1.0,
+) -> jax.Array:
+    r"""Solve the GVMC sample-space minimum-SR equation.
+
+    Computes ``J^H A^-1 force`` with
+    ``A = J J^H + lam1 * ||J||^2 / n^2 + lam0 I``.  The ``lam1`` term is the
+    scalar all-ones shift used by the reference implementation, rather than a
+    second diagonal shift.
+
+    Returns:
+        The minimum-SR parameter direction.
+
+    Raises:
+        ValueError: If the Jacobian or force has an incompatible shape.
+    """
+    if jacobian.ndim != 2:
+        raise ValueError("jacobian must be a rank-2 matrix")
+    if force.shape != (jacobian.shape[0],):
+        raise ValueError(
+            f"force must have shape {(jacobian.shape[0],)}, got {force.shape}"
+        )
+    factor = jsp.linalg.cho_factor(_sample_matrix(jacobian, lam0, lam1))
+    return jnp.conj(jacobian.T) @ jsp.linalg.cho_solve(factor, force)
+
+
+def minsr_solve_kacz(
+    jacobian: jax.Array,
+    force: jax.Array,
+    previous_delta: jax.Array,
+    *,
+    lam0: float = 1e-4,
+    lam1: float = 1.0,
+    mu: float = 0.99,
+) -> jax.Array:
+    """Apply the GVMC Kaczmarz/SPRING continuation equation.
+
+    Returns:
+        The continued minimum-SR parameter direction.
+    """
+    residual_force = force - mu * (jacobian @ previous_delta)
+    return (
+        minsr_solve(jacobian, residual_force, lam0=lam0, lam1=lam1)
+        + mu * previous_delta
+    )
+
+
+def minsr_solve_gradient(
+    jacobian: jax.Array,
+    gradient: jax.Array,
+    *,
+    lam0: float = 1e-4,
+    lam1: float = 1.0,
+) -> jax.Array:
+    r"""Apply the same minimum-SR solve to an already reduced VMC gradient.
+
+    If ``gradient = J^H force``, the matrix inversion lemma makes this exactly
+    equivalent to :func:`minsr_solve`.  This form preserves JaQMC's native
+    ``OptimizerLike`` contract, whose optimizer receives a parameter-shaped
+    energy gradient rather than the per-walker local-energy force.
+
+    Returns:
+        The minimum-SR direction reconstructed from the reduced gradient.
+
+    Raises:
+        ValueError: If regularization is invalid or gradient shape is incompatible.
+    """
+    if lam0 <= 0:
+        raise ValueError("lam0 must be positive for the gradient-form solve")
+    if gradient.shape != (jacobian.shape[1],):
+        raise ValueError(
+            f"gradient must have shape {(jacobian.shape[1],)}, got {gradient.shape}"
+        )
+    factor = jsp.linalg.cho_factor(_sample_matrix(jacobian, lam0, lam1))
+    projected = jacobian @ gradient
+    correction = jnp.conj(jacobian.T) @ jsp.linalg.cho_solve(factor, projected)
+    return (gradient - correction) / lam0
+
+
+class GVMCReferenceSRState(NamedTuple):
+    """Optimizer state containing the step counter and previous SR direction."""
+
+    counter: jax.Array
+    previous_delta: jax.Array
+
+
+@configurable_dataclass
+class GVMCReferenceSROptimizer:
+    """Source-equation Grassmann SR backend for single-device A/B tests.
+
+    For production, use :class:`jaqmc.optimizer.sr.SROptimizer`; it evaluates
+    the same Grassmann score while adding distributed reductions, chunked Gram
+    construction, mixed precision, and robust stabilization.  The native
+    ``OptimizerLike`` gradient supplied to :meth:`update` follows JaQMC's
+    ``2 Re[J^H B]`` VMC convention.  This adapter divides it by two before
+    applying the GVMC source equation, whose reduced gradient is
+    ``Re[J^H B]``.  ``previous_delta`` is therefore stored in GVMC convention.
+
+    Args:
+        learning_rate: Constant update step used by the GVMC reference code.
+        lam0: Diagonal sample-space regularization.
+        lam1: Centered-score null-direction regularization.
+        mu: Kaczmarz/SPRING continuation coefficient.
+        score_chunk_size: Optional chunk size for score evaluation.
+        f_log_psi: Runtime-wired determinant log amplitude.
+    """
+
+    learning_rate: float = 0.1
+    lam0: float = 1e-3
+    lam1: float = 1.0
+    mu: float = 0.9
+    score_chunk_size: int | None = None
+    f_log_psi: NumericWavefunctionEvaluate = runtime_dep()
+
+    def __post_init__(self):
+        if self.learning_rate <= 0:
+            raise ValueError("learning_rate must be positive")
+        if self.lam0 <= 0:
+            raise ValueError("lam0 must be positive")
+        if self.lam1 < 0:
+            raise ValueError("lam1 must be non-negative")
+        if not 0 <= self.mu < 1:
+            raise ValueError("mu must satisfy 0 <= mu < 1")
+        if self.score_chunk_size is not None and self.score_chunk_size < 1:
+            raise ValueError("score_chunk_size must be positive or None")
+
+    def init(
+        self,
+        params: Params,
+        *,
+        batched_data: BatchedData,
+        **extra: Any,
+    ) -> GVMCReferenceSRState:
+        """Initialize the previous-direction state.
+
+        Returns:
+            A zero-initialized reference optimizer state.
+
+        Raises:
+            NotImplementedError: If multiple devices or complex parameters are used.
+        """
+        del batched_data, extra
+        if jax.device_count() != 1:
+            raise NotImplementedError(
+                "GVMCReferenceSROptimizer is a single-device numerical oracle; "
+                "use jaqmc.optimizer.sr:SROptimizer for multi-device runs."
+            )
+        flat, _ = ravel_pytree(params)
+        if jnp.iscomplexobj(flat):
+            raise NotImplementedError(
+                "GVMCReferenceSROptimizer currently requires real parameters."
+            )
+        return GVMCReferenceSRState(
+            counter=jnp.asarray(0, dtype=jnp.int32),
+            previous_delta=jnp.zeros_like(flat),
+        )
+
+    def _score_matrix(self, params: Params, batched_data: BatchedData) -> jax.Array:
+        score_fn = grad_maybe_complex(self.f_log_psi)
+        score_tree = chunked_vmap(
+            lambda sample: score_fn(params, sample),
+            in_axes=(batched_data.vmap_axis,),
+            out_axes=0,
+            chunk_size=self.score_chunk_size,
+        )(batched_data.data)
+        score = jax.vmap(lambda tree: ravel_pytree(tree)[0])(score_tree)
+        score = (score - jnp.mean(score, axis=0, keepdims=True)) / math.sqrt(
+            batched_data.batch_size
+        )
+        if jnp.iscomplexobj(score):
+            score = jnp.concatenate((jnp.real(score), jnp.imag(score)), axis=0)
+        return score
+
+    def update(
+        self,
+        grads: Params,
+        state: GVMCReferenceSRState,
+        params: Params,
+        *,
+        batched_data: BatchedData,
+        **extra: Any,
+    ) -> tuple[Params, GVMCReferenceSRState]:
+        """Return a reference Grassmann-SR parameter update."""
+        del extra
+        native_gradient, unravel = ravel_pytree(grads)
+        gradient = _native_vmc_to_gvmc_gradient(native_gradient)
+        score = self._score_matrix(params, batched_data)
+        metric_previous = score @ state.previous_delta
+        residual_gradient = gradient - self.mu * (jnp.conj(score.T) @ metric_previous)
+        delta = (
+            minsr_solve_gradient(
+                score,
+                residual_gradient,
+                lam0=self.lam0,
+                lam1=self.lam1,
+            )
+            + self.mu * state.previous_delta
+        )
+        # Match cqsl/GVMC's actual parameter update.  Its lr / sqrt(M)
+        # quantity is used only for an auxiliary displacement diagnostic and
+        # is not applied to params.
+        updates = unravel(-self.learning_rate * delta)
+        return updates, GVMCReferenceSRState(
+            counter=state.counter + 1,
+            previous_delta=delta,
+        )

--- a/src/jaqmc/optimizer/sr/sr.py
+++ b/src/jaqmc/optimizer/sr/sr.py
@@ -71,7 +71,7 @@ class SROptimizer:
     learning_rate: Any = module_config(Standard, direct_value_type=float)
     max_norm: Any = module_config(
         "fixed",
-        direct_value_type=float | Literal["fixed"],
+        direct_value_type=float | Literal["fixed"] | None,
         module_import_base="jaqmc.optimizer",
     )
     damping: Any = module_config(
@@ -80,14 +80,18 @@ class SROptimizer:
     max_cond_num: float | None = 1e7
     robust_gamma: Any = module_config(
         "sqrt",
-        direct_value_type=float | Literal["sqrt"],
+        direct_value_type=float | Literal["sqrt"] | None,
         module_import_base="jaqmc.optimizer",
     )
     spring_mu: Any = module_config(
-        0.9, direct_value_type=float, module_import_base="jaqmc.optimizer"
+        0.9,
+        direct_value_type=float | None,
+        module_import_base="jaqmc.optimizer",
     )
     march_beta: Any = module_config(
-        0.995, direct_value_type=float, module_import_base="jaqmc.optimizer"
+        0.995,
+        direct_value_type=float | None,
+        module_import_base="jaqmc.optimizer",
     )
     march_mode: Literal["var", "diff"] = "var"
     eps: float = 1e-8

--- a/src/jaqmc/sampler/__init__.py
+++ b/src/jaqmc/sampler/__init__.py
@@ -17,5 +17,12 @@ the chaining logics are handled in `DataGenerator`s instead of the samplers them
 """
 
 from .base import SamplePlan, SamplerInit, SamplerLike, SamplerStep
+from .determinant import DeterminantMCMCSampler
 
-__all__ = ["SamplePlan", "SamplerInit", "SamplerLike", "SamplerStep"]
+__all__ = [
+    "DeterminantMCMCSampler",
+    "SamplePlan",
+    "SamplerInit",
+    "SamplerLike",
+    "SamplerStep",
+]

--- a/src/jaqmc/sampler/determinant.py
+++ b/src/jaqmc/sampler/determinant.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Replica-row Metropolis sampler for determinant-state wavefunctions."""
+
+from typing import Literal
+
+import jax
+
+from jaqmc.utils.config import configurable_dataclass
+
+from .mcmc import MCMCSampler
+
+
+@configurable_dataclass
+class DeterminantMCMCSampler(MCMCSampler):
+    """Reuse JaQMC MH adaptation while moving one physical replica per proposal.
+
+    The initial implementation deliberately uses a full determinant recomputation
+    for proposal scoring. It keeps the sampler contract identical to
+    :class:`MCMCSampler`; a cached rank-one backend can be added without changing
+    workflow or wavefunction interfaces.
+    """
+
+    n_states: int = 1
+    update_mode: Literal["full"] = "full"
+
+    def __post_init__(self):
+        if self.n_states < 1:
+            raise ValueError("n_states must be positive")
+        if self.update_mode != "full":
+            raise ValueError("Only the correctness-first 'full' update is supported")
+        self._physical_proposal = self.sampling_proposal
+        self.sampling_proposal = self._single_replica_proposal
+
+    def _single_replica_proposal(self, rngs, x, stddev):
+        if self.n_states == 1:
+            return self._physical_proposal(rngs, x, stddev)
+        leaves, treedef = jax.tree.flatten(x)
+        if not leaves:
+            return x
+        batch_size = leaves[0].shape[0]
+        rngs, index_key = jax.random.split(rngs)
+        replica_index = jax.random.randint(index_key, (batch_size,), 0, self.n_states)
+        selected = []
+        for leaf in leaves:
+            if leaf.ndim < 2 or leaf.shape[1] != self.n_states:
+                raise ValueError(
+                    "Determinant sampler fields must have shape [batch, states, ...]"
+                )
+            selected.append(
+                jax.vmap(lambda row, index: row[index])(leaf, replica_index)
+            )
+        selected_tree = jax.tree.unflatten(treedef, selected)
+        proposed_selected = self._physical_proposal(rngs, selected_tree, stddev)
+        proposed_leaves = jax.tree.leaves(proposed_selected)
+        proposed = []
+        for leaf, proposal in zip(leaves, proposed_leaves):
+            proposed.append(
+                jax.vmap(lambda row, value, index: row.at[index].set(value))(
+                    leaf, proposal, replica_index
+                )
+            )
+        return jax.tree.unflatten(treedef, proposed)

--- a/src/jaqmc/utils/parallel_jax.py
+++ b/src/jaqmc/utils/parallel_jax.py
@@ -132,6 +132,21 @@ def pnanmean(x):
     return pmean(local_sum) / pmean(local_count)
 
 
+def psum[ValueT](x: ValueT) -> ValueT:
+    """Sum ``x`` across devices along the batch axis.
+
+    Outside a ``shard_map`` context this is the identity, matching
+    :func:`pmean`'s convenient single-device behavior.
+
+    Returns:
+        The cross-device sum, or the input outside a shard-map context.
+    """
+    try:
+        return jax.lax.psum(x, axis_name=BATCH_AXIS_NAME)
+    except NameError:
+        return x
+
+
 def all_gather(x):
     """Gather ``x`` from every device along the batch axis and tile the result.
 

--- a/src/jaqmc/utils/subspace_linalg.py
+++ b/src/jaqmc/utils/subspace_linalg.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Numerically stable small-matrix operations for variational subspaces."""
+
+import jax
+from jax import numpy as jnp
+
+
+def row_scaled_matrix(log_amplitudes: jax.Array) -> tuple[jax.Array, jax.Array]:
+    """Exponentiate a log-amplitude matrix after removing per-row scales.
+
+    Returns:
+        The scaled amplitude matrix and removed row shifts.
+    """
+    row_shift = jax.lax.stop_gradient(jnp.max(jnp.real(log_amplitudes), axis=-1))
+    return jnp.exp(log_amplitudes - row_shift[:, None]), row_shift
+
+
+def stable_complex_logdet(log_amplitudes: jax.Array) -> jax.Array:
+    """Return ``log(det(exp(log_amplitudes)))`` without amplitude overflow."""
+    scaled, row_shift = row_scaled_matrix(log_amplitudes)
+    phase, logabsdet = jnp.linalg.slogdet(scaled)
+    return jnp.sum(row_shift) + logabsdet + 1j * jnp.angle(phase)
+
+
+def rayleigh_solve(phi: jax.Array, phi_h: jax.Array) -> jax.Array:
+    """Solve the local Rayleigh system ``phi @ R = phi_h``.
+
+    Returns:
+        The local Rayleigh matrix.
+    """
+    return jnp.linalg.solve(phi, phi_h)
+
+
+def solve_residual(a: jax.Array, x: jax.Array, b: jax.Array) -> jax.Array:
+    """Return the relative Frobenius residual of ``a @ x = b``."""
+    tiny = jnp.finfo(jnp.real(b).dtype).tiny
+    return jnp.linalg.norm(a @ x - b) / jnp.maximum(jnp.linalg.norm(b), tiny)
+
+
+def complex_variance(x: jax.Array, axis=0) -> jax.Array:
+    """Return ``E[|x-E[x]|^2]`` for real or complex samples."""
+    centered = x - jnp.nanmean(x, axis=axis, keepdims=True)
+    return jnp.nanmean(jnp.abs(centered) ** 2, axis=axis)
+
+
+def matrix_condition_proxy(matrix: jax.Array) -> jax.Array:
+    """Return the singular-value condition number of a small matrix."""
+    singular_values = jnp.linalg.svd(matrix, compute_uv=False)
+    return singular_values[0] / singular_values[-1]
+
+
+def singular_value_diagnostics(
+    matrix: jax.Array,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Return minimum/maximum singular values and their condition ratio."""
+    singular_values = jnp.linalg.svd(matrix, compute_uv=False)
+    sigma_max = singular_values[0]
+    sigma_min = singular_values[-1]
+    return sigma_min, sigma_max, sigma_max / sigma_min
+
+
+def hermitianized_rayleigh(g: jax.Array, gh: jax.Array) -> jax.Array:
+    """Map a generalized Hermitian eigenproblem to an ordinary one.
+
+    Returns:
+        The Hermitian standard-form matrix.
+    """
+    g = (g + g.conj().T) / 2
+    gh = (gh + gh.conj().T) / 2
+    chol = jnp.linalg.cholesky(g)
+    left_solved = jnp.linalg.solve(chol, gh)
+    result = jnp.linalg.solve(chol, left_solved.conj().T).conj().T
+    return (result + result.conj().T) / 2
+
+
+def generalized_ritz(g: jax.Array, gh: jax.Array) -> tuple[jax.Array, jax.Array]:
+    """Solve ``GH c = G c e`` for positive-definite overlap ``G``.
+
+    Returns:
+        The Ritz values and generalized eigenvectors.
+    """
+    effective = hermitianized_rayleigh(g, gh)
+    values, orthonormal_vectors = jnp.linalg.eigh(effective)
+    chol = jnp.linalg.cholesky((g + g.conj().T) / 2)
+    vectors = jnp.linalg.solve(chol.conj().T, orthonormal_vectors)
+    return values, vectors

--- a/src/jaqmc/wavefunction/__init__.py
+++ b/src/jaqmc/wavefunction/__init__.py
@@ -8,11 +8,25 @@ from .base import (
     WavefunctionInit,
     WavefunctionLike,
 )
+from .determinant_state import (
+    CheckpointStateBundle,
+    DeterminantStateWavefunction,
+    IndependentStateBundle,
+    SubspaceSpec,
+    take_replica,
+    take_replica_dynamic,
+)
 
 __all__ = [
+    "CheckpointStateBundle",
+    "DeterminantStateWavefunction",
+    "IndependentStateBundle",
     "NumericWavefunctionEvaluate",
+    "SubspaceSpec",
     "Wavefunction",
     "WavefunctionEvaluate",
     "WavefunctionInit",
     "WavefunctionLike",
+    "take_replica",
+    "take_replica_dynamic",
 ]

--- a/src/jaqmc/wavefunction/determinant_state.py
+++ b/src/jaqmc/wavefunction/determinant_state.py
@@ -1,0 +1,249 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Determinant-state adapters for variational subspace Monte Carlo."""
+
+import dataclasses
+from dataclasses import dataclass
+from operator import eq
+from typing import Protocol
+
+import jax
+from jax import numpy as jnp
+
+from jaqmc.array_types import Params, PRNGKey
+from jaqmc.data import Data
+from jaqmc.utils.checkpoint import NumPyCheckpointManager
+from jaqmc.utils.subspace_linalg import row_scaled_matrix, stable_complex_logdet
+
+
+class ComponentWavefunctionLike(Protocol):
+    """Minimal component interface used by a determinant-state bundle."""
+
+    def init_params(self, data: Data, rngs: PRNGKey) -> Params: ...
+
+    def phase_logpsi(
+        self, params: Params, data: Data
+    ) -> tuple[jax.Array, jax.Array]: ...
+
+
+@dataclass(frozen=True)
+class SubspaceSpec:
+    """Describe the state/replica axis embedded in one physical walker."""
+
+    n_states: int
+    replica_fields: tuple[str, ...] = ("electrons",)
+
+    def __post_init__(self):
+        if self.n_states < 1:
+            raise ValueError("n_states must be positive")
+        if not self.replica_fields:
+            raise ValueError("replica_fields must not be empty")
+
+
+def take_replica(data: Data, replica_index: int, spec: SubspaceSpec) -> Data:
+    """Remove the replica axis from selected fields of one determinant walker.
+
+    Returns:
+        Physical data for the selected replica.
+
+    Raises:
+        KeyError: If a configured replica field is absent from the data.
+    """
+    missing = set(spec.replica_fields) - set(data.field_names)
+    if missing:
+        raise KeyError(f"Replica fields are absent from data: {sorted(missing)}")
+    return dataclasses.replace(
+        data,
+        **{name: data[name][replica_index] for name in spec.replica_fields},
+    )
+
+
+def take_replica_dynamic(
+    data: Data, replica_index: jax.Array, spec: SubspaceSpec
+) -> Data:
+    """Select one replica with a traced index without expanding replica data.
+
+    Returns:
+        Physical data for the dynamically selected replica.
+
+    Raises:
+        KeyError: If a configured replica field is absent from the data.
+    """
+    missing = set(spec.replica_fields) - set(data.field_names)
+    if missing:
+        raise KeyError(f"Replica fields are absent from data: {sorted(missing)}")
+    return dataclasses.replace(
+        data,
+        **{
+            name: jax.tree.map(
+                lambda x: jax.lax.dynamic_index_in_dim(
+                    x, replica_index, axis=0, keepdims=False
+                ),
+                data[name],
+            )
+            for name in spec.replica_fields
+        },
+    )
+
+
+class IndependentStateBundle:
+    """Evaluate one JaQMC ansatz architecture with independent state parameters."""
+
+    def __init__(
+        self, base_wavefunction: ComponentWavefunctionLike, spec: SubspaceSpec
+    ):
+        self.base_wavefunction = base_wavefunction
+        self.spec = spec
+
+    def init_params(self, physical_data: Data, rngs: PRNGKey) -> Params:
+        """Initialize independent parameters and stack every PyTree leaf.
+
+        Returns:
+            Parameters stacked along the leading state axis.
+        """
+        # Preserve exact native initialization semantics for the M=1
+        # regression path.  Splitting a single key would otherwise produce a
+        # statistically equivalent, but different, initial wavefunction.
+        keys = (
+            jnp.expand_dims(rngs, 0)
+            if self.spec.n_states == 1
+            else jax.random.split(rngs, self.spec.n_states)
+        )
+        params = [
+            self.base_wavefunction.init_params(physical_data, key) for key in keys
+        ]
+        return jax.tree.map(lambda *xs: jnp.stack(xs), *params)
+
+    def phase_logpsi_all_states(
+        self, stacked_params: Params, physical_data: Data
+    ) -> tuple[jax.Array, jax.Array]:
+        """Return component phases and log amplitudes with shape ``[M]``."""
+        return jax.vmap(self.base_wavefunction.phase_logpsi, in_axes=(0, None))(
+            stacked_params, physical_data
+        )
+
+    def complex_logpsi_all_states(
+        self, stacked_params: Params, physical_data: Data
+    ) -> jax.Array:
+        """Return phase-aware complex log amplitudes with shape ``[M]``."""
+        phase, logabs = self.phase_logpsi_all_states(stacked_params, physical_data)
+        phase = phase.astype(jnp.result_type(phase, 1j))
+        return logabs + 1j * jnp.angle(phase)
+
+    def logpsi_matrix(self, stacked_params: Params, replica_data: Data) -> jax.Array:
+        """Return ``L[r, s] = log(psi_s(R_r))`` with shape ``[M, M]``."""
+        physical_axis = dataclasses.replace(
+            replica_data,
+            **{
+                name: 0 if name in self.spec.replica_fields else None
+                for name in replica_data.field_names
+            },
+        )
+        return jax.vmap(self.complex_logpsi_all_states, in_axes=(None, physical_axis))(
+            stacked_params, replica_data
+        )
+
+
+class CheckpointStateBundle(IndependentStateBundle):
+    """Initialize independent states from native JaQMC checkpoints."""
+
+    def __init__(
+        self,
+        base_wavefunction: ComponentWavefunctionLike,
+        spec: SubspaceSpec,
+        checkpoint_paths: tuple[str, ...] | list[str],
+    ):
+        super().__init__(base_wavefunction, spec)
+        self.checkpoint_paths = tuple(checkpoint_paths)
+        if len(self.checkpoint_paths) != spec.n_states:
+            raise ValueError(
+                "subspace.initialization.checkpoints must contain exactly "
+                f"n_states={spec.n_states} paths; got {len(self.checkpoint_paths)}"
+            )
+
+    def init_params(self, physical_data: Data, rngs: PRNGKey) -> Params:
+        template = self.base_wavefunction.init_params(physical_data, rngs)
+        template_def = jax.tree.structure(template)
+        template_shapes = jax.tree.map(jnp.shape, template)
+        loaded = []
+        for checkpoint_path in self.checkpoint_paths:
+            manager = NumPyCheckpointManager(
+                checkpoint_path, checkpoint_path, prefix="train"
+            )
+            _, restored = manager.restore({"params": template}, strict=True)
+            params = restored["params"]
+            if not eq(jax.tree.structure(params), template_def):
+                raise ValueError(
+                    f"Checkpoint parameter PyTree does not match: {checkpoint_path}"
+                )
+            shapes = jax.tree.map(jnp.shape, params)
+            if jax.tree.leaves(shapes) != jax.tree.leaves(template_shapes):
+                raise ValueError(
+                    f"Checkpoint parameter shapes do not match: {checkpoint_path}"
+                )
+            loaded.append(params)
+        return jax.tree.map(lambda *xs: jnp.stack(xs), *loaded)
+
+
+class StateBundleLike(Protocol):
+    """Internal adapter contract used by the determinant wrapper."""
+
+    spec: SubspaceSpec
+
+    def init_params(self, physical_data: Data, rngs: PRNGKey) -> Params: ...
+
+    def complex_logpsi_all_states(
+        self, stacked_params: Params, physical_data: Data
+    ) -> jax.Array: ...
+
+    def logpsi_matrix(
+        self, stacked_params: Params, replica_data: Data
+    ) -> jax.Array: ...
+
+
+class DeterminantStateWavefunction:
+    """Wavefunction whose amplitude is a determinant of component states."""
+
+    def __init__(
+        self,
+        base_wavefunction: ComponentWavefunctionLike,
+        spec: SubspaceSpec,
+        *,
+        state_bundle: StateBundleLike | None = None,
+    ):
+        self.base_wavefunction = base_wavefunction
+        self.spec = spec
+        self.bundle = state_bundle or IndependentStateBundle(base_wavefunction, spec)
+        if self.bundle.spec != spec:
+            raise ValueError("state_bundle.spec must match determinant spec")
+
+    def init_params(self, data: Data, rngs: PRNGKey) -> Params:
+        physical_data = take_replica(data, 0, self.spec)
+        return self.bundle.init_params(physical_data, rngs)
+
+    def component_logpsi_matrix(self, params: Params, data: Data) -> jax.Array:
+        return self.bundle.logpsi_matrix(params, data)
+
+    def component_amplitude_row(
+        self, params: Params, data: Data
+    ) -> tuple[jax.Array, jax.Array]:
+        """Return a scaled component row and its removed real log scale."""
+        logs = self.bundle.complex_logpsi_all_states(params, data)
+        shift = jax.lax.stop_gradient(jnp.max(jnp.real(logs)))
+        return jnp.exp(logs - shift), shift
+
+    def stable_amplitude_matrix(
+        self, params: Params, data: Data
+    ) -> tuple[jax.Array, jax.Array]:
+        return row_scaled_matrix(self.component_logpsi_matrix(params, data))
+
+    def logpsi(self, params: Params, data: Data) -> jax.Array:
+        return stable_complex_logdet(self.component_logpsi_matrix(params, data))
+
+    def phase_logpsi(self, params: Params, data: Data) -> tuple[jax.Array, jax.Array]:
+        logpsi = self.logpsi(params, data)
+        return jnp.exp(1j * jnp.imag(logpsi)), jnp.real(logpsi)
+
+    def evaluate(self, params: Params, data: Data) -> dict[str, jax.Array]:
+        return {"logpsi": self.logpsi(params, data)}

--- a/src/jaqmc/workflow/__init__.py
+++ b/src/jaqmc/workflow/__init__.py
@@ -3,10 +3,13 @@
 
 from .base import Workflow, WorkflowConfig, init_batched_data
 from .evaluation import EvaluationWorkflow
+from .subspace_vmc import SubspaceConfig, SubspaceVMCWorkflow
 from .vmc import VMCWorkflow
 
 __all__ = [
     "EvaluationWorkflow",
+    "SubspaceConfig",
+    "SubspaceVMCWorkflow",
     "VMCWorkflow",
     "Workflow",
     "WorkflowConfig",

--- a/src/jaqmc/workflow/stage/vmc.py
+++ b/src/jaqmc/workflow/stage/vmc.py
@@ -234,6 +234,15 @@ class VMCWorkStage(SamplingWorkStage):
             opt_state=opt_state,
         )
 
+    def optimizer_step_valid(self, stats: dict[str, Any]):
+        """Return whether an optimizer update may be applied for this step.
+
+        Specialized VMC stages can override this hook while reusing the native
+        sampling, estimator, optimizer, and state-update pipeline.
+        """
+        del stats
+        return jnp.asarray(True)
+
     def compute_step(
         self, state: VMCState, rngs: PRNGKey
     ) -> tuple[VMCState, dict[str, Any]]:
@@ -257,14 +266,40 @@ class VMCWorkStage(SamplingWorkStage):
         grads = final_stats.pop("grads", None)
         if grads is None:
             raise ValueError("None of the estimators provides `grads` stats.")
-        updates, opt_state = self.optimizer.update(
-            grads,
-            state.opt_state,
-            params=state.params,
-            batched_data=data,
-            rngs=opt_rngs,
-        )
-        params = optax.apply_updates(state.params, updates)
+        grad_norm = optax.tree.norm(grads)
+        final_stats["grad_norm"] = grad_norm
+        valid = jnp.asarray(self.optimizer_step_valid(final_stats))
+
+        def apply_optimizer(_):
+            updates, opt_state = self.optimizer.update(
+                grads,
+                state.opt_state,
+                params=state.params,
+                batched_data=data,
+                rngs=opt_rngs,
+            )
+            return (
+                optax.apply_updates(state.params, updates),
+                opt_state,
+                optax.tree.norm(updates),
+            )
+
+        def preserve_state(_):
+            return state.params, state.opt_state, jnp.zeros_like(grad_norm)
+
+        try:
+            concrete_valid = bool(valid)
+        except jax.errors.TracerBoolConversionError:
+            params, opt_state, update_norm = jax.lax.cond(
+                valid, apply_optimizer, preserve_state, operand=None
+            )
+        else:
+            if concrete_valid:
+                params, opt_state, update_norm = apply_optimizer(None)
+            else:
+                params, opt_state, update_norm = preserve_state(None)
+
+        final_stats["update_norm"] = update_norm
         new_state = replace(
             state,
             params=params,

--- a/src/jaqmc/workflow/subspace_vmc.py
+++ b/src/jaqmc/workflow/subspace_vmc.py
@@ -1,0 +1,296 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""JaQMC-native assembly of determinant-state variational training."""
+
+import logging
+from collections.abc import Callable, Mapping
+from dataclasses import replace
+from typing import Any, cast
+
+import jax
+from jax import numpy as jnp
+
+from jaqmc.array_types import PRNGKey
+from jaqmc.data import BatchedData
+from jaqmc.estimator import (
+    CrossLocalEnergyEvaluator,
+    EstimatorLike,
+    StreamingLossAndGrad,
+)
+from jaqmc.estimator.rayleigh import RayleighMatrixEstimator
+from jaqmc.optimizer.optax import adam
+from jaqmc.sampler.determinant import DeterminantMCMCSampler
+from jaqmc.utils.config import ConfigManager, configurable_dataclass
+from jaqmc.utils.wiring import wire
+from jaqmc.wavefunction.base import WavefunctionLike
+from jaqmc.wavefunction.determinant_state import (
+    CheckpointStateBundle,
+    DeterminantStateWavefunction,
+    SubspaceSpec,
+)
+from jaqmc.workflow.stage.vmc import VMCWorkStage
+from jaqmc.workflow.vmc import VMCWorkflow
+
+logger = logging.getLogger(__name__)
+
+
+@configurable_dataclass
+class SubspaceConfig:
+    """Configuration shared by molecule and solid subspace workflows."""
+
+    n_states: int = 2
+    condition_warning: float = 1e10
+    solve_residual_warning: float = 1e-6
+    max_imag_eigenvalue_warning: float = 1e-6
+
+    def __post_init__(self):
+        if self.n_states < 1:
+            raise ValueError("subspace.n_states must be positive")
+
+
+def replicate_walker_replicas(
+    batched_data: BatchedData, spec: SubspaceSpec
+) -> BatchedData:
+    """Repeat batched fields along a new replica axis.
+
+    This shape helper is useful in tests and adapters but must not initialize a
+    determinant chain: identical replica rows produce a singular amplitude
+    matrix.  Use :func:`make_subspace_data_init` for workflow initialization.
+
+    Returns:
+        Batched data with a repeated replica axis.
+
+    Raises:
+        ValueError: If configured replica fields do not carry a batch axis.
+    """
+    missing = set(spec.replica_fields) - set(batched_data.fields_with_batch)
+    if missing:
+        raise ValueError(
+            "Replica fields must already carry the walker batch axis: "
+            f"{sorted(missing)}"
+        )
+    data = replace(
+        batched_data.data,
+        **{
+            name: jax.tree.map(
+                lambda x: jnp.repeat(x[:, None], spec.n_states, axis=1),
+                batched_data.data[name],
+            )
+            for name in spec.replica_fields
+        },
+    )
+    return replace(batched_data, data=data)
+
+
+def make_subspace_data_init(
+    physical_data_init: Callable[[int, PRNGKey], BatchedData], spec: SubspaceSpec
+):
+    """Initialize independent physical configurations and group them by walker.
+
+    Repeating one configuration across replicas makes the initial amplitude
+    matrix singular.  Requesting ``B*M`` native samples keeps initialization
+    owned by the app while introducing only a reshape in this adapter.
+
+    Returns:
+        A data initializer that groups independent samples by walker.
+    """
+
+    def data_init(size: int, rngs: PRNGKey) -> BatchedData:
+        physical = physical_data_init(size * spec.n_states, rngs)
+        physical.check()
+        if extra := set(physical.fields_with_batch) - set(spec.replica_fields):
+            raise ValueError(
+                "All native batched fields must be listed in replica_fields; "
+                f"missing {sorted(extra)}"
+            )
+        data = replace(
+            physical.data,
+            **{
+                name: jax.tree.map(
+                    lambda x: x.reshape(size, spec.n_states, *x.shape[1:]),
+                    physical.data[name],
+                )
+                for name in physical.fields_with_batch
+                if name in spec.replica_fields
+            },
+        )
+        result = replace(physical, data=data)
+        result.check()
+        return result
+
+    return data_init
+
+
+class SubspaceVMCWorkflow(VMCWorkflow):
+    """Base workflow that reuses JaQMC's VMC stage, gradients, and optimizers."""
+
+    config_namespace = "subspace_train"
+
+    @classmethod
+    def default_preset(cls) -> dict[str, Any]:
+        fields = (
+            "pmove:.2f,energy=subspace_energy:.4f,"
+            "variance=subspace_energy_var:.4f,imag=subspace_energy_imag:.2e,"
+            "grass_var=grassmann_hamiltonian_variance:.3e,"
+            "sigma_min=amplitude_sigma_min:.2e,"
+            "condition=amplitude_condition:.2e,"
+            "residual=rayleigh_solve_residual:.2e,"
+            "max_imag=max_ritz_imag:.2e,"
+            "grad_norm=grad_norm:.2e,update_norm=update_norm:.2e"
+        )
+        return {
+            "train": {
+                "run": {"iterations": 200_000},
+                "writers": {"console": {"fields": fields}},
+            }
+        }
+
+    def __init__(self, cfg: ConfigManager) -> None:
+        super().__init__(cfg)
+        # Read leaves separately so the ``subspace`` namespace can also hold
+        # nested sampler/evaluation configuration without dataclass decoding
+        # treating those sections as unknown SubspaceConfig fields.
+        self.subspace = SubspaceConfig(
+            n_states=cfg.get("subspace.n_states", 2),
+            condition_warning=cfg.get("subspace.diagnostics.condition_warning", 1e10),
+            solve_residual_warning=cfg.get(
+                "subspace.diagnostics.solve_residual_warning", 1e-6
+            ),
+            max_imag_eigenvalue_warning=cfg.get(
+                "subspace.diagnostics.max_imag_eigenvalue_warning", 1e-6
+            ),
+        )
+        self.spec = SubspaceSpec(self.subspace.n_states)
+        self.initialization_mode = cfg.get("subspace.initialization.mode", "random")
+        self.initialization_checkpoints: list[str] = cfg.get(
+            "subspace.initialization.checkpoints", []
+        )
+        if self.initialization_mode not in ("random", "checkpoints"):
+            raise ValueError(
+                "subspace.initialization.mode must be 'random' or 'checkpoints'"
+            )
+
+    def configure_subspace(
+        self,
+        *,
+        base_wavefunction,
+        physical_data_init: Callable[[int, PRNGKey], BatchedData],
+        physical_energy_estimators: Mapping[str, EstimatorLike],
+        physical_proposal=None,
+    ) -> None:
+        """Assemble the native VMC stage around app-provided physical pieces.
+
+        Raises:
+            TypeError: If the configured gradient estimator lacks ``loss_key``.
+        """
+        self.base_wavefunction = base_wavefunction
+        state_bundle = None
+        if self.initialization_mode == "checkpoints":
+            state_bundle = CheckpointStateBundle(
+                base_wavefunction, self.spec, self.initialization_checkpoints
+            )
+        self.wf = DeterminantStateWavefunction(
+            base_wavefunction, self.spec, state_bundle=state_bundle
+        )
+        self.data_init = make_subspace_data_init(physical_data_init, self.spec)
+
+        sampler_default = DeterminantMCMCSampler(
+            n_states=self.spec.n_states,
+            initial_width=0.02,
+            **(
+                {"sampling_proposal": physical_proposal}
+                if physical_proposal is not None
+                else {}
+            ),
+        )
+        sampler = self.cfg.get("subspace.sampling", sampler_default)
+        self.subspace_sampler = sampler
+        rayleigh = self.cfg.get_module(
+            "subspace.evaluation",
+            RayleighMatrixEstimator,
+        )
+        rayleigh.condition_warning = self.subspace.condition_warning
+        rayleigh.solve_residual_warning = self.subspace.solve_residual_warning
+        rayleigh.max_imag_eigenvalue_warning = self.subspace.max_imag_eigenvalue_warning
+        cross_energy = CrossLocalEnergyEvaluator(
+            physical_energy_estimators,
+            self.spec,
+            pair_chunk_size=rayleigh.pair_chunk_size,
+        )
+        wire(
+            rayleigh,
+            f_component_logpsi_matrix=self.wf.component_logpsi_matrix,
+            f_cross_local_energy=cross_energy,
+        )
+
+        train = VMCWorkStage.builder(
+            self.cfg.scoped("train"), cast(WavefunctionLike, self.wf)
+        )
+        train.configure_sample_plan(self.wf.logpsi, {"electrons": sampler})
+        train.configure_optimizer(default=adam, f_log_psi=self.wf.logpsi)
+        train.configure_estimators(rayleigh=rayleigh)
+        grads = train.cfg.get("grads", StreamingLossAndGrad)
+        if not hasattr(grads, "loss_key"):
+            raise TypeError("train.grads estimator must expose a loss_key field")
+        grads.loss_key = "subspace_local_energy"
+        train.configure_loss_grads(grads, f_log_psi=self.wf.logpsi)
+        device_count = jax.device_count()
+        local_batch = self.config.batch_size // device_count
+        logger.info(
+            "Subspace chunking: n_states=%s, global_batch=%s, "
+            "local_batch=%s, devices=%s, "
+            "rayleigh_walkers=%s, cross_pairs=%s, gradient_walkers=%s, "
+            "matrix_dtype=%s, optimizer=%s, objective=%s",
+            self.spec.n_states,
+            self.config.batch_size,
+            local_batch,
+            device_count,
+            rayleigh.vmap_chunk_size,
+            rayleigh.pair_chunk_size,
+            getattr(grads, "vmap_chunk_size", None),
+            rayleigh.matrix_dtype,
+            type(train.optimizer).__name__,
+            grads.loss_key,
+        )
+        native_stage = train.build()
+        self.train_stage = SubspaceVMCWorkStage(
+            config=native_stage.config,
+            name=native_stage.name,
+            wavefunction=native_stage.wavefunction,
+            sample_plan=native_stage.sample_plan,
+            estimators=native_stage.estimators,
+            writers=native_stage.writers,
+            optimizer=native_stage.optimizer,
+        )
+
+
+class SubspaceVMCWorkStage(VMCWorkStage):
+    """Native VMC stage that gates invalid Rayleigh steps before optimization."""
+
+    def optimizer_step_valid(self, stats: dict[str, Any]):
+        """Require the Rayleigh estimator to approve the optimizer step.
+
+        Returns:
+            A scalar Boolean array indicating whether to update parameters.
+        """
+        return jnp.asarray(stats.get("training_step_valid", True))
+
+    def _has_nan(self, stats: dict[str, Any]) -> bool:
+        if "training_step_valid" in stats and not bool(
+            jnp.asarray(stats["training_step_valid"])
+        ):
+            return True
+        return super()._has_nan(stats)
+
+
+def energy_estimators_only(
+    estimators: Mapping[str, EstimatorLike],
+) -> dict[str, EstimatorLike]:
+    """Keep the ordered physical energy pipeline and discard other observables.
+
+    Returns:
+        The energy-only estimator mapping in native evaluation order.
+    """
+    names = ("potential", "kinetic", "ecp", "ph", "total")
+    return {name: estimators[name] for name in names if name in estimators}

--- a/tests/cli_dry_run_test.py
+++ b/tests/cli_dry_run_test.py
@@ -400,6 +400,53 @@ def test_cli_command_dry_run(
     assert result.exit_code == 0, f"command: {case.command}\noutput:\n{result.output}"
 
 
+def test_solid_subspace_train_help_is_exposed() -> None:
+    result = CliRunner().invoke(cli, ["solid", "subspace-train", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "solid-state low-energy subspace" in result.output
+
+
+def test_hydrogen_subspace_example_dry_run() -> None:
+    root = Path(__file__).resolve().parents[1]
+    result = CliRunner().invoke(
+        cli,
+        [
+            "molecule",
+            "subspace-train",
+            "--yml",
+            str(root / "examples" / "atoms" / "hydrogen_subspace.yml"),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+
+
+@pytest.mark.parametrize(
+    "optimizer_config",
+    ["subspace_grassmann_sr.yml", "subspace_gvmc_reference_sr.yml"],
+)
+def test_hydrogen_subspace_grassmann_optimizer_overlay_dry_run(
+    optimizer_config: str,
+) -> None:
+    root = Path(__file__).resolve().parents[1]
+    result = CliRunner().invoke(
+        cli,
+        [
+            "molecule",
+            "subspace-train",
+            "--yml",
+            str(root / "examples" / "atoms" / "hydrogen_subspace.yml"),
+            "--yml",
+            str(root / "configs" / "workflows" / optimizer_config),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+
+
 def test_cli_verbose_config_dotlist(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level("INFO", logger="jaqmc.utils.config")
 

--- a/tests/estimator/loss_grad_test.py
+++ b/tests/estimator/loss_grad_test.py
@@ -1,15 +1,21 @@
 # Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
 # SPDX-License-Identifier: Apache-2.0
 
+from operator import itemgetter
+
+import jax
 import numpy as np
+import pytest
 import yaml
 from jax import lax
 from jax import numpy as jnp
 
 from jaqmc.app.hall import HallTrainWorkflow
-from jaqmc.estimator.loss_grad import LossAndGrad
+from jaqmc.data import BatchedData, Data
+from jaqmc.estimator import LossAndGrad, StreamingLossAndGrad
 from jaqmc.utils.clip import clip_observable
 from jaqmc.utils.config import ConfigManager
+from jaqmc.utils.func_transform import grad_maybe_complex
 
 
 def _mock_all_gather_identity(monkeypatch):
@@ -74,6 +80,141 @@ def test_loss_and_grad_reduce_uses_selected_clip_method(monkeypatch):
         reduced["grad_logpsi_and_loss"]["w"],
         jnp.mean(grads["w"] * expected_clipped),
     )
+    assert not any(key.endswith("_var") for key in reduced)
+
+
+class GradientData(Data):
+    x: jax.Array
+
+
+def test_native_vmc_gradient_convention_is_two_times_centered_score_force():
+    data = BatchedData(
+        GradientData(x=jnp.array([-1.2, -0.4, 0.1, 0.6, 1.0, 1.7])), ["x"]
+    )
+    params = {"weights": jnp.array([0.3, -0.2], dtype=jnp.float64)}
+    local_energy = jnp.array(
+        [0.8 + 0.1j, -0.4 + 0.7j, 1.3 - 0.2j, -0.1 + 0.5j, 0.6 - 0.8j, -0.7 + 0.2j],
+        dtype=jnp.complex128,
+    )
+
+    def logpsi(p, sample):
+        value = p["weights"][0] * sample.x + p["weights"][1] * sample.x**2
+        return value + 0.2j * p["weights"][0] * sample.x**2
+
+    estimator = StreamingLossAndGrad(
+        loss_key="energy", clip_method="none", f_log_psi=logpsi
+    )
+    sums, _ = estimator.evaluate_batch_walkers(
+        params, data, {"energy": local_energy}, None, jax.random.key(0)
+    )
+    reduced = estimator.reduce(sums)
+    final = estimator.finalize_stats(jax.tree.map(itemgetter(None), reduced), None)
+
+    scores = jax.vmap(lambda sample: grad_maybe_complex(logpsi)(params, sample))(
+        data.data
+    )["weights"]
+    n_walkers = data.batch_size
+    jacobian = (scores - jnp.mean(scores, axis=0)) / jnp.sqrt(n_walkers)
+    force = (local_energy - jnp.mean(local_energy)) / jnp.sqrt(n_walkers)
+    jacobian = jnp.concatenate((jnp.real(jacobian), jnp.imag(jacobian)), axis=0)
+    force = jnp.concatenate((jnp.real(force), jnp.imag(force)), axis=0)
+    gvmc_gradient = jacobian.T @ force
+
+    np.testing.assert_allclose(
+        final["grads"]["weights"], 2.0 * gvmc_gradient, rtol=1e-11, atol=1e-12
+    )
+
+
+@pytest.mark.parametrize("clip_method", ["none", "mad", "iqr"])
+@pytest.mark.parametrize("complex_output", [False, True])
+@pytest.mark.parametrize("chunk_size", [1, 2, 4, 6])
+def test_streaming_loss_grad_matches_reference(
+    monkeypatch, clip_method, complex_output, chunk_size
+):
+    _mock_all_gather_identity(monkeypatch)
+    data = BatchedData(
+        GradientData(x=jnp.array([0.2, -0.4, 0.7, 1.1, -0.8, 0.3])), ["x"]
+    )
+    params = {"a": jnp.array(0.6), "b": jnp.array(-0.3)}
+    local_energy = jnp.array(
+        [
+            1.0 + 0.2j,
+            -0.5 + 0.7j,
+            2.0 - 0.3j,
+            0.1 + 0.9j,
+            1.3 - 0.4j,
+            -0.2 + 0.1j,
+        ]
+    )
+
+    def logpsi(p, one_data):
+        value = p["a"] * one_data.x + p["b"] * one_data.x**2
+        return value + 1j * p["b"] * one_data.x if complex_output else value
+
+    reference = LossAndGrad(
+        loss_key="energy", clip_method=clip_method, f_log_psi=logpsi
+    )
+    streaming = StreamingLossAndGrad(
+        loss_key="energy",
+        vmap_chunk_size=chunk_size,
+        clip_method=clip_method,
+        f_log_psi=logpsi,
+    )
+    prev_stats = {"energy": local_energy}
+
+    ref_walkers, _ = reference.evaluate_batch_walkers(
+        params, data, prev_stats, None, jax.random.key(0)
+    )
+    ref_reduced = reference.reduce(ref_walkers)
+    ref_final = reference.finalize_stats(
+        jax.tree.map(itemgetter(None), ref_reduced), None
+    )
+    stream_sums, _ = streaming.evaluate_batch_walkers(
+        params, data, prev_stats, None, jax.random.key(0)
+    )
+    stream_reduced = streaming.reduce(stream_sums)
+    stream_final = streaming.finalize_stats(
+        jax.tree.map(itemgetter(None), stream_reduced), None
+    )
+
+    np.testing.assert_allclose(stream_final["loss"], ref_final["loss"], rtol=1e-6)
+    for actual, expected in zip(
+        jax.tree.leaves(stream_final["grads"]),
+        jax.tree.leaves(ref_final["grads"]),
+    ):
+        np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)
+
+
+def test_loss_and_grad_keeps_imaginary_local_energy_contribution():
+    estimator = LossAndGrad(clip_method="none")
+    local_energy = jnp.array([1.0 + 2.0j, 3.0 - 1.0j])
+    grad_logpsi = {"w": jnp.array([1.0 + 1.0j, 2.0 - 3.0j])}
+
+    reduced = estimator.reduce({"loss": local_energy, "grad_logpsi": grad_logpsi})
+    final = estimator.finalize_stats(jax.tree.map(itemgetter(None), reduced), None)
+    centered = local_energy - jnp.mean(local_energy)
+    expected = 2 * jnp.mean(jnp.real(jnp.conj(grad_logpsi["w"]) * centered))
+    wrong_real_only = 2 * jnp.mean(
+        jnp.real(jnp.conj(grad_logpsi["w"]) * jnp.real(centered))
+    )
+
+    np.testing.assert_allclose(final["grads"]["w"], expected)
+    assert not np.isclose(float(expected), float(wrong_real_only))
+
+
+def test_loss_and_grad_validity_mask_uses_same_walker_subset():
+    estimator = LossAndGrad(clip_method="none", validity_key="valid")
+    reduced = estimator.reduce(
+        {
+            "loss": jnp.array([1.0, 1000.0, 5.0]),
+            "grad_logpsi": {"w": jnp.array([1.0, 100.0, 3.0])},
+            "loss_valid": jnp.array([True, False, True]),
+        }
+    )
+    final = estimator.finalize_stats(jax.tree.map(itemgetter(None), reduced), None)
+    expected = 2 * jnp.mean(jnp.array([1.0, 3.0]) * (jnp.array([1.0, 5.0]) - 3.0))
+
+    np.testing.assert_allclose(final["grads"]["w"], expected)
 
 
 def test_loss_and_grad_config_roundtrip_preserves_clip_method():

--- a/tests/estimator/rayleigh_test.py
+++ b/tests/estimator/rayleigh_test.py
@@ -1,0 +1,338 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from jaqmc.data import Data
+from jaqmc.estimator.rayleigh import (
+    CrossLocalEnergyEvaluator,
+    RayleighMatrixEstimator,
+    grassmann_hamiltonian_statistics,
+)
+from jaqmc.estimator.total_energy import TotalEnergy
+from jaqmc.utils import parallel_jax
+from jaqmc.wavefunction.determinant_state import SubspaceSpec
+
+
+class ToyData(Data):
+    electrons: jax.Array
+
+
+def test_rayleigh_estimator_matches_direct_solve():
+    phi = jnp.array([[2.0, 0.5], [0.25, 1.5]], dtype=jnp.complex64)
+    logs = jnp.log(phi)
+    local_energy = jnp.array([[1.0, 2.0], [3.0, 4.0]], dtype=jnp.complex64)
+    estimator = RayleighMatrixEstimator(
+        matrix_dtype="complex64",
+        f_component_logpsi_matrix=lambda params, data: logs,
+        f_cross_local_energy=lambda params, data, rngs: local_energy,
+    )
+
+    stats, state = estimator.evaluate_single_walker(
+        {}, ToyData(electrons=jnp.zeros((2, 1, 1))), {}, None, jax.random.key(0)
+    )
+    expected = jnp.linalg.solve(phi, phi * local_energy)
+
+    assert state is None
+    np.testing.assert_allclose(stats["local_rayleigh"], expected, rtol=1e-6)
+    np.testing.assert_allclose(
+        stats["subspace_energy"], jnp.trace(expected).real, rtol=1e-6
+    )
+    np.testing.assert_allclose(
+        stats["subspace_local_energy"], jnp.trace(expected), rtol=1e-6
+    )
+    # CUDA complex64 small solves have backend-dependent residuals around
+    # 1e-4; the estimator's production default remains complex128.
+    np.testing.assert_allclose(stats["rayleigh_solve_residual"], 0, atol=5e-4)
+
+
+def test_m1_rayleigh_reduces_to_native_local_energy():
+    estimator = RayleighMatrixEstimator(
+        matrix_dtype="complex64",
+        f_component_logpsi_matrix=lambda params, data: jnp.array([[3.0]]),
+        f_cross_local_energy=lambda params, data, rngs: jnp.array([[1.25]]),
+    )
+
+    stats, _ = estimator.evaluate_single_walker(
+        {}, ToyData(electrons=jnp.zeros((1, 1, 1))), {}, None, jax.random.key(0)
+    )
+
+    np.testing.assert_allclose(stats["local_rayleigh"], [[1.25]], rtol=1e-6)
+    np.testing.assert_allclose(stats["subspace_energy"], 1.25, rtol=1e-6)
+
+
+def test_cross_local_energy_reuses_ordered_native_estimator_pipeline():
+    def component(params, data, prev_stats, state, rngs):
+        del prev_stats, rngs
+        value = params["slope"] * jnp.sum(data.electrons)
+        return {"energy:toy": value}, state
+
+    evaluator = CrossLocalEnergyEvaluator(
+        {"component": component, "total": TotalEnergy()},
+        SubspaceSpec(2),
+        pair_chunk_size=2,
+    )
+    data = ToyData(electrons=jnp.array([[[1.0]], [[3.0]]]))
+    params = {"slope": jnp.array([2.0, 5.0])}
+    evaluator.init(data, jax.random.key(0))
+
+    actual = evaluator(params, data, jax.random.key(1))
+
+    np.testing.assert_allclose(actual, [[2.0, 5.0], [6.0, 15.0]])
+
+
+def test_cross_local_energy_reuses_state_independent_potential():
+    def potential(params, data, prev_stats, state, rngs):
+        del params, prev_stats, rngs
+        return {"energy:potential": jnp.sum(data.electrons)}, state
+
+    def kinetic(params, data, prev_stats, state, rngs):
+        del data, prev_stats, rngs
+        return {"energy:kinetic": params["slope"]}, state
+
+    evaluator = CrossLocalEnergyEvaluator(
+        {"potential": potential, "kinetic": kinetic, "total": TotalEnergy()},
+        SubspaceSpec(2),
+        pair_chunk_size=1,
+    )
+    data = ToyData(electrons=jnp.array([[[1.0]], [[3.0]]]))
+    params = {"slope": jnp.array([2.0, 5.0])}
+    evaluator.init(data, jax.random.key(0))
+
+    actual = evaluator(params, data, jax.random.key(1))
+
+    np.testing.assert_allclose(actual, [[3.0, 6.0], [5.0, 8.0]])
+
+
+@pytest.mark.parametrize("n_states", [2, 4, 8, 16])
+@pytest.mark.parametrize("chunk_size", [1, 2, 4])
+def test_cross_local_energy_dynamic_pair_indexing_scales(n_states, chunk_size):
+    def component(params, data, prev_stats, state, rngs):
+        del prev_stats, rngs
+        return {"total_energy": params["slope"] * jnp.sum(data.electrons)}, state
+
+    evaluator = CrossLocalEnergyEvaluator(
+        {"total": component},
+        SubspaceSpec(n_states),
+        pair_chunk_size=chunk_size,
+    )
+    data = ToyData(electrons=jnp.arange(1, n_states + 1, dtype=float)[:, None, None])
+    params = {"slope": jnp.arange(1, n_states + 1, dtype=float)}
+    evaluator.init(data, jax.random.key(0))
+
+    actual = jax.jit(evaluator)(params, data, jax.random.key(1))
+    expected = (
+        jnp.arange(1, n_states + 1, dtype=float)[:, None]
+        * jnp.arange(1, n_states + 1, dtype=float)[None, :]
+    )
+
+    np.testing.assert_allclose(actual, expected)
+
+
+def test_numerical_failure_invalidates_the_whole_step_without_filtering():
+    estimator = RayleighMatrixEstimator(matrix_dtype="complex64")
+    matrices = jnp.array(
+        [
+            [[1.0, 2.0], [3.0, 4.0]],
+            [[10.0, jnp.nan], [30.0, 40.0]],
+            [[5.0, 6.0], [7.0, 8.0]],
+        ],
+        dtype=jnp.complex64,
+    )
+    stats = {
+        "local_rayleigh": matrices,
+        "subspace_local_energy": jnp.array([5.0, jnp.nan, 13.0]),
+        "subspace_energy": jnp.array([5.0, jnp.nan, 13.0]),
+        "rayleigh_valid": jnp.array([True, True, True]),
+    }
+
+    reduced = estimator.reduce(stats)
+
+    assert jnp.isnan(reduced["rayleigh_mean"]).any()
+    np.testing.assert_allclose(reduced["rayleigh_valid_fraction"], 2 / 3)
+    np.testing.assert_allclose(reduced["rayleigh_invalid_count"], 1)
+    assert not reduced["training_step_valid"]
+
+
+def test_subspace_energy_variance_uses_all_walkers():
+    estimator = RayleighMatrixEstimator(matrix_dtype="complex64")
+    matrices = jnp.array(
+        [
+            [[1.0, 2.0], [3.0, 4.0]],
+            [[5.0, 6.0], [7.0, 8.0]],
+        ],
+        dtype=jnp.complex64,
+    )
+    stats = {
+        "local_rayleigh": matrices,
+        "subspace_local_energy": jnp.array([5.0, 13.0], dtype=jnp.complex64),
+        "subspace_energy": jnp.array([5.0, 13.0]),
+        "rayleigh_valid": jnp.array([True, True]),
+    }
+
+    reduced = estimator.reduce(stats)
+
+    np.testing.assert_allclose(reduced["subspace_energy"], 9.0)
+    np.testing.assert_allclose(reduced["subspace_energy_var"], 16.0)
+    assert reduced["training_step_valid"]
+
+
+def test_grassmann_variance_matches_reference_formula_elementwise():
+    local_rayleigh = jnp.array(
+        [
+            [[1.0 + 0.2j, 0.3], [0.1j, 2.0 - 0.1j]],
+            [[1.4 - 0.3j, -0.2j], [0.5, 2.5 + 0.4j]],
+            [[0.8 + 0.1j, 0.7], [-0.3j, 1.7 - 0.2j]],
+        ],
+        dtype=jnp.complex128,
+    )
+    actual = grassmann_hamiltonian_statistics(local_rayleigh)
+
+    mean_rayleigh = jnp.mean(local_rayleigh, axis=0)
+    local_trace = jnp.trace(local_rayleigh, axis1=-2, axis2=-1)
+    expected_matrix = jnp.mean(
+        local_rayleigh * jnp.conj(local_trace)[:, None, None], axis=0
+    ) - mean_rayleigh * jnp.conj(jnp.mean(local_trace))
+    expected_variance = jnp.real(jnp.trace(expected_matrix)) / 2
+
+    np.testing.assert_allclose(
+        actual["grassmann_hamiltonian_variance_matrix"], expected_matrix
+    )
+    np.testing.assert_allclose(
+        actual["grassmann_hamiltonian_variance"], expected_variance
+    )
+    np.testing.assert_allclose(
+        actual["grassmann_average_energy"], jnp.trace(mean_rayleigh) / 2
+    )
+
+
+def test_grassmann_variance_m1_is_local_energy_variance():
+    local_energy = jnp.array([1.0, 2.0, 4.0], dtype=jnp.complex128)
+    stats = grassmann_hamiltonian_statistics(local_energy[:, None, None])
+
+    np.testing.assert_allclose(
+        stats["grassmann_hamiltonian_variance"], jnp.var(local_energy.real)
+    )
+
+
+def test_grassmann_variance_detects_hamiltonian_leakage():
+    invariant = jnp.broadcast_to(
+        jnp.array([[1.0, 0.2], [0.0, 2.0]], dtype=jnp.complex128),
+        (4, 2, 2),
+    )
+    leaking = invariant.at[:, 0, 0].add(jnp.array([-1.0, 0.0, 1.0, 2.0]))
+
+    invariant_stats = grassmann_hamiltonian_statistics(invariant)
+    leaking_stats = grassmann_hamiltonian_statistics(leaking)
+
+    np.testing.assert_allclose(
+        invariant_stats["grassmann_hamiltonian_variance"], 0, atol=1e-12
+    )
+    assert leaking_stats["grassmann_hamiltonian_variance"] > 0
+
+
+def test_rayleigh_reduce_appends_grassmann_fields_without_replacing_old_fields():
+    estimator = RayleighMatrixEstimator(matrix_dtype="complex128")
+    matrices = jnp.array(
+        [
+            [[1.0, 0.2], [0.1, 2.0]],
+            [[1.5, 0.3], [0.0, 2.5]],
+        ],
+        dtype=jnp.complex128,
+    )
+    stats = {
+        "local_rayleigh": matrices,
+        "subspace_local_energy": jnp.trace(matrices, axis1=-2, axis2=-1),
+        "subspace_energy": jnp.real(jnp.trace(matrices, axis1=-2, axis2=-1)),
+        "rayleigh_valid": jnp.ones(2, dtype=bool),
+    }
+
+    reduced = estimator.reduce(stats)
+
+    for old_key in (
+        "subspace_energy",
+        "subspace_energy_var",
+        "local_rayleigh_variance",
+        "ritz_energies",
+    ):
+        assert old_key in reduced
+    for new_key in (
+        "grassmann_average_energy",
+        "grassmann_hamiltonian_variance",
+        "grassmann_hamiltonian_variance_matrix",
+        "grassmann_hamiltonian_std",
+    ):
+        assert new_key in reduced
+
+
+def test_grassmann_variance_uses_global_multi_device_moments():
+    if jax.local_device_count() < 2:
+        pytest.skip("requires at least two devices")
+    matrices = jnp.array(
+        [
+            [[[1.0, 0.1], [0.0, 2.0]], [[1.5, 0.2], [0.1, 2.2]]],
+            [[[0.5, -0.1], [0.2, 1.7]], [[2.0, 0.3], [0.0, 2.8]]],
+        ],
+        dtype=jnp.complex128,
+    )
+    estimator = RayleighMatrixEstimator(matrix_dtype="complex128")
+
+    def reduce(local_rayleigh):
+        trace = jnp.trace(local_rayleigh, axis1=-2, axis2=-1)
+        return estimator.reduce(
+            {
+                "local_rayleigh": local_rayleigh,
+                "subspace_local_energy": trace,
+                "subspace_energy": jnp.real(trace),
+                "rayleigh_valid": jnp.ones(local_rayleigh.shape[0], dtype=bool),
+            }
+        )
+
+    distributed = jax.pmap(reduce, axis_name=parallel_jax.BATCH_AXIS_NAME)(matrices)
+    expected = grassmann_hamiltonian_statistics(matrices.reshape(-1, 2, 2))
+
+    for key in (
+        "grassmann_average_energy",
+        "grassmann_hamiltonian_variance",
+        "grassmann_hamiltonian_variance_matrix",
+    ):
+        np.testing.assert_allclose(distributed[key][0], expected[key])
+        np.testing.assert_allclose(distributed[key][1], expected[key])
+
+
+def test_ill_conditioned_finite_solve_remains_a_valid_sample():
+    phi = jnp.array([[1.0, 1.0], [1.0, 1.0001]], dtype=jnp.complex64)
+    local_energy = jnp.array([[1.0, 2.0], [3.0, 4.0]], dtype=jnp.complex64)
+    estimator = RayleighMatrixEstimator(
+        matrix_dtype="complex64",
+        condition_warning=1e3,
+        f_component_logpsi_matrix=lambda params, data: jnp.log(phi),
+        f_cross_local_energy=lambda params, data, rngs: local_energy,
+    )
+
+    stats, _ = estimator.evaluate_single_walker(
+        {}, ToyData(electrons=jnp.zeros((2, 1, 1))), {}, None, jax.random.key(0)
+    )
+
+    assert stats["amplitude_condition_warning"]
+    assert stats["rayleigh_valid"]
+    assert jnp.isfinite(stats["rayleigh_solve_residual"])
+
+
+def test_near_singular_amplitude_matrix_triggers_diagnostic():
+    logs = jnp.log(jnp.array([[1.0, 1.0], [1.0, 1.0]], dtype=jnp.complex64))
+    estimator = RayleighMatrixEstimator(
+        matrix_dtype="complex64",
+        f_component_logpsi_matrix=lambda params, data: logs,
+        f_cross_local_energy=lambda params, data, rngs: jnp.ones((2, 2)),
+    )
+
+    stats, _ = estimator.evaluate_single_walker(
+        {}, ToyData(electrons=jnp.zeros((2, 1, 1))), {}, None, jax.random.key(0)
+    )
+
+    assert stats["amplitude_condition_warning"]
+    assert not stats["rayleigh_finite"]

--- a/tests/estimator/streaming_loss_grad_multi_device_test.py
+++ b/tests/estimator/streaming_loss_grad_multi_device_test.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2025-2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+"""Multi-device equivalence tests for streaming VMC gradients."""
+
+from operator import itemgetter
+
+import jax
+import numpy as np
+import pytest
+from jax import numpy as jnp
+
+from jaqmc.data import BatchedData, Data
+from jaqmc.estimator import LossAndGrad, StreamingLossAndGrad
+from jaqmc.utils import parallel_jax
+
+
+class GradientData(Data):
+    x: jax.Array
+
+
+def _logpsi(params, data):
+    real = params["a"] * data.x + params["b"] * data.x**2
+    return real + 1j * params["b"] * data.x
+
+
+def _finalize(estimator, params, data, loss):
+    walker_stats, _ = estimator.evaluate_batch_walkers(
+        params, data, {"energy": loss}, None, jax.random.key(0)
+    )
+    reduced = estimator.reduce(walker_stats)
+    final = estimator.finalize_stats(jax.tree.map(itemgetter(None), reduced), None)
+    return reduced, final
+
+
+def test_streaming_loss_grad_matches_global_reference_across_devices():
+    if jax.device_count() < 2:
+        pytest.skip("At least two JAX devices are required")
+
+    device_count = jax.device_count()
+    batch_size = 4 * device_count
+    x = jnp.linspace(-1.2, 1.3, batch_size)
+    loss = jnp.linspace(-0.7, 1.8, batch_size) + 0.2j * x
+    params = {"a": jnp.array(0.6), "b": jnp.array(-0.3)}
+    data = BatchedData(GradientData(x=x), ["x"])
+
+    reference = LossAndGrad(loss_key="energy", clip_method="none", f_log_psi=_logpsi)
+    expected_reduced, expected_final = _finalize(reference, params, data, loss)
+
+    streaming = StreamingLossAndGrad(
+        loss_key="energy",
+        vmap_chunk_size=1,
+        clip_method="none",
+        f_log_psi=_logpsi,
+    )
+
+    def distributed(p, d, local_loss):
+        return _finalize(streaming, p, d, local_loss)
+
+    distributed = parallel_jax.shard_map(
+        distributed,
+        mesh=parallel_jax.make_mesh(),
+        in_specs=(
+            parallel_jax.SHARE_PARTITION,
+            data.partition_spec,
+            parallel_jax.DATA_PARTITION,
+        ),
+        out_specs=parallel_jax.SHARE_PARTITION,
+    )
+    actual_reduced, actual_final = distributed(params, data, loss)
+
+    for key in ("grad_logpsi", "grad_logpsi_and_loss"):
+        for actual, expected in zip(
+            jax.tree.leaves(actual_reduced[key]),
+            jax.tree.leaves(expected_reduced[key]),
+        ):
+            np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)
+    np.testing.assert_allclose(
+        actual_reduced["loss"], expected_reduced["loss"], rtol=1e-6
+    )
+    for actual, expected in zip(
+        jax.tree.leaves(actual_final["grads"]),
+        jax.tree.leaves(expected_final["grads"]),
+    ):
+        np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)

--- a/tests/optimizer/gvmc_reference_sr_test.py
+++ b/tests/optimizer/gvmc_reference_sr_test.py
@@ -1,0 +1,443 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+from operator import itemgetter
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+import pytest
+from jax.flatten_util import ravel_pytree
+
+from jaqmc.data import BatchedData, Data
+from jaqmc.estimator import StreamingLossAndGrad
+from jaqmc.optimizer.gvmc_reference_sr import (
+    GVMCReferenceSROptimizer,
+    _native_vmc_to_gvmc_gradient,
+    minsr_solve,
+    minsr_solve_gradient,
+    minsr_solve_kacz,
+)
+from jaqmc.utils.func_transform import grad_maybe_complex
+
+pytestmark = pytest.mark.requires_x64
+
+
+def _reference_matrix(jacobian, lam0, lam1):
+    n = jacobian.shape[0]
+    scale = jnp.linalg.norm(jacobian) ** 2 / n
+    return jacobian @ jnp.conj(jacobian.T) + scale * (lam1 / n) + lam0 * jnp.eye(n)
+
+
+def test_minsr_solve_matches_gvmc_source_equation():
+    jacobian = jnp.array(
+        [[1.0 + 0.2j, 0.3], [-0.4j, 1.2], [-1.0 + 0.2j, -1.5]],
+        dtype=jnp.complex128,
+    )
+    force = jnp.array([0.4 + 0.1j, -0.2j, -0.4 + 0.1j])
+    lam0, lam1 = 2e-3, 0.7
+
+    actual = minsr_solve(jacobian, force, lam0=lam0, lam1=lam1)
+    expected = jnp.conj(jacobian.T) @ jnp.linalg.solve(
+        _reference_matrix(jacobian, lam0, lam1), force
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-11, atol=1e-12)
+
+
+def test_minsr_kacz_matches_reference_continuation():
+    jacobian = jnp.array(
+        [[0.5, -0.2, 0.4], [1.0, 0.3, -0.1], [-1.5, -0.1, -0.3]],
+        dtype=jnp.float64,
+    )
+    force = jnp.array([0.2, -0.5, 0.3], dtype=jnp.float64)
+    previous = jnp.array([0.1, -0.2, 0.05], dtype=jnp.float64)
+    mu = 0.8
+
+    actual = minsr_solve_kacz(jacobian, force, previous, lam0=1e-3, lam1=1.0, mu=mu)
+    residual = force - mu * jacobian @ previous
+    expected = (
+        jnp.conj(jacobian.T)
+        @ jnp.linalg.solve(_reference_matrix(jacobian, 1e-3, 1.0), residual)
+        + mu * previous
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-10, atol=1e-12)
+
+
+def test_minsr_and_kacz_match_cqsl_gvmc_golden_vectors():
+    """Anchor cqsl/GVMC@e68e503, including its all-entries lam1 shift."""
+    jacobian = jnp.array(
+        [
+            [0.7, -0.2, 0.4],
+            [-0.1, 0.9, -0.3],
+            [-0.6, -0.7, -0.1],
+            [0.2, 0.5, 0.8],
+        ],
+        dtype=jnp.float64,
+    )
+    force = jnp.array([0.35, -0.15, -0.25, 0.05], dtype=jnp.float64)
+    previous = jnp.array([0.12, -0.08, 0.03], dtype=jnp.float64)
+    expected_minsr = jnp.array(
+        [0.47438583246858684, -0.08512767274722458, 0.02486287395734668]
+    )
+    expected_kacz = jnp.array(
+        [0.4769540823520102, -0.08619417530168463, 0.02372779043486619]
+    )
+
+    actual_minsr = minsr_solve(jacobian, force, lam0=0.017, lam1=0.65)
+    actual_kacz = minsr_solve_kacz(
+        jacobian,
+        force,
+        previous,
+        lam0=0.017,
+        lam1=0.65,
+        mu=0.73,
+    )
+
+    np.testing.assert_allclose(actual_minsr, expected_minsr, rtol=1e-12, atol=1e-13)
+    np.testing.assert_allclose(actual_kacz, expected_kacz, rtol=1e-12, atol=1e-13)
+
+
+def test_gradient_form_is_equivalent_for_centered_force():
+    key_j, key_b = jax.random.split(jax.random.key(3))
+    jacobian = jax.random.normal(key_j, (6, 4), dtype=jnp.float64)
+    jacobian -= jnp.mean(jacobian, axis=0, keepdims=True)
+    force = jax.random.normal(key_b, (6,), dtype=jnp.float64)
+    force -= jnp.mean(force)
+    gradient = jnp.conj(jacobian.T) @ force
+
+    direct = minsr_solve(jacobian, force, lam0=3e-3, lam1=1.0)
+    from_gradient = minsr_solve_gradient(jacobian, gradient, lam0=3e-3, lam1=1.0)
+
+    np.testing.assert_allclose(from_gradient, direct, rtol=1e-9, atol=1e-11)
+
+
+def test_native_gradient_adapter_removes_vmc_factor_two():
+    native_gradient = jnp.array([2.0, -4.0, 0.5], dtype=jnp.float64)
+
+    np.testing.assert_array_equal(
+        _native_vmc_to_gvmc_gradient(native_gradient),
+        jnp.array([1.0, -2.0, 0.25], dtype=jnp.float64),
+    )
+
+
+class LinearData(Data):
+    features: jax.Array
+
+
+def _linear_problem(n_states=2):
+    params = {
+        "weights": jnp.array([[0.2, -0.1], [0.4, 0.3]], dtype=jnp.float64)[:n_states]
+    }
+    features = jnp.array(
+        [
+            [[1.0, 0.0], [0.0, 1.0]],
+            [[0.5, 1.0], [-0.5, 0.2]],
+            [[-1.0, 0.5], [1.0, -0.3]],
+            [[0.2, -0.7], [0.4, 0.9]],
+            [[0.8, 0.3], [-0.2, -0.6]],
+            [[-0.4, -0.9], [0.7, 0.1]],
+            [[1.1, -0.2], [-0.8, 0.5]],
+            [[-0.6, 0.8], [0.3, -1.0]],
+        ],
+        dtype=jnp.float64,
+    )[:, :n_states]
+    data = BatchedData(LinearData(features=features), ["features"])
+
+    def logpsi(p, sample):
+        value = jnp.sum(p["weights"] * sample.features)
+        phase = jnp.sum(p["weights"] * sample.features**2)
+        return value + 0.2j * phase
+
+    return params, data, logpsi
+
+
+def _reference_score_and_force(params, data, logpsi, local_trace):
+    scores = jax.vmap(lambda sample: grad_maybe_complex(logpsi)(params, sample))(
+        data.data
+    )
+    flat_scores = jax.vmap(lambda tree: ravel_pytree(tree)[0])(scores)
+    scale = jnp.sqrt(data.batch_size)
+    jacobian = (flat_scores - jnp.mean(flat_scores, axis=0)) / scale
+    force = (local_trace - jnp.mean(local_trace)) / scale
+    return (
+        jnp.concatenate((jnp.real(jacobian), jnp.imag(jacobian)), axis=0),
+        jnp.concatenate((jnp.real(force), jnp.imag(force)), axis=0),
+    )
+
+
+def _streaming_native_gradient(params, data, logpsi, local_trace):
+    estimator = StreamingLossAndGrad(
+        loss_key="local_trace", clip_method="none", f_log_psi=logpsi
+    )
+    sums, _ = estimator.evaluate_batch_walkers(
+        params,
+        data,
+        {"local_trace": local_trace},
+        None,
+        jax.random.key(0),
+    )
+    reduced = estimator.reduce(sums)
+    final = estimator.finalize_stats(jax.tree.map(itemgetter(None), reduced), None)
+    return final["grads"]
+
+
+def test_reference_optimizer_m2_uses_source_lr_with_factor_control():
+    params, data, logpsi = _linear_problem()
+    local_trace = jnp.array(
+        [
+            0.8 + 0.1j,
+            -0.4 + 0.7j,
+            1.3 - 0.2j,
+            -0.1 + 0.5j,
+            0.6 - 0.8j,
+            -0.7 + 0.2j,
+            1.1 + 0.4j,
+            -0.2 - 0.6j,
+        ],
+        dtype=jnp.complex128,
+    )
+    lam0, lam1, learning_rate = 1e-2, 1.0, 0.1
+    jacobian, force = _reference_score_and_force(params, data, logpsi, local_trace)
+    native_grads = _streaming_native_gradient(params, data, logpsi, local_trace)
+    native_gradient, _ = ravel_pytree(native_grads)
+    gvmc_gradient = jacobian.T @ force
+    direct = minsr_solve(jacobian, force, lam0=lam0, lam1=lam1)
+    legacy = minsr_solve_gradient(jacobian, native_gradient, lam0=lam0, lam1=lam1)
+    fixed = minsr_solve_gradient(
+        jacobian,
+        _native_vmc_to_gvmc_gradient(native_gradient),
+        lam0=lam0,
+        lam1=lam1,
+    )
+
+    optimizer = GVMCReferenceSROptimizer(
+        learning_rate=learning_rate,
+        lam0=lam0,
+        lam1=lam1,
+        mu=0.0,
+        f_log_psi=logpsi,
+    )
+    state = optimizer.init(params, batched_data=data)
+    updates, new_state = optimizer.update(
+        native_grads, state, params, batched_data=data
+    )
+    flat_updates, _ = ravel_pytree(updates)
+
+    np.testing.assert_allclose(native_gradient, 2.0 * gvmc_gradient, rtol=1e-11)
+    np.testing.assert_allclose(legacy, 2.0 * direct, rtol=1e-9, atol=1e-11)
+    np.testing.assert_allclose(fixed, direct, rtol=1e-9, atol=1e-11)
+    legacy_ratio = jnp.linalg.norm(legacy) / jnp.linalg.norm(direct)
+    fixed_ratio = jnp.linalg.norm(fixed) / jnp.linalg.norm(direct)
+    legacy_cosine = jnp.vdot(legacy, direct) / (
+        jnp.linalg.norm(legacy) * jnp.linalg.norm(direct)
+    )
+    fixed_cosine = jnp.vdot(fixed, direct) / (
+        jnp.linalg.norm(fixed) * jnp.linalg.norm(direct)
+    )
+    np.testing.assert_allclose(legacy_ratio, 2.0, rtol=1e-9)
+    np.testing.assert_allclose(fixed_ratio, 1.0, rtol=1e-9)
+    np.testing.assert_allclose(legacy_cosine, 1.0, rtol=1e-9)
+    np.testing.assert_allclose(fixed_cosine, 1.0, rtol=1e-9)
+    np.testing.assert_allclose(new_state.previous_delta, direct, rtol=1e-9)
+    np.testing.assert_allclose(flat_updates, -learning_rate * direct, rtol=1e-9)
+    wrong_sqrt_scaled = -learning_rate / np.sqrt(2.0) * direct
+    assert not np.allclose(flat_updates, wrong_sqrt_scaled, rtol=1e-4, atol=1e-6)
+
+
+def test_reference_optimizer_matches_direct_gvmc_kacz_trajectory():
+    params, data, logpsi = _linear_problem()
+    optimizer = GVMCReferenceSROptimizer(
+        learning_rate=0.1,
+        lam0=3e-3,
+        lam1=0.7,
+        mu=0.8,
+        f_log_psi=logpsi,
+    )
+    state = optimizer.init(params, batched_data=data)
+    direct_previous = jnp.zeros_like(state.previous_delta)
+    base_trace = jnp.array(
+        [
+            0.8 + 0.1j,
+            -0.4 + 0.7j,
+            1.3 - 0.2j,
+            -0.1 + 0.5j,
+            0.6 - 0.8j,
+            -0.7 + 0.2j,
+            1.1 + 0.4j,
+            -0.2 - 0.6j,
+        ]
+    )
+
+    for step in range(5):
+        local_trace = base_trace + (0.03 * step) * jnp.arange(8) ** 2
+        jacobian, force = _reference_score_and_force(params, data, logpsi, local_trace)
+        direct = minsr_solve_kacz(
+            jacobian,
+            force,
+            direct_previous,
+            lam0=optimizer.lam0,
+            lam1=optimizer.lam1,
+            mu=optimizer.mu,
+        )
+        native_grads = _streaming_native_gradient(params, data, logpsi, local_trace)
+        updates, state = optimizer.update(
+            native_grads, state, params, batched_data=data
+        )
+        flat_updates, _ = ravel_pytree(updates)
+
+        np.testing.assert_allclose(state.previous_delta, direct, rtol=1e-9, atol=1e-11)
+        np.testing.assert_allclose(flat_updates, -0.1 * direct, rtol=1e-9, atol=1e-11)
+        np.testing.assert_array_equal(state.counter, step + 1)
+        direct_previous = direct
+
+
+def test_reference_optimizer_matches_direct_gvmc_parameter_trajectory():
+    params, data, _ = _linear_problem()
+
+    def logpsi(p, sample):
+        weights = p["weights"]
+        value = jnp.sum((weights + 0.1 * weights**2) * sample.features)
+        phase = jnp.sum((weights + 0.05 * weights**3) * sample.features**2)
+        return value + 0.2j * phase
+
+    learning_rate = 0.02
+    optimizer = GVMCReferenceSROptimizer(
+        learning_rate=learning_rate,
+        lam0=4e-3,
+        lam1=0.6,
+        mu=0.7,
+        f_log_psi=logpsi,
+    )
+    params_direct = params
+    params_backend = params
+    state = optimizer.init(params_backend, batched_data=data)
+    direct_previous = jnp.zeros_like(state.previous_delta)
+    base_trace = jnp.array(
+        [
+            0.7 + 0.2j,
+            -0.3 + 0.6j,
+            1.1 - 0.4j,
+            -0.2 + 0.3j,
+            0.5 - 0.7j,
+            -0.8 + 0.1j,
+            0.9 + 0.5j,
+            -0.1 - 0.5j,
+        ]
+    )
+
+    for step in range(5):
+        local_trace = base_trace + 0.02 * step * jnp.arange(8) ** 2
+        jacobian, force = _reference_score_and_force(
+            params_direct, data, logpsi, local_trace
+        )
+        direct = minsr_solve_kacz(
+            jacobian,
+            force,
+            direct_previous,
+            lam0=optimizer.lam0,
+            lam1=optimizer.lam1,
+            mu=optimizer.mu,
+        )
+        _, unravel = ravel_pytree(params_direct)
+        params_direct = optax.apply_updates(
+            params_direct, unravel(-learning_rate * direct)
+        )
+
+        native_grads = _streaming_native_gradient(
+            params_backend, data, logpsi, local_trace
+        )
+        updates, state = optimizer.update(
+            native_grads, state, params_backend, batched_data=data
+        )
+        params_backend = optax.apply_updates(params_backend, updates)
+
+        np.testing.assert_allclose(state.previous_delta, direct, rtol=1e-9, atol=1e-11)
+        for actual, expected in zip(
+            jax.tree.leaves(params_backend), jax.tree.leaves(params_direct)
+        ):
+            np.testing.assert_allclose(actual, expected, rtol=1e-9, atol=1e-11)
+        direct_previous = direct
+
+
+def test_reference_optimizer_m1_matches_direct_sr_and_keeps_learning_rate():
+    params, data, logpsi = _linear_problem(n_states=1)
+    local_trace = jnp.array(
+        [
+            0.2 + 0.3j,
+            -0.6 + 0.1j,
+            0.8 - 0.4j,
+            1.1 + 0.2j,
+            -0.2 - 0.7j,
+            0.4 + 0.5j,
+            -0.9 + 0.1j,
+            0.3 - 0.2j,
+        ]
+    )
+    jacobian, force = _reference_score_and_force(params, data, logpsi, local_trace)
+    direct = minsr_solve(jacobian, force, lam0=1e-2, lam1=1.0)
+    native_grads = _streaming_native_gradient(params, data, logpsi, local_trace)
+    optimizer = GVMCReferenceSROptimizer(
+        learning_rate=0.07,
+        lam0=1e-2,
+        mu=0.0,
+        f_log_psi=logpsi,
+    )
+    state = optimizer.init(params, batched_data=data)
+    updates, state = optimizer.update(native_grads, state, params, batched_data=data)
+    flat_updates, _ = ravel_pytree(updates)
+
+    np.testing.assert_allclose(state.previous_delta, direct, rtol=1e-9, atol=1e-11)
+    np.testing.assert_allclose(flat_updates, -0.07 * direct, rtol=1e-9, atol=1e-11)
+
+
+def test_reference_optimizer_implements_native_optimizer_protocol():
+    params = {"weights": jnp.array([[0.2, -0.1], [0.4, 0.3]], dtype=jnp.float64)}
+    data = BatchedData(
+        LinearData(
+            features=jnp.array(
+                [
+                    [[1.0, 0.0], [0.0, 1.0]],
+                    [[0.5, 1.0], [-0.5, 0.2]],
+                    [[-1.0, 0.5], [1.0, -0.3]],
+                    [[0.2, -0.7], [0.4, 0.9]],
+                ],
+                dtype=jnp.float64,
+            )
+        ),
+        ["features"],
+    )
+    grads = {"weights": jnp.array([[0.3, -0.2], [0.1, 0.4]])}
+
+    def logpsi(p, sample):
+        value = jnp.sum(p["weights"] * sample.features)
+        return value + 0.2j * value
+
+    optimizer = GVMCReferenceSROptimizer(
+        learning_rate=0.1,
+        lam0=1e-2,
+        mu=0.0,
+        f_log_psi=logpsi,
+    )
+    state = optimizer.init(params, batched_data=data)
+    updates, new_state = jax.jit(optimizer.update)(
+        grads, state, params, batched_data=data
+    )
+
+    assert jax.tree.structure(updates) == jax.tree.structure(params)
+    assert new_state.counter == 1
+    assert all(np.isfinite(np.asarray(leaf)).all() for leaf in jax.tree.leaves(updates))
+    flat_update, _ = ravel_pytree(updates)
+    assert jnp.linalg.norm(flat_update) > 0
+
+
+def test_reference_optimizer_rejects_multi_device(monkeypatch):
+    optimizer = GVMCReferenceSROptimizer(f_log_psi=lambda p, d: p["w"].sum())
+    params = {"w": jnp.ones((2, 1))}
+    data = BatchedData(LinearData(features=jnp.ones((2, 2, 1))), ["features"])
+    monkeypatch.setattr(jax, "device_count", lambda: 2)
+
+    with pytest.raises(NotImplementedError, match="single-device"):
+        optimizer.init(params, batched_data=data)

--- a/tests/sampler/determinant_sampler_test.py
+++ b/tests/sampler/determinant_sampler_test.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jaqmc.sampler.determinant import DeterminantMCMCSampler
+from jaqmc.sampler.mcmc import gaussian_proposal
+
+
+def test_proposal_changes_exactly_one_replica_per_walker():
+    sampler = DeterminantMCMCSampler(n_states=3)
+    electrons = jnp.zeros((16, 3, 2, 3))
+
+    proposed = sampler.sampling_proposal(jax.random.key(7), electrons, 0.2)
+    changed = jnp.any(proposed != electrons, axis=(2, 3))
+
+    np.testing.assert_array_equal(changed.sum(axis=1), jnp.ones(16))
+
+
+def test_physical_proposal_only_receives_selected_replica_shape():
+    seen_shapes = []
+
+    def proposal(rngs, x, stddev):
+        del rngs
+        seen_shapes.append(x.shape)
+        return x + stddev
+
+    sampler = DeterminantMCMCSampler(n_states=3, sampling_proposal=proposal)
+    electrons = jnp.zeros((5, 3, 2, 3))
+
+    sampler.sampling_proposal(jax.random.key(1), electrons, 0.1)
+
+    assert seen_shapes == [(5, 2, 3)]
+
+
+def test_m1_proposal_matches_native_physical_proposal():
+    def deterministic_proposal(rngs, x, stddev):
+        del rngs
+        return x + stddev
+
+    sampler = DeterminantMCMCSampler(
+        n_states=1, sampling_proposal=deterministic_proposal
+    )
+    electrons = jnp.zeros((4, 1, 2, 3))
+    proposed = sampler.sampling_proposal(jax.random.key(0), electrons, 0.5)
+    np.testing.assert_allclose(proposed, 0.5)
+
+
+def test_m1_random_proposal_has_exact_native_rng_semantics():
+    sampler = DeterminantMCMCSampler(n_states=1)
+    electrons = jnp.zeros((4, 1, 2, 3))
+    key = jax.random.key(3)
+
+    proposed = sampler.sampling_proposal(key, electrons, 0.5)
+    expected = gaussian_proposal(key, electrons, 0.5)
+
+    np.testing.assert_array_equal(proposed, expected)

--- a/tests/utils/subspace_linalg_test.py
+++ b/tests/utils/subspace_linalg_test.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+import jax.numpy as jnp
+import numpy as np
+
+from jaqmc.utils.subspace_linalg import (
+    complex_variance,
+    generalized_ritz,
+    rayleigh_solve,
+    row_scaled_matrix,
+    solve_residual,
+    stable_complex_logdet,
+)
+
+
+def test_row_scaling_and_complex_logdet_are_stable():
+    logs = jnp.array([[1000.0, 999.0], [998.0, 1001.0]], dtype=jnp.complex64)
+    scaled, shifts = row_scaled_matrix(logs)
+    expected = jnp.linalg.slogdet(scaled)
+
+    actual = stable_complex_logdet(logs)
+
+    np.testing.assert_allclose(actual.real, shifts.sum() + expected[1], rtol=1e-6)
+    np.testing.assert_allclose(actual.imag, jnp.angle(expected[0]), atol=1e-6)
+    assert np.isfinite(actual)
+
+
+def test_rayleigh_solve_and_residual():
+    phi = jnp.array([[2.0, 0.5], [0.25, 1.5]], dtype=jnp.complex64)
+    expected = jnp.array([[1.0, 0.2j], [-0.1j, 3.0]], dtype=jnp.complex64)
+    phi_h = phi @ expected
+
+    actual = rayleigh_solve(phi, phi_h)
+
+    # CUDA complex64 small-matrix solves can use lower-precision kernels than
+    # the CPU backend.  Keep this test about dtype-appropriate correctness;
+    # production Rayleigh evaluation defaults to complex128.
+    np.testing.assert_allclose(actual, expected, rtol=5e-4, atol=5e-4)
+    np.testing.assert_allclose(solve_residual(phi, actual, phi_h), 0, atol=5e-4)
+
+
+def test_generalized_ritz_matches_explicit_reference():
+    g = jnp.array([[2.0, 0.2], [0.2, 1.0]])
+    gh = jnp.array([[1.0, 0.1], [0.1, 3.0]])
+
+    values, vectors = generalized_ritz(g, gh)
+    residual = gh @ vectors - g @ vectors * values[None, :]
+
+    np.testing.assert_allclose(residual, 0, atol=2e-6)
+    np.testing.assert_allclose(vectors.T @ g @ vectors, jnp.eye(2), atol=2e-6)
+
+
+def test_complex_variance_uses_absolute_square():
+    samples = jnp.array([1 + 1j, 1 - 1j])
+    np.testing.assert_allclose(complex_variance(samples), 1.0)
+
+
+def test_rayleigh_similarity_preserves_trace_and_spectrum():
+    rayleigh = jnp.array([[1.0, 0.2], [0.3, 2.0]], dtype=jnp.complex64)
+    basis = jnp.array([[1.0, 0.4], [-0.2, 1.0]], dtype=jnp.complex64)
+    transformed = jnp.linalg.solve(basis, rayleigh @ basis)
+
+    np.testing.assert_allclose(jnp.trace(transformed), jnp.trace(rayleigh), atol=5e-4)
+    np.testing.assert_allclose(
+        jnp.sort(jnp.linalg.eigvals(transformed)),
+        jnp.sort(jnp.linalg.eigvals(rayleigh)),
+        atol=5e-4,
+    )

--- a/tests/wavefunction/determinant_state_test.py
+++ b/tests/wavefunction/determinant_state_test.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from jaqmc.data import Data
+from jaqmc.utils.checkpoint import NumPyCheckpointManager
+from jaqmc.wavefunction.determinant_state import (
+    CheckpointStateBundle,
+    DeterminantStateWavefunction,
+    SubspaceSpec,
+)
+
+
+class ToyData(Data):
+    electrons: jax.Array
+    fixed: jax.Array
+
+
+class ToyWavefunction:
+    def init_params(self, data, rngs):
+        del data
+        return {"slope": jax.random.uniform(rngs, (), minval=0.5, maxval=1.5)}
+
+    def phase_logpsi(self, params, data):
+        value = 1 + params["slope"] * data.electrons.sum()
+        return jnp.sign(value), jnp.log(jnp.abs(value))
+
+
+def test_m1_reduces_to_component_amplitude_and_gradient():
+    wf = DeterminantStateWavefunction(ToyWavefunction(), SubspaceSpec(1))
+    data = ToyData(electrons=jnp.array([[[0.2], [0.3]]]), fixed=jnp.array(1.0))
+    params = {"slope": jnp.array([0.7])}
+    physical = ToyData(electrons=data.electrons[0], fixed=data.fixed)
+    _, expected_logabs = ToyWavefunction().phase_logpsi(
+        {"slope": params["slope"][0]}, physical
+    )
+
+    actual = wf.logpsi(params, data)
+    actual_grad = jax.grad(lambda p: wf.logpsi(p, data).real)(params)
+    expected_grad = jax.grad(lambda p: ToyWavefunction().phase_logpsi(p, physical)[1])(
+        {"slope": params["slope"][0]}
+    )
+
+    np.testing.assert_allclose(actual.real, expected_logabs, rtol=1e-6)
+    np.testing.assert_allclose(actual_grad["slope"][0], expected_grad["slope"])
+
+
+def test_m1_initialization_uses_the_native_key_exactly():
+    base = ToyWavefunction()
+    wf = DeterminantStateWavefunction(base, SubspaceSpec(1))
+    physical = ToyData(electrons=jnp.array([[0.2]]), fixed=jnp.array(1.0))
+    replica = ToyData(electrons=physical.electrons[None, ...], fixed=physical.fixed)
+    key = jax.random.key(11)
+
+    native = base.init_params(physical, key)
+    determinant = wf.init_params(replica, key)
+
+    np.testing.assert_array_equal(determinant["slope"][0], native["slope"])
+
+
+def test_component_matrix_matches_explicit_loop_and_permutation_invariance():
+    wf = DeterminantStateWavefunction(ToyWavefunction(), SubspaceSpec(2))
+    data = ToyData(electrons=jnp.array([[[0.1]], [[0.8]]]), fixed=jnp.array(1.0))
+    params = {"slope": jnp.array([0.4, 1.2])}
+
+    logs = wf.component_logpsi_matrix(params, data)
+    expected = np.empty((2, 2), dtype=np.complex64)
+    for r in range(2):
+        for s in range(2):
+            phase, logabs = ToyWavefunction().phase_logpsi(
+                {"slope": params["slope"][s]},
+                ToyData(electrons=data.electrons[r], fixed=data.fixed),
+            )
+            expected[r, s] = np.asarray(logabs + 1j * jnp.angle(phase + 0j))
+    np.testing.assert_allclose(logs, expected, rtol=1e-6)
+
+    original = wf.logpsi(params, data)
+    permuted_params = {"slope": params["slope"][::-1]}
+    permuted = wf.logpsi(permuted_params, data)
+    np.testing.assert_allclose(original.real, permuted.real, atol=1e-6)
+    np.testing.assert_allclose(
+        jnp.exp(2 * original.real), jnp.exp(2 * permuted.real), rtol=1e-6
+    )
+
+
+def test_checkpoint_state_bundle_loads_and_stacks_native_params(tmp_path):
+    paths = []
+    for index, slope in enumerate((0.4, 1.2)):
+        path = tmp_path / f"state-{index}"
+        NumPyCheckpointManager(path, prefix="train").save(
+            index, {"params": {"slope": jnp.array(slope)}}
+        )
+        paths.append(str(path))
+    physical = ToyData(electrons=jnp.array([[0.2]]), fixed=jnp.array(1.0))
+    bundle = CheckpointStateBundle(ToyWavefunction(), SubspaceSpec(2), paths)
+
+    params = bundle.init_params(physical, jax.random.key(0))
+
+    np.testing.assert_allclose(params["slope"], [0.4, 1.2])
+
+
+def test_checkpoint_state_bundle_requires_one_path_per_state():
+    with pytest.raises(ValueError, match="exactly n_states=2"):
+        CheckpointStateBundle(ToyWavefunction(), SubspaceSpec(2), ["one"])

--- a/tests/wavefunction/grassmann_qgt_test.py
+++ b/tests/wavefunction/grassmann_qgt_test.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from jaqmc.utils.func_transform import grad_maybe_complex
+from jaqmc.utils.subspace_linalg import stable_complex_logdet
+
+
+def _synthetic_logs(theta):
+    n_states = theta.shape[0]
+    rows = jnp.arange(1, n_states + 1, dtype=theta.dtype)[:, None]
+    cols = jnp.arange(1, n_states + 1, dtype=theta.dtype)[None, :]
+    base = 0.07 * rows * cols + 0.03j * (rows - cols)
+    return base + theta[None, :] * (0.2 * rows + 0.05j * rows**2)
+
+
+@pytest.mark.parametrize("n_states", [2, 3])
+def test_logdet_score_matches_gvmc_vjp_identity(n_states):
+    theta = jnp.linspace(-0.3, 0.4, n_states, dtype=jnp.float64)
+    score = grad_maybe_complex(
+        lambda value: stable_complex_logdet(_synthetic_logs(value))
+    )(theta)
+
+    logs = _synthetic_logs(theta)
+    phi = jnp.exp(logs)
+    cotangent = phi * jnp.linalg.inv(phi).T
+    _, vjp = jax.vjp(_synthetic_logs, theta)
+    (score_real,) = vjp(cotangent)
+    (score_imag,) = vjp(-1j * cotangent)
+    reference = jax.lax.complex(score_real, score_imag)
+
+    np.testing.assert_allclose(score, reference, rtol=1e-10, atol=1e-12)
+
+
+@pytest.mark.parametrize("n_states", [2, 3])
+def test_stable_row_scaling_preserves_logdet_score(n_states):
+    theta = jnp.linspace(-0.2, 0.5, n_states, dtype=jnp.float64)
+
+    def direct(value):
+        sign, logabs = jnp.linalg.slogdet(jnp.exp(_synthetic_logs(value)))
+        return logabs + jnp.log(sign)
+
+    stable_score = grad_maybe_complex(
+        lambda value: stable_complex_logdet(_synthetic_logs(value))
+    )(theta)
+    direct_score = grad_maybe_complex(direct)(theta)
+
+    np.testing.assert_allclose(stable_score, direct_score, rtol=1e-10, atol=1e-12)
+
+
+def test_m1_grassmann_qgt_reduces_to_ordinary_score_covariance():
+    theta = jnp.array([0.35], dtype=jnp.float64)
+    samples = jnp.array([-1.0, -0.2, 0.7, 1.5], dtype=jnp.float64)
+
+    def component(value, sample):
+        return value[0] * sample + 0.1j * value[0] * sample**2
+
+    def determinant(value, sample):
+        return stable_complex_logdet(component(value, sample)[None, None])
+
+    component_scores = jax.vmap(
+        lambda sample: grad_maybe_complex(component)(theta, sample)
+    )(samples)
+    determinant_scores = jax.vmap(
+        lambda sample: grad_maybe_complex(determinant)(theta, sample)
+    )(samples)
+    centered = component_scores - jnp.mean(component_scores, axis=0)
+    ordinary_qgt = jnp.real(jnp.conj(centered).T @ centered) / len(samples)
+    det_centered = determinant_scores - jnp.mean(determinant_scores, axis=0)
+    grassmann_qgt = jnp.real(jnp.conj(det_centered).T @ det_centered) / len(samples)
+
+    np.testing.assert_allclose(
+        determinant_scores, component_scores, rtol=1e-11, atol=1e-12
+    )
+    np.testing.assert_allclose(grassmann_qgt, ordinary_qgt, rtol=1e-11)

--- a/tests/workflow/subspace_vmc_test.py
+++ b/tests/workflow/subspace_vmc_test.py
@@ -1,0 +1,320 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from jaqmc.data import BatchedData, Data
+from jaqmc.estimator import StreamingLossAndGrad
+from jaqmc.optimizer.gvmc_reference_sr import GVMCReferenceSROptimizer
+from jaqmc.optimizer.sr import SROptimizer
+from jaqmc.utils import parallel_jax
+from jaqmc.utils.config import ConfigManager
+from jaqmc.wavefunction.determinant_state import SubspaceSpec, take_replica
+from jaqmc.workflow.base import init_batched_data
+from jaqmc.workflow.stage.vmc import VMCState
+from jaqmc.workflow.subspace_vmc import (
+    SubspaceVMCWorkflow,
+    SubspaceVMCWorkStage,
+    make_subspace_data_init,
+    replicate_walker_replicas,
+)
+
+
+class ToyData(Data):
+    electrons: jax.Array
+    atoms: jax.Array
+
+
+def test_replica_axis_is_inside_walker_axis_and_physical_data_is_recoverable():
+    physical = BatchedData(
+        ToyData(electrons=jnp.zeros((5, 2, 3)), atoms=jnp.ones((1, 3))),
+        ["electrons"],
+    )
+    spec = SubspaceSpec(4)
+
+    replica_data = replicate_walker_replicas(physical, spec)
+    one_walker = replica_data.unbatched_example()
+    recovered = take_replica(one_walker, 2, spec)
+
+    assert replica_data.data.electrons.shape == (5, 4, 2, 3)
+    assert replica_data.fields_with_batch == ["electrons"]
+    assert recovered.electrons.shape == (2, 3)
+    np.testing.assert_array_equal(recovered.atoms, physical.data.atoms)
+
+
+def test_subspace_data_init_groups_independent_native_samples():
+    requested_sizes = []
+
+    def physical_data_init(size, rngs):
+        del rngs
+        requested_sizes.append(size)
+        return BatchedData(
+            ToyData(
+                electrons=jnp.arange(size, dtype=float)[:, None, None],
+                atoms=jnp.ones((1, 3)),
+            ),
+            ["electrons"],
+        )
+
+    data_init = make_subspace_data_init(physical_data_init, SubspaceSpec(3))
+    result = data_init(4, jax.random.key(0))
+
+    assert requested_sizes == [12]
+    assert result.data.electrons.shape == (4, 3, 1, 1)
+    np.testing.assert_array_equal(
+        result.data.electrons[:, :, 0, 0], jnp.arange(12).reshape(4, 3)
+    )
+
+
+class ToyWavefunction:
+    def init_params(self, data, rngs):
+        del data
+        return {"slope": jax.random.uniform(rngs, (), minval=0.5, maxval=1.5)}
+
+    def logpsi(self, params, data):
+        return params["slope"] * jnp.sum(data.electrons)
+
+    def phase_logpsi(self, params, data):
+        return jnp.array(1.0), self.logpsi(params, data)
+
+    def orbitals(self, params, data):
+        value = params["slope"] * jnp.sum(data.electrons)
+        return value[None, None]
+
+
+def test_workflow_accepts_documented_nested_subspace_config():
+    cfg = ConfigManager(
+        {
+            "workflow": {"batch_size": 4, "save_path": ".tmp/subspace-test"},
+            "subspace": {
+                "n_states": 2,
+                "sampling": {"steps": 3, "initial_width": 0.04},
+                "evaluation": {
+                    "pair_chunk_size": 2,
+                    "matrix_dtype": "complex64",
+                },
+                "diagnostics": {
+                    "condition_warning": 1e8,
+                    "solve_residual_warning": 1e-5,
+                    "max_imag_eigenvalue_warning": 1e-4,
+                },
+            },
+            "train": {
+                "grads": {
+                    "vmap_chunk_size": 3,
+                    "clip_method": "none",
+                    "clip_scale": 7.0,
+                    "loss_key": "must_be_overridden",
+                }
+            },
+        }
+    )
+
+    def physical_data_init(size, rngs):
+        del rngs
+        return BatchedData(
+            ToyData(
+                electrons=jnp.arange(size, dtype=float)[:, None, None],
+                atoms=jnp.ones((1, 3)),
+            ),
+            ["electrons"],
+        )
+
+    def energy(params, data, prev_stats, state, rngs):
+        del params, data, prev_stats, rngs
+        return {"total_energy": jnp.array(1.0)}, state
+
+    workflow = SubspaceVMCWorkflow(cfg)
+    workflow.configure_subspace(
+        base_wavefunction=ToyWavefunction(),
+        physical_data_init=physical_data_init,
+        physical_energy_estimators={"total": energy},
+    )
+    workflow.prepare(dry_run=True)
+
+    sampler = workflow.train_stage.sample_plan.samplers["electrons",]
+    optimizer = workflow.train_stage.optimizer
+    grads = workflow.train_stage.estimators.estimators["grads"]
+    assert sampler.n_states == 2
+    assert sampler.steps == 3
+    np.testing.assert_allclose(sampler.initial_width, 0.04)
+    assert type(optimizer).__name__ == "adam"
+    assert isinstance(grads, StreamingLossAndGrad)
+    assert grads.vmap_chunk_size == 3
+    assert grads.clip_method == "none"
+    np.testing.assert_allclose(grads.clip_scale, 7.0)
+    assert grads.loss_key == "subspace_local_energy"
+
+    console_fields = workflow.default_preset()["train"]["writers"]["console"]["fields"]
+    assert "grad_norm=grad_norm" in console_fields
+    assert "update_norm=update_norm" in console_fields
+
+    data = init_batched_data(workflow.data_init, 4, jax.random.key(2))
+    state = workflow.train_stage.create_state(jax.random.key(3), batched_data=data)
+    partition = state.partition()
+    compute = parallel_jax.jit_sharded(
+        workflow.train_stage.compute_step,
+        in_specs=(partition, parallel_jax.DATA_PARTITION),
+        out_specs=(partition, parallel_jax.SHARE_PARTITION),
+        check_vma=False,
+    )
+    rngs = jax.device_put(
+        jax.random.split(jax.random.PRNGKey(4), jax.device_count()).flatten(),
+        parallel_jax.make_sharding(parallel_jax.DATA_PARTITION),
+    )
+    updated, stats = compute(state, rngs)
+
+    assert jnp.isfinite(stats["subspace_energy"])
+    assert jnp.isfinite(stats["subspace_energy_var"])
+    assert all(
+        np.isfinite(np.asarray(x)).all() for x in jax.tree.leaves(updated.params)
+    )
+
+
+@pytest.mark.parametrize(
+    ("module", "expected_type"),
+    [
+        ("jaqmc.optimizer.sr:SROptimizer", SROptimizer),
+        (
+            "jaqmc.optimizer.gvmc_reference_sr:GVMCReferenceSROptimizer",
+            GVMCReferenceSROptimizer,
+        ),
+    ],
+)
+def test_subspace_optimizer_is_swappable_through_native_config(module, expected_type):
+    cfg = ConfigManager(
+        {
+            "workflow": {"batch_size": 4},
+            "subspace": {"n_states": 2},
+            "train": {
+                "optim": {"module": module},
+                "grads": {"clip_method": "none"},
+            },
+        }
+    )
+
+    def physical_data_init(size, rngs):
+        del rngs
+        return BatchedData(
+            ToyData(electrons=jnp.ones((size, 1, 1)), atoms=jnp.ones((1, 3))),
+            ["electrons"],
+        )
+
+    workflow = SubspaceVMCWorkflow(cfg)
+    workflow.configure_subspace(
+        base_wavefunction=ToyWavefunction(),
+        physical_data_init=physical_data_init,
+        physical_energy_estimators={},
+    )
+
+    assert isinstance(workflow.train_stage.optimizer, expected_type)
+    grads = workflow.train_stage.estimators.estimators["grads"]
+    assert grads.clip_method == "none"
+
+
+def test_invalid_subspace_step_skips_optimizer_update():
+    @dataclass
+    class ToyState:
+        params: dict
+        batched_data: object
+        sampler_state: object
+        estimator_state: object
+        opt_state: dict
+
+    original = ToyState(
+        params={"w": jnp.array(1.0)},
+        batched_data=object(),
+        sampler_state=None,
+        estimator_state=None,
+        opt_state={"count": jnp.array(2)},
+    )
+
+    class SamplePlan:
+        def step(self, params, data, sampler_state, rngs):
+            del params, rngs
+            return data, {}, sampler_state
+
+    class Estimators:
+        def evaluate(self, params, data, estimator_state, rngs):
+            del params, data, rngs
+            return {}, estimator_state
+
+        def finalize_stats(self, stats, estimator_state):
+            del stats, estimator_state
+            return {
+                "grads": {"w": jnp.array(jnp.nan)},
+                "training_step_valid": jnp.array(False),
+            }
+
+    class Optimizer:
+        def update(self, grads, opt_state, **kwargs):
+            del grads, opt_state, kwargs
+            raise AssertionError("optimizer must not be called")
+
+    stage = object.__new__(SubspaceVMCWorkStage)
+    stage.sample_plan = SamplePlan()
+    stage.estimators = Estimators()
+    stage.optimizer = Optimizer()
+
+    updated, stats = stage.compute_step(original, jax.random.key(0))
+
+    np.testing.assert_array_equal(updated.params["w"], original.params["w"])
+    np.testing.assert_array_equal(
+        updated.opt_state["count"], original.opt_state["count"]
+    )
+    np.testing.assert_array_equal(stats["update_norm"], 0)
+    assert stage._has_nan(stats)
+
+
+def test_invalid_subspace_step_preserves_state_under_jit():
+    data = BatchedData(
+        ToyData(electrons=jnp.ones((2, 1, 1)), atoms=jnp.ones((1, 3))),
+        ["electrons"],
+    )
+    original = VMCState(
+        params={"w": jnp.array(1.0)},
+        batched_data=data,
+        sampler_state=jnp.array(3),
+        estimator_state=jnp.array(4),
+        opt_state={"count": jnp.array(2)},
+    )
+
+    class SamplePlan:
+        def step(self, params, batched_data, sampler_state, rngs):
+            del params, rngs
+            return batched_data, {"pmove": jnp.array(1.0)}, sampler_state
+
+    class Estimators:
+        def evaluate(self, params, batched_data, estimator_state, rngs):
+            del params, batched_data, rngs
+            return {"dummy": jnp.array(0.0)}, estimator_state
+
+        def finalize_stats(self, stats, estimator_state):
+            del stats, estimator_state
+            return {
+                "grads": {"w": jnp.array(5.0)},
+                "training_step_valid": jnp.array(False),
+            }
+
+    class SentinelOptimizer:
+        def update(self, grads, opt_state, **kwargs):
+            del grads, opt_state, kwargs
+            return {"w": jnp.array(999.0)}, {"count": jnp.array(999)}
+
+    stage = object.__new__(SubspaceVMCWorkStage)
+    stage.sample_plan = SamplePlan()
+    stage.estimators = Estimators()
+    stage.optimizer = SentinelOptimizer()
+
+    updated, stats = jax.jit(stage.compute_step)(original, jax.random.key(0))
+
+    np.testing.assert_array_equal(updated.params["w"], original.params["w"])
+    np.testing.assert_array_equal(
+        updated.opt_state["count"], original.opt_state["count"]
+    )
+    np.testing.assert_array_equal(stats["update_norm"], 0)


### PR DESCRIPTION
## Summary

This PR adds variational subspace VMC support to JaQMC for optimizing multiple low-energy states as a determinant-defined subspace.

Main additions include:

- determinant-state wavefunctions and determinant MCMC sampling;
- Rayleigh-matrix and subspace-variance estimators;
- memory-efficient streaming VMC gradients;
- Grassmann natural-gradient optimization using JaQMC SR/SPRING;
- a GVMC-compatible reference minSR/Kaczmarz implementation for numerical validation;
- molecular and solid-state `subspace-train` workflows;
- optional periodic TDA-based subspace initialization;
- unit, multi-device, and regression tests for the subspace, gradient, Rayleigh, and Grassmann-SR paths;
- hydrogen-atom and hydrogen-chain example configurations.

The implementation keeps the production optimization path based on JaQMC's native distributed SR infrastructure, while using the GVMC reference backend only as a small-system correctness oracle.

References:
-Hendry, Douglas, Alessandro Sinibaldi和Giuseppe Carleo. 《Grassmann Variational Monte Carlo with Neural Wave Functions》. Physical Review B 114, 期 13 (2026): 134404. https://doi.org/10.1103/l8mr-567g.
-Kahn, Adrien, Luca Gravina和Filippo Vicentini. 《Variational Subspace Methods and Application to Improving Variational Monte Carlo Dynamics》. 版 2. 预印本, arXiv, 2025年. https://doi.org/10.48550/ARXIV.2507.08930.
